### PR TITLE
Add delete button for inventory recipe suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,10 @@
                         </div>
                         <button id="save-inventory-btn" class="btn-secondary"><i class="fa-solid fa-magnifying-glass"></i> Vorrat speichern & Rezepte finden</button>
                     </div>
-                    <div id="inventory-results-container"></div>
+                    <div id="inventory-results-container">
+                        <!-- Content dynamically filled by js/ui.js -->
+                    </div>
+                    <button id="delete-inventory-recipes-btn" class="btn-danger hidden"><i class="fa-solid fa-trash-can"></i> Vorgeschlagene Rezepte löschen</button>
                 </section>
 
                 <section id="shopping-list-view" class="view hidden">

--- a/js/app.js
+++ b/js/app.js
@@ -23,6 +23,9 @@ function initializeApp() {
             const confirmPlanBtn = document.getElementById('confirm-plan-btn');
             const inventoryInput = document.getElementById('inventory-input');
             const saveInventoryBtn = document.getElementById('save-inventory-btn');
+            const deleteInventoryRecipesBtn = document.getElementById('delete-inventory-recipes-btn');
+
+            let matchingRecipes = []; // To store inventory based recipe suggestions
 
             const handleRecipeSelect = (dayIndex, recipeId) => {
                 if (!weeklyPlan) return;
@@ -88,8 +91,13 @@ function initializeApp() {
             saveInventoryBtn.addEventListener('click', () => {
                 inventory = inventoryInput.value.split(',').map(item => item.trim()).filter(Boolean);
                 store.setItem('inventory', inventory);
-                const matchingRecipes = findAlmostCompleteRecipes(ALL_RECIPES, inventory);
+                matchingRecipes = findAlmostCompleteRecipes(ALL_RECIPES, inventory); // Store results
                 ui.renderInventoryResults(matchingRecipes, handleInfoClick);
+            });
+
+            deleteInventoryRecipesBtn.addEventListener('click', () => {
+                matchingRecipes = []; // Clear the stored recipes
+                ui.clearInventoryResults();
             });
             
             navLinks.forEach(link => {
@@ -99,7 +107,9 @@ function initializeApp() {
                     navLinks.forEach(navLink => navLink.classList.remove('active'));
                     e.currentTarget.classList.add('active');
                     if (viewId === 'inventory-view') {
-                        const matchingRecipes = findAlmostCompleteRecipes(ALL_RECIPES, inventory);
+                        // When navigating to inventory view, re-render based on current matchingRecipes
+                        // This ensures that if recipes were cleared, they stay cleared,
+                        // or if they were previously loaded, they are shown again.
                         ui.renderInventoryResults(matchingRecipes, handleInfoClick);
                     } else if (viewId === 'shopping-list-view') {
                         const list = generateShoppingList(weeklyPlan, inventory, persons);

--- a/js/ui.js
+++ b/js/ui.js
@@ -2,6 +2,7 @@ const ui = (() => {
     const modal = document.getElementById('recipe-modal');
     const modalBody = document.getElementById('modal-body');
     const modalCloseBtn = document.querySelector('.modal-close-btn');
+    const deleteInventoryRecipesBtn = document.getElementById('delete-inventory-recipes-btn');
 
     const closeModal = () => modal.classList.add('hidden');
 
@@ -71,11 +72,32 @@ const ui = (() => {
         },
         renderInventoryResults: (recipes, onInfoClick) => {
             const container = document.getElementById('inventory-results-container');
-            container.innerHTML = '<h3><i class="fa-solid fa-lightbulb"></i> Deine besten Optionen</h3>';
+            container.innerHTML = ''; // Clear previous results
+            const resultsHeader = document.createElement('h3');
+            resultsHeader.innerHTML = '<i class="fa-solid fa-lightbulb"></i> Deine besten Optionen';
+            container.appendChild(resultsHeader);
+
             const resultsDiv = document.createElement('div');
-            if (recipes.length === 0) resultsDiv.innerHTML = '<p>Keine Rezepte gefunden, für die du mindestens 80% der Zutaten hast.</p>';
-            else recipes.forEach(recipe => resultsDiv.appendChild(createRecipeCardElement(recipe, onInfoClick)));
+            if (recipes.length === 0) {
+                resultsDiv.innerHTML = '<p>Keine Rezepte gefunden, für die du mindestens 80% der Zutaten hast.</p>';
+                if (deleteInventoryRecipesBtn) deleteInventoryRecipesBtn.classList.add('hidden');
+            } else {
+                recipes.forEach(recipe => resultsDiv.appendChild(createRecipeCardElement(recipe, onInfoClick)));
+                if (deleteInventoryRecipesBtn) deleteInventoryRecipesBtn.classList.remove('hidden');
+            }
             container.appendChild(resultsDiv);
+        },
+        clearInventoryResults: () => {
+            const container = document.getElementById('inventory-results-container');
+            container.innerHTML = ''; // Clear the recipe cards
+            if (deleteInventoryRecipesBtn) deleteInventoryRecipesBtn.classList.add('hidden');
+            // Add a placeholder message if desired
+            const resultsHeader = document.createElement('h3');
+            resultsHeader.innerHTML = '<i class="fa-solid fa-lightbulb"></i> Deine besten Optionen';
+            container.appendChild(resultsHeader);
+            const placeholder = document.createElement('p');
+            placeholder.textContent = 'Gib Zutaten in deinen Vorrat ein, um Rezeptvorschläge zu sehen, oder lösche die aktuelle Ansicht.';
+            container.appendChild(placeholder);
         },
         openRecipeModal: openModalWithRecipe,
         switchView: (viewId) => { document.querySelectorAll('.view').forEach(v => v.classList.add('hidden')); document.getElementById(viewId).classList.remove('hidden'); },


### PR DESCRIPTION
This commit introduces a delete button on the inventory view, allowing users to clear the recipe suggestions generated based on their inventory.

- Added a 'Vorgeschlagene Rezepte löschen' button to index.html.
- Modified js/ui.js to manage the visibility of this button and to clear the inventory results display.
- Updated js/app.js to handle the button's click event, clear the underlying data for inventory recipes, and ensure the state persists during navigation.