### PR TITLE
feat: Populate recipes.json with English recipes from API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+package.json

--- a/data/new_api_recipes.json
+++ b/data/new_api_recipes.json
@@ -1,0 +1,1194 @@
+[
+  {
+    "id": "rezept-api-52874",
+    "name": "Beef and Mustard Pie",
+    "description": "A delicious Beef dish from British cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 1,
+        "unit": "kg"
+      },
+      {
+        "name": "Plain Flour",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Rapeseed Oil",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Red Wine",
+        "quantity": 200,
+        "unit": "ml"
+      },
+      {
+        "name": "Beef Stock",
+        "quantity": 400,
+        "unit": "ml"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "finely sliced"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Thyme",
+        "quantity": 3,
+        "unit": "sprigs"
+      },
+      {
+        "name": "Mustard",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Egg Yolks",
+        "quantity": 2,
+        "unit": "free-range"
+      },
+      {
+        "name": "Puff Pastry",
+        "quantity": 400,
+        "unit": "g"
+      },
+      {
+        "name": "Green Beans",
+        "quantity": 300,
+        "unit": "g"
+      },
+      {
+        "name": "Butter",
+        "quantity": 25,
+        "unit": "g"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "pinch"
+      }
+    ],
+    "instructions": [
+      "Preheat the oven to 150C/300F/Gas 2.",
+      "Toss the beef and flour together in a bowl with some salt and black pepper.",
+      "Heat a large casserole until hot, add half of the rapeseed oil and enough of the beef to just cover the bottom of the casserole.",
+      "Fry until browned on each side, then remove and set aside.",
+      "Repeat with the remaining oil and beef.",
+      "Return the beef to the pan, add the wine and cook until the volume of liquid has reduced by half, then add the stock, onion, carrots, thyme and mustard, and season well with salt and pepper.",
+      "Cover with a lid and place in the oven for two hours.",
+      "Remove from the oven, check the seasoning and set aside to cool.",
+      "Remove the thyme.",
+      "When the beef is cool and you're ready to assemble the pie, preheat the oven to 200C/400F/Gas 6.",
+      "Transfer the beef to a pie dish, brush the rim with the beaten egg yolks and lay the pastry over the top.",
+      "Brush the top of the pastry with more beaten egg.",
+      "Trim the pastry so there is just enough excess to crimp the edges, then place in the oven and bake for 30 minutes, or until the pastry is golden-brown and cooked through.",
+      "For the green beans, bring a saucepan of salted water to the boil, add the beans and cook for 4-5 minutes, or until just tender.",
+      "Drain and toss with the butter, then season with black pepper.",
+      "To serve, place a large spoonful of pie onto each plate with some green beans alongside."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "British",
+      "Meat",
+      "Pie"
+    ]
+  },
+  {
+    "id": "rezept-api-52878",
+    "name": "Beef and Oyster pie",
+    "description": "A delicious Beef dish from British cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 900,
+        "unit": "g"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Shallots",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Garlic",
+        "quantity": 2,
+        "unit": "cloves minced"
+      },
+      {
+        "name": "Bacon",
+        "quantity": 125,
+        "unit": "g"
+      },
+      {
+        "name": "Thyme",
+        "quantity": 1,
+        "unit": "tbs chopped"
+      },
+      {
+        "name": "Bay Leaf",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Stout",
+        "quantity": 330,
+        "unit": "ml"
+      },
+      {
+        "name": "Beef Stock",
+        "quantity": 400,
+        "unit": "ml"
+      },
+      {
+        "name": "Corn Flour",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Oysters",
+        "quantity": 8,
+        "unit": null
+      },
+      {
+        "name": "Plain Flour",
+        "quantity": 400,
+        "unit": "g"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Butter",
+        "quantity": 250,
+        "unit": "g"
+      },
+      {
+        "name": "Eggs",
+        "quantity": 1,
+        "unit": "To Glaze"
+      }
+    ],
+    "instructions": [
+      "Season the beef cubes with salt and black pepper.",
+      "Heat a tablespoon of oil in the frying pan and fry the meat over a high heat.",
+      "Do this in three batches so that you don’t overcrowd the pan, transferring the meat to a large flameproof casserole dish once it is browned all over.",
+      "Add extra oil if the pan seems dry.",
+      "In the same pan, add another tablespoon of oil and cook the shallots for 4-5 minutes, then add the garlic and fry for 30 seconds.",
+      "Add the bacon and fry until slightly browned.",
+      "Transfer the onion and bacon mixture to the casserole dish and add the herbs.",
+      "Preheat the oven to 180C/350F/Gas 4.",
+      "Pour the stout into the frying pan and bring to the boil, stirring to lift any stuck-on browned bits from the bottom of the pan.",
+      "Pour the stout over the beef in the casserole dish and add the stock.",
+      "Cover the casserole and place it in the oven for 1½-2 hours, or until the beef is tender and the sauce is reduced.",
+      "Skim off any surface fat, taste and add salt and pepper if necessary, then stir in the cornflour paste.",
+      "Put the casserole dish on the hob – don’t forget that it will be hot – and simmer for 1-2 minutes, stirring, until thickened.",
+      "Leave to cool.",
+      "Increase the oven to 200C/400F/Gas 6.",
+      "To make the pastry, put the flour and salt in a very large bowl.",
+      "Grate the butter and stir it into the flour in three batches.",
+      "Gradually add 325ml/11fl oz cold water – you may not need it all – and stir with a round-bladed knife until the mixture just comes together.",
+      "Knead the pastry lightly into a ball on a lightly floured surface and set aside 250g/9oz for the pie lid.",
+      "Roll the rest of the pastry out until about 2cm/¾in larger than the dish you’re using.",
+      "Line the dish with the pastry then pile in the filling, tucking the oysters in as well.",
+      "Brush the edge of the pastry with beaten egg.",
+      "Roll the remaining pastry until slightly larger than your dish and gently lift over the filling, pressing the edges firmly to seal, then trim with a sharp knife.",
+      "Brush with beaten egg to glaze.",
+      "Put the dish on a baking tray and bake for 25-30 minutes, or until the pastry is golden-brown and the filling is bubbling."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "British",
+      "Pie"
+    ]
+  },
+  {
+    "id": "rezept-api-53071",
+    "name": "Beef Asado",
+    "description": "A delicious Beef dish from Filipino cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 1.5,
+        "unit": "kg"
+      },
+      {
+        "name": "Beef Stock Concentrate",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Tomato Puree",
+        "quantity": 8,
+        "unit": "ounces"
+      },
+      {
+        "name": "Water",
+        "quantity": 3,
+        "unit": "cups"
+      },
+      {
+        "name": "Soy Sauce",
+        "quantity": 6,
+        "unit": "tablespoons"
+      },
+      {
+        "name": "White Wine Vinegar",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Bay Leaf",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Lemon",
+        "quantity": 0.5,
+        "unit": null
+      },
+      {
+        "name": "Tomato Sauce",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Butter",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 0.5,
+        "unit": "cup"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 4,
+        "unit": "cloves"
+      }
+    ],
+    "instructions": [
+      "0.\tCombine beef, crushed peppercorn, soy sauce, vinegar, dried bay leaves, lemon, and tomato sauce.",
+      "Mix well.",
+      "Marinate beef for at least 30 minutes.",
+      "1.\tPut the marinated beef in a cooking pot along with remaining marinade.",
+      "Add water.",
+      "Let boil.",
+      "2.\tAdd Knorr Beef Cube.",
+      "Stir.",
+      "Cover the pot and cook for 40 minutes in low heat.",
+      "3.\tTurn the beef over.",
+      "Add tomato paste.",
+      "Continue cooking until beef tenderizes.",
+      "Set aside.",
+      "4.\tHeat oil in a pan.",
+      "Fry the potato until it browns.",
+      "Turn over and continue frying the opposite side.",
+      "Remove from the pan and place on a clean plate.",
+      "Do the same with the carrots.",
+      "5.\tSave 3 tablespoons of cooking oil from the pan where the potato was fried.",
+      "Saute onion and garlic until onion softens.",
+      "6.\tPour-in the sauce from the beef stew.",
+      "Let boil.",
+      "Add the beef.",
+      "Cook for 2 minutes.",
+      "7.\tAdd butter and let it melt.",
+      "Continue cooking until the sauce reduces to half."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Filipino"
+    ]
+  },
+  {
+    "id": "rezept-api-52940",
+    "name": "Brown Stew Chicken",
+    "description": "A delicious Chicken dish from Jamaican cuisine.",
+    "ingredients": [
+      {
+        "name": "Chicken",
+        "quantity": 1,
+        "unit": "whole"
+      },
+      {
+        "name": "Tomato",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Onions",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Red Pepper",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Lime",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Thyme",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Allspice",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Soy Sauce",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Cornstarch",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Coconut Milk",
+        "quantity": 2,
+        "unit": "cups"
+      },
+      {
+        "name": "Vegetable Oil",
+        "quantity": 1,
+        "unit": "tbs"
+      }
+    ],
+    "instructions": [
+      "Squeeze lime over chicken and rub well.",
+      "Drain off excess lime juice.",
+      "Combine tomato, scallion, onion, garlic, pepper, thyme, pimento and soy sauce in a large bowl with the chicken pieces.",
+      "Cover and marinate at least one hour.",
+      "Heat oil in a dutch pot or large saucepan.",
+      "Shake off the seasonings as you remove each piece of chicken from the marinade.",
+      "Reserve the marinade for sauce.",
+      "Lightly brown the chicken a few pieces at a time in very hot oil.",
+      "Place browned chicken pieces on a plate to rest while you brown the remaining pieces.",
+      "Drain off excess oil and return the chicken to the pan.",
+      "Pour the marinade over the chicken and add the carrots.",
+      "Stir and cook over medium heat for 10 minutes.",
+      "Mix flour and coconut milk and add to stew, stirring constantly.",
+      "Turn heat down to minimum and cook another 20 minutes or until tender."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "Jamaican",
+      "Stew"
+    ]
+  },
+  {
+    "id": "rezept-api-52846",
+    "name": "Chicken & mushroom Hotpot",
+    "description": "A delicious Chicken dish from British cuisine.",
+    "ingredients": [
+      {
+        "name": "Butter",
+        "quantity": 50,
+        "unit": "g"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Mushrooms",
+        "quantity": 100,
+        "unit": "g"
+      },
+      {
+        "name": "Plain Flour",
+        "quantity": 40,
+        "unit": "g"
+      },
+      {
+        "name": "Chicken Stock Cube",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Nutmeg",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Mustard Powder",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Chicken",
+        "quantity": 250,
+        "unit": "g"
+      },
+      {
+        "name": "Sweetcorn",
+        "quantity": 2,
+        "unit": "Handfuls"
+      },
+      {
+        "name": "Potatoes",
+        "quantity": 2,
+        "unit": "large"
+      },
+      {
+        "name": "Butter",
+        "quantity": 1,
+        "unit": "knob"
+      }
+    ],
+    "instructions": [
+      "Heat oven to 200C/180C fan/gas 6.",
+      "Put the butter in a medium-size saucepan and place over a medium heat.",
+      "Add the onion and leave to cook for 5 mins, stirring occasionally.",
+      "Add the mushrooms to the saucepan with the onions.",
+      "Once the onion and mushrooms are almost cooked, stir in the flour – this will make a thick paste called a roux.",
+      "If you are using a stock cube, crumble the cube into the roux now and stir well.",
+      "Put the roux over a low heat and stir continuously for 2 mins – this will cook the flour and stop the sauce from having a floury taste.",
+      "Take the roux off the heat.",
+      "Slowly add the fresh stock, if using, or pour in 500ml water if you’ve used a stock cube, stirring all the time.",
+      "Once all the liquid has been added, season with pepper, a pinch of nutmeg and mustard powder.",
+      "Put the saucepan back onto a medium heat and slowly bring it to the boil, stirring all the time.",
+      "Once the sauce has thickened, place on a very low heat.",
+      "Add the cooked chicken and vegetables to the sauce and stir well.",
+      "Grease a medium-size ovenproof pie dish with a little butter and pour in the chicken and mushroom filling.",
+      "Carefully lay the potatoes on top of the hot-pot filling, overlapping them slightly, almost like a pie top.",
+      "Brush the potatoes with a little melted butter and cook in the oven for about 35 mins.",
+      "The hot-pot is ready once the potatoes are cooked and golden brown."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "British"
+    ]
+  },
+  {
+    "id": "rezept-api-52796",
+    "name": "Chicken Alfredo Primavera",
+    "description": "A delicious Chicken dish from Italian cuisine.",
+    "ingredients": [
+      {
+        "name": "Butter",
+        "quantity": 2,
+        "unit": "tablespoons"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 3,
+        "unit": "tablespoons"
+      },
+      {
+        "name": "Chicken",
+        "quantity": 5,
+        "unit": "boneless"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "Squash",
+        "quantity": 1,
+        "unit": "cut into 1/2-inch cubes"
+      },
+      {
+        "name": "Broccoli",
+        "quantity": 1,
+        "unit": "Head chopped"
+      },
+      {
+        "name": "mushrooms",
+        "quantity": 8,
+        "unit": "-ounce sliced"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "red"
+      },
+      {
+        "name": "onion",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "garlic",
+        "quantity": 3,
+        "unit": "cloves"
+      },
+      {
+        "name": "red pepper flakes",
+        "quantity": 0.5,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "white wine",
+        "quantity": 0.5,
+        "unit": "cup"
+      },
+      {
+        "name": "milk",
+        "quantity": 0.5,
+        "unit": "cup"
+      },
+      {
+        "name": "heavy cream",
+        "quantity": 0.5,
+        "unit": "cup"
+      },
+      {
+        "name": "Parmesan cheese",
+        "quantity": 1,
+        "unit": "cup grated"
+      },
+      {
+        "name": "bowtie pasta",
+        "quantity": 16,
+        "unit": "ounces"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Parsley",
+        "quantity": 1,
+        "unit": "chopped"
+      }
+    ],
+    "instructions": [
+      "Heat 1 tablespoon of butter and 2 tablespoons of olive oil in a large skillet over medium-high heat.",
+      "Season both sides of each chicken breast with seasoned salt and a pinch of pepper.",
+      "Add the chicken to the skillet and cook for 5-7 minutes on each side, or until cooked through.",
+      "While the chicken is cooking, bring a large pot of water to a boil.",
+      "Season the boiling water with a few generous pinches of kosher salt.",
+      "Add the pasta and give it a stir.",
+      "Cook, stirring occasionally, until al dente, about 12 minutes.",
+      "Reserve 1/2 cup of  pasta water before draining the pasta.",
+      "Remove the chicken from the pan and transfer it to a cutting board; allow it to rest.",
+      "Turn the heat down to medium and dd the remaining 1 tablespoon of butter and olive oil to the same pan you used to cook the chicken.",
+      "Add the veggies (minus the garlic) and red pepper flakes to the pan and stir to coat with the oil and butter (refrain from seasoning with salt until the veggies are finished browning).",
+      "Cook, stirring often, until the veggies are tender, about 5 minutes.",
+      "Add the garlic and a generous pinch of salt and pepper to the pan and cook for 1 minute.",
+      "Deglaze the pan with the white wine.",
+      "Continue to cook until the wine has reduced by half, about 3 minutes.",
+      "Stir in the milk, heavy cream, and reserved pasta water.",
+      "Bring the mixture to a gentle boil and allow to simmer and reduce for 2-3 minutes.",
+      "Turn off the heat and add the Parmesan cheese and cooked pasta.",
+      "Season with salt and pepper to taste.",
+      "Garnish with Parmesan cheese and chopped parsley, if desired."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "Italian",
+      "Pasta",
+      "Meat",
+      "Dairy"
+    ]
+  },
+  {
+    "id": "rezept-api-52807",
+    "name": "Baingan Bharta",
+    "description": "A delicious Vegetarian dish from Indian cuisine.",
+    "ingredients": [
+      {
+        "name": "Aubergine",
+        "quantity": 1,
+        "unit": "large"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "½ cup"
+      },
+      {
+        "name": "Tomatoes",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 6,
+        "unit": "cloves"
+      },
+      {
+        "name": "Green Chilli",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Red Chilli Powder",
+        "quantity": 1,
+        "unit": "¼ teaspoon"
+      },
+      {
+        "name": "Oil",
+        "quantity": 1.5,
+        "unit": "tablespoon"
+      },
+      {
+        "name": "Coriander Leaves",
+        "quantity": 1,
+        "unit": "tablespoon chopped"
+      },
+      {
+        "name": "salt",
+        "quantity": 1,
+        "unit": "as required"
+      }
+    ],
+    "instructions": [
+      "Rinse the baingan (eggplant or aubergine) in water.",
+      "Pat dry with a kitchen napkin.",
+      "Apply some oil all over and.",
+      "keep it for roasting on an open flame.",
+      "You can also grill the baingan or roast in the oven.",
+      "But then you won't get.",
+      "the smoky flavor of the baingan.",
+      "Keep the eggplant turning after a 2 to 3 minutes on the flame, so that its evenly.",
+      "cooked.",
+      "You could also embed some garlic cloves in the baingan and then roast it.",
+      "2.",
+      "Roast the aubergine till its completely cooked and tender.",
+      "With a knife check the doneness.",
+      "The knife should slid.",
+      "easily in aubergines without any resistance.",
+      "Remove the baingan and immerse in a bowl of water till it cools.",
+      "down.",
+      "3.",
+      "You can also do the dhungar technique of infusing charcoal smoky flavor in the baingan.",
+      "This is an optional step.",
+      "Use natural charcoal for this method.",
+      "Heat a small piece of charcoal on flame till it becomes smoking hot and red.",
+      "4.",
+      "Make small cuts on the baingan with a knife.",
+      "Place the red hot charcoal in the same plate where the roasted.",
+      "aubergine is kept.",
+      "Add a few drops of oil on the charcoal.",
+      "The charcoal would begin to smoke.",
+      "5.",
+      "As soon as smoke begins to release from the charcoal, cover the entire plate tightly with a large bowl.",
+      "Allow the.",
+      "charcoal smoke to get infused for 1 to 2 minutes.",
+      "The more you do, the more smoky the baingan bharta will.",
+      "become.",
+      "I just keep for a minute.",
+      "Alternatively, you can also do this dhungar method once the baingan bharta is.",
+      "cooked, just like the way we do for Dal Tadka.",
+      "6.",
+      "Peel the skin from the roasted and smoked eggplant.",
+      "7.",
+      "Chop the cooked eggplant finely or you can even mash it.",
+      "8.",
+      "In a kadai or pan, heat oil.",
+      "Then add finely chopped onions and garlic.",
+      "9.",
+      "Saute the onions till translucent.",
+      "Don't brown them.",
+      "10.",
+      "Add chopped green chilies and saute for a minute.",
+      "11.",
+      "Add the chopped tomatoes and mix it well.",
+      "12.",
+      "Bhuno (saute) the tomatoes till the oil starts separating from the mixture.",
+      "13.",
+      "Now add the red chili powder.",
+      "Stir and mix well.",
+      "14.",
+      "Add the chopped cooked baingan.",
+      "15.",
+      "Stir and mix the chopped baingan very well with the onion­tomato masala mixture.",
+      "16.",
+      "Season with salt.",
+      "Stir and saute for some more 4 to 5 minutes more.",
+      "17.",
+      "Finally stir in the coriander leaves with the baingan bharta or garnish it with them.",
+      "Serve Baingan Bharta with.",
+      "phulkas, rotis or chapatis.",
+      "It goes well even with bread, toasted or grilled bread and plain rice or jeera rice."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "Indian",
+      "Spicy",
+      "Bun",
+      "Calorific",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-53078",
+    "name": "Beetroot Soup (Borscht)",
+    "description": "A delicious Vegetarian dish from Ukrainian cuisine.",
+    "ingredients": [
+      {
+        "name": "Beetroot",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 4,
+        "unit": "tbs"
+      },
+      {
+        "name": "Chicken Stock Cube",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Water",
+        "quantity": 6,
+        "unit": "cups"
+      },
+      {
+        "name": "Potatoes",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Cannellini Beans",
+        "quantity": 1,
+        "unit": "can"
+      },
+      {
+        "name": "Dill",
+        "quantity": 1,
+        "unit": "Garnish"
+      }
+    ],
+    "instructions": [
+      "Chop the beetroot, add water and stock cube and cook for 15mins.",
+      "Add the other ingredients and boil until soft.",
+      "Finally add the beans and cook for 5mins.",
+      "Serve in the soup pot."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Ukrainian",
+      "Soup",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-53077",
+    "name": "Cabbage Soup (Shchi)",
+    "description": "A delicious Vegetarian dish from Russian cuisine.",
+    "ingredients": [
+      {
+        "name": "Unsalted Butter",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "large"
+      },
+      {
+        "name": "Cabbage",
+        "quantity": 1,
+        "unit": "medium"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Celery",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Bay Leaf",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Vegetable Stock",
+        "quantity": 8,
+        "unit": "cups"
+      },
+      {
+        "name": "Potatoes",
+        "quantity": 2,
+        "unit": "large"
+      },
+      {
+        "name": "Tomatoes",
+        "quantity": 2,
+        "unit": "large"
+      },
+      {
+        "name": "Sour Cream",
+        "quantity": 1,
+        "unit": "Garnish"
+      },
+      {
+        "name": "Dill",
+        "quantity": 1,
+        "unit": "Garnish"
+      }
+    ],
+    "instructions": [
+      "Add the butter to a large Dutch oven or other heavy-duty pot over medium heat.",
+      "When the butter has melted, add the onion and sauté until translucent.",
+      "Add the cabbage, carrot, and celery.",
+      "Sauté until the vegetables begin to soften, stirring frequently, about 3 minutes.",
+      "Add the bay leaf and vegetable stock and bring to a boil over high heat.",
+      "Reduce the heat to low and simmer, covered, until the vegetables are crisp-tender, about 15 minutes.",
+      "Add the potatoes and bring it back to a boil over high heat.",
+      "Reduce the heat to low and simmer, covered, until the potatoes are tender, about 10 minutes.",
+      "Add the tomatoes (or undrained canned tomatoes) and bring the soup back to a boil over high heat.",
+      "Reduce the heat to low and simmer, uncovered, for 5 minutes.",
+      "Season to taste with salt and pepper.",
+      "emove and discard the bay leaf from the pot.",
+      "Serve topped with fresh sour cream and fresh dill."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Russian",
+      "Soup",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52870",
+    "name": "Chickpea Fajitas",
+    "description": "A delicious Vegetarian dish from Mexican cuisine.",
+    "ingredients": [
+      {
+        "name": "Chickpeas",
+        "quantity": 400,
+        "unit": "g"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 1,
+        "unit": "tblsp"
+      },
+      {
+        "name": "Paprika",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Tomatoes",
+        "quantity": 2,
+        "unit": "small cut chunks"
+      },
+      {
+        "name": "Red Onions",
+        "quantity": 1,
+        "unit": "finely sliced"
+      },
+      {
+        "name": "Red Wine Vinegar",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Avocado",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Lime",
+        "quantity": 1,
+        "unit": "Juice of 1"
+      },
+      {
+        "name": "Lime",
+        "quantity": 1,
+        "unit": "Chopped"
+      },
+      {
+        "name": "Sour Cream",
+        "quantity": 100,
+        "unit": "g"
+      },
+      {
+        "name": "Harissa Spice",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Corn Tortillas",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Coriander",
+        "quantity": 1,
+        "unit": "to serve"
+      }
+    ],
+    "instructions": [
+      "Heat oven to 200C/180C fan/gas 6 and line a baking tray with foil.",
+      "Drain the chickpeas, pat dry and tip onto the prepared baking tray.",
+      "Add the oil and paprika, toss to coat, then roast for 20-25 mins until browned and crisp, shaking halfway through cooking.",
+      "Meanwhile, put the tomatoes and onion in a small bowl with the vinegar and set aside to pickle.",
+      "Put the avocado in another bowl and mash with a fork, leaving some larger chunks.",
+      "Stir in the lime juice and season well.",
+      "Mix the soured cream with the harissa and set aside until ready to serve.",
+      "Heat a griddle pan until nearly smoking.",
+      "Add the tortillas , one at a time, charring each side until hot with griddle lines.",
+      "Put everything on the table and build the fajitas : spread a little of the harissa cream over the tortilla, top with roasted chickpeas, guacamole, pickled salsa and coriander, if you like.",
+      "Serve with the lime wedges for squeezing over."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Mexican",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-53072",
+    "name": "Crispy Eggplant",
+    "description": "A delicious Vegetarian dish from Filipino cuisine.",
+    "ingredients": [
+      {
+        "name": "Egg Plants",
+        "quantity": 1,
+        "unit": "large"
+      },
+      {
+        "name": "Breadcrumbs",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Sesame Seed",
+        "quantity": 50,
+        "unit": "g"
+      },
+      {
+        "name": "Eggs",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "To taste"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "To taste"
+      },
+      {
+        "name": "Vegetable Oil",
+        "quantity": 1,
+        "unit": "For frying"
+      }
+    ],
+    "instructions": [
+      "Slice eggplant into 1 cm (0.4-inch) slices.",
+      "Place them in a bowl and sprinkle them with salt.",
+      "allow them to sit for 30 minutes to render some of their liquid and bitterness.",
+      "2.",
+      "After 30 minutes wash eggplant slices from salt and pat dry with a kitchen towel.",
+      "3.",
+      "In a large bowl/plate place breadcrumbs and sesame seeds.",
+      "In another bowl beat 2 eggs with pinch salt and pepper.",
+      "4.",
+      "Heal oil in a large skillet over high heat.",
+      "5.",
+      "Dip eggplant slices in egg, then in crumbs, and place in hot oil.",
+      "Fry 2 to 3 minutes on each side, or until golden brown.",
+      "Drain on a paper towel."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Filipino",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52785",
+    "name": "Dal fry",
+    "description": "A delicious Vegetarian dish from Indian cuisine.",
+    "ingredients": [
+      {
+        "name": "Toor dal",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Water",
+        "quantity": 2,
+        "unit": "-1/2 cups"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Turmeric",
+        "quantity": 0.25,
+        "unit": "tsp"
+      },
+      {
+        "name": "Ghee",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Chopped tomatoes",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Cumin seeds",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Mustard Seeds",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Bay Leaf",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Green Chilli",
+        "quantity": 1,
+        "unit": "tbs chopped"
+      },
+      {
+        "name": "Ginger",
+        "quantity": 2,
+        "unit": "tsp shredded"
+      },
+      {
+        "name": "Cilantro",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Red Pepper",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Salt",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Sugar",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Garam Masala",
+        "quantity": 0.25,
+        "unit": "tsp"
+      }
+    ],
+    "instructions": [
+      "Wash and soak toor dal in approx.",
+      "3 cups of water, for at least one hours.",
+      "Dal will be double in volume after soaking.",
+      "Drain the water.",
+      "Cook dal with 2-1/2 cups water and add salt, turmeric, on medium high heat, until soft in texture (approximately 30 mins) it should be like thick soup.",
+      "In a frying pan, heat the ghee.",
+      "Add cumin seeds, and mustard seeds.",
+      "After the seeds crack, add bay leaves, green chili, ginger and chili powder.",
+      "Stir for a few seconds.",
+      "Add tomatoes, salt and sugar stir and cook until tomatoes are tender and mushy.",
+      "Add cilantro and garam masala cook for about one minute.",
+      "Pour the seasoning over dal mix it well and cook for another minute.",
+      "Serve with Naan."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Indian",
+      "Curry",
+      "Cake",
+      "vegetarian"
+    ]
+  }
+]

--- a/data/recipes.json
+++ b/data/recipes.json
@@ -1,1467 +1,6552 @@
 [
   {
-    "id": "rezept-1",
-    "name": "Bunter Salat mit Halloumi",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Salat\". Perfekt für jeden Anlass.",
+    "id": "rezept-api-52881",
+    "name": "Steak and Kidney Pie",
+    "description": "A delicious Beef dish from British cuisine.",
     "ingredients": [
       {
-        "name": "Halloumi",
-        "quantity": 218,
+        "name": "Puff Pastry",
+        "quantity": 300,
         "unit": "g"
       },
       {
-        "name": "Brot",
-        "quantity": 111,
+        "name": "Egg White",
+        "quantity": 1,
+        "unit": "Beaten"
+      },
+      {
+        "name": "Egg Yolks",
+        "quantity": 1,
+        "unit": "Beaten"
+      },
+      {
+        "name": "Vegetable Oil",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Beef",
+        "quantity": 70,
+        "unit": "ml"
+      },
+      {
+        "name": "Lamb Kidney",
+        "quantity": 200,
         "unit": "g"
       },
       {
-        "name": "Mais",
-        "quantity": 178,
+        "name": "Onions",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Plain Flour",
+        "quantity": 30,
         "unit": "g"
       },
       {
-        "name": "Zwiebel",
-        "quantity": 235,
-        "unit": "g"
+        "name": "Beef Stock",
+        "quantity": 85,
+        "unit": "ml"
       },
       {
-        "name": "Frische Kräuter",
-        "quantity": 118,
-        "unit": "g"
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Worcestershire Sauce",
+        "quantity": 1,
+        "unit": "Dash"
       }
     ],
     "instructions": [
-      "Alle Zutaten vorbereiten und in einer Schüssel mischen.",
-      "Mit einem Dressing nach Wahl anmachen.",
-      "Mit frischen Kräutern garnieren."
+      "Preheat the oven to 220C/425F/Gas 7.",
+      "Heat the vegetable oil in a large frying pan, and brown the beef all over.",
+      "(You may need to do this in batches.) Set aside, then brown the kidneys on both sides in the same pan.",
+      "Add the onions and cook for 3-4 minutes.",
+      "Return the beef to the pan, sprinkle flour over and coat the meat and onions.",
+      "Add the stock to the pan, stir well and bring to the boil.",
+      "Turn the heat down and simmer for 1½ hours without a lid.",
+      "If the liquid evaporates too much, add more stock.",
+      "Remove from the heat.",
+      "Add salt, pepper and Worcestershire sauce and allow to cool completely.",
+      "Place the cooked meat mixture into a pie dish.",
+      "Roll out the pastry to 5mm/¼in thick and 5cm/2in larger than the dish you are using.",
+      "Using a rolling pin, lift the pastry and place it over the top of the pie dish.",
+      "Trim and crimp the edges with your fingers and thumb.",
+      "Brush the surface with the beaten egg mixture and bake for 30-40 minutes until golden-brown and puffed.",
+      "Serve with creamy mash and steamed vegetables to soak up the gravy."
     ],
-    "estimatedCostPerServing": 4.14,
-    "isSimple": true,
-    "isVegetarian": true,
+    "isVegetarian": false,
     "isVegan": false,
     "tags": [
-      "schnell",
-      "mediterranean",
-      "defty"
+      "Beef",
+      "British",
+      "Pie"
     ]
   },
   {
-    "id": "rezept-2",
-    "name": "Hähnchenbrust-Eintopf mit Rotkohl",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Eintopf\". Perfekt für jeden Anlass.",
+    "id": "rezept-api-52874",
+    "name": "Beef and Mustard Pie",
+    "description": "A delicious Beef dish from British cuisine.",
     "ingredients": [
       {
-        "name": "Hähnchenbrust",
-        "quantity": 224,
+        "name": "Beef",
+        "quantity": 1,
+        "unit": "kg"
+      },
+      {
+        "name": "Plain Flour",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Rapeseed Oil",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Red Wine",
+        "quantity": 200,
+        "unit": "ml"
+      },
+      {
+        "name": "Beef Stock",
+        "quantity": 400,
+        "unit": "ml"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "finely sliced"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Thyme",
+        "quantity": 3,
+        "unit": "sprigs"
+      },
+      {
+        "name": "Mustard",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Egg Yolks",
+        "quantity": 2,
+        "unit": "free-range"
+      },
+      {
+        "name": "Puff Pastry",
+        "quantity": 400,
+        "unit": "g"
+      },
+      {
+        "name": "Green Beans",
+        "quantity": 300,
+        "unit": "g"
+      },
+      {
+        "name": "Butter",
+        "quantity": 25,
+        "unit": "g"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "pinch"
+      }
+    ],
+    "instructions": [
+      "Preheat the oven to 150C/300F/Gas 2.",
+      "Toss the beef and flour together in a bowl with some salt and black pepper.",
+      "Heat a large casserole until hot, add half of the rapeseed oil and enough of the beef to just cover the bottom of the casserole.",
+      "Fry until browned on each side, then remove and set aside.",
+      "Repeat with the remaining oil and beef.",
+      "Return the beef to the pan, add the wine and cook until the volume of liquid has reduced by half, then add the stock, onion, carrots, thyme and mustard, and season well with salt and pepper.",
+      "Cover with a lid and place in the oven for two hours.",
+      "Remove from the oven, check the seasoning and set aside to cool.",
+      "Remove the thyme.",
+      "When the beef is cool and you're ready to assemble the pie, preheat the oven to 200C/400F/Gas 6.",
+      "Transfer the beef to a pie dish, brush the rim with the beaten egg yolks and lay the pastry over the top.",
+      "Brush the top of the pastry with more beaten egg.",
+      "Trim the pastry so there is just enough excess to crimp the edges, then place in the oven and bake for 30 minutes, or until the pastry is golden-brown and cooked through.",
+      "For the green beans, bring a saucepan of salted water to the boil, add the beans and cook for 4-5 minutes, or until just tender.",
+      "Drain and toss with the butter, then season with black pepper.",
+      "To serve, place a large spoonful of pie onto each plate with some green beans alongside."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "British",
+      "Meat",
+      "Pie"
+    ]
+  },
+  {
+    "id": "rezept-api-53006",
+    "name": "Moussaka",
+    "description": "A delicious Beef dish from Greek cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 500,
         "unit": "g"
       },
       {
         "name": "Aubergine",
-        "quantity": 232,
-        "unit": "g"
+        "quantity": 1,
+        "unit": "large"
       },
       {
-        "name": "Rotkohl",
-        "quantity": 147,
-        "unit": "g"
-      },
-      {
-        "name": "Tomaten",
-        "quantity": 242,
-        "unit": "g"
-      },
-      {
-        "name": "Bulgur",
-        "quantity": 185,
-        "unit": "g"
-      },
-      {
-        "name": "Frische Kräuter",
-        "quantity": 182,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Hähnchenbrust und Gemüse anbraten.",
-      "Mit Wasser oder Brühe aufgießen und köcheln lassen, bis alles weich ist.",
-      "Mit frischen Kräutern servieren."
-    ],
-    "estimatedCostPerServing": 2.76,
-    "isSimple": true,
-    "isVegetarian": false,
-    "isVegan": false,
-    "tags": [
-      "günstig",
-      "resteverwertung",
-      "light",
-      "asian",
-      "mediterranean",
-      "defty"
-    ]
-  },
-  {
-    "id": "rezept-3",
-    "name": "Gnocchi-Auflauf mit Linsen",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Auflauf\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Linsen",
-        "quantity": 231,
-        "unit": "g"
-      },
-      {
-        "name": "Gnocchi",
-        "quantity": 161,
-        "unit": "g"
-      },
-      {
-        "name": "Karotten",
-        "quantity": 218,
-        "unit": "g"
-      },
-      {
-        "name": "Sahnesauce",
-        "quantity": 186,
-        "unit": "g"
-      },
-      {
-        "name": "geriebenem Käse",
-        "quantity": 128,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Zutaten mischen, in eine Auflaufform geben.",
-      "Mit Sahnesauce übergießen und mit geriebenem Käse bestreuen.",
-      "Bei 180°C ca. 30 Minuten backen."
-    ],
-    "estimatedCostPerServing": 3.65,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": false,
-    "tags": [
-      "für gäste",
-      "mediterranean",
-      "defty",
-      "light"
-    ]
-  },
-  {
-    "id": "rezept-4",
-    "name": "Großer Salat mit Hähnchenbrust",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Salat\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Hähnchenbrust",
-        "quantity": 222,
-        "unit": "g"
-      },
-      {
-        "name": "Brot",
-        "quantity": 139,
-        "unit": "g"
-      },
-      {
-        "name": "Tomaten",
-        "quantity": 133,
-        "unit": "g"
-      },
-      {
-        "name": "Zwiebel",
-        "quantity": 159,
-        "unit": "g"
-      },
-      {
-        "name": "Frische Kräuter",
-        "quantity": 223,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Alle Zutaten vorbereiten und in einer Schüssel mischen.",
-      "Mit einem Dressing nach Wahl anmachen.",
-      "Mit frischen Kräutern garnieren."
-    ],
-    "estimatedCostPerServing": 4.1,
-    "isSimple": true,
-    "isVegetarian": false,
-    "isVegan": false,
-    "tags": [
-      "schnell",
-      "light",
-      "asian",
-      "defty",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-5",
-    "name": "Linsen-Eintopf mit Zucchini",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Eintopf\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Linsen",
-        "quantity": 128,
-        "unit": "g"
-      },
-      {
-        "name": "Zwiebel",
-        "quantity": 175,
-        "unit": "g"
-      },
-      {
-        "name": "Mais",
-        "quantity": 178,
-        "unit": "g"
-      },
-      {
-        "name": "Zucchini",
-        "quantity": 236,
-        "unit": "g"
-      },
-      {
-        "name": "Bulgur",
-        "quantity": 110,
-        "unit": "g"
-      },
-      {
-        "name": "Frische Kräuter",
-        "quantity": 154,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Linsen und Gemüse anbraten.",
-      "Mit Wasser oder Brühe aufgießen und köcheln lassen, bis alles weich ist.",
-      "Mit frischen Kräutern servieren."
-    ],
-    "estimatedCostPerServing": 2.76,
-    "isSimple": true,
-    "isVegetarian": true,
-    "isVegan": true,
-    "tags": [
-      "günstig",
-      "light",
-      "defty",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-6",
-    "name": "Kartoffel-Auflauf mit Tofu",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Auflauf\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Tofu",
-        "quantity": 169,
-        "unit": "g"
-      },
-      {
-        "name": "Kartoffeln",
-        "quantity": 102,
-        "unit": "g"
-      },
-      {
-        "name": "Pilze",
-        "quantity": 223,
-        "unit": "g"
-      },
-      {
-        "name": "Tomatensauce",
-        "quantity": 240,
-        "unit": "g"
-      },
-      {
-        "name": "geriebenem Käse",
-        "quantity": 202,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Zutaten mischen, in eine Auflaufform geben.",
-      "Mit Tomatensauce übergießen und mit geriebenem Käse bestreuen.",
-      "Bei 180°C ca. 30 Minuten backen."
-    ],
-    "estimatedCostPerServing": 3.86,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": false,
-    "tags": [
-      "für gäste",
-      "defty",
-      "asian",
-      "light",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-7",
-    "name": "Großer Salat mit Tofu",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Salat\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Tofu",
-        "quantity": 140,
-        "unit": "g"
-      },
-      {
-        "name": "Brot",
-        "quantity": 113,
-        "unit": "g"
-      },
-      {
-        "name": "Tomaten",
-        "quantity": 111,
-        "unit": "g"
-      },
-      {
-        "name": "Zwiebel",
-        "quantity": 139,
-        "unit": "g"
-      },
-      {
-        "name": "Geröstete Kerne",
-        "quantity": 204,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Alle Zutaten vorbereiten und in einer Schüssel mischen.",
-      "Mit einem Dressing nach Wahl anmachen.",
-      "Mit gerösteten Kernen garnieren."
-    ],
-    "estimatedCostPerServing": 4.54,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": true,
-    "tags": [
-      "schnell",
-      "asian",
-      "light",
-      "defty",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-8",
-    "name": "Quinoa-Pfanne mit Linsen",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Pfanne\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Linsen",
-        "quantity": 218,
-        "unit": "g"
-      },
-      {
-        "name": "Quinoa",
-        "quantity": 215,
-        "unit": "g"
-      },
-      {
-        "name": "Brokkoli",
-        "quantity": 105,
-        "unit": "g"
-      },
-      {
-        "name": "Knoblauch",
-        "quantity": 242,
-        "unit": "g"
-      },
-      {
-        "name": "Sojasauce",
-        "quantity": 136,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Quinoa kochen.",
-      "Linsen mit Brokkoli und Knoblauch anbraten.",
-      "Gekochte Quinoa und Sojasauce zugeben und vermengen."
-    ],
-    "estimatedCostPerServing": 3.73,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": true,
-    "tags": [
-      "schnell",
-      "light",
-      "defty",
-      "mediterranean",
-      "asian"
-    ]
-  },
-  {
-    "id": "rezept-9",
-    "name": "Schweinefilet-Eintopf mit Knoblauch",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Eintopf\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Schweinefilet",
-        "quantity": 103,
-        "unit": "g"
-      },
-      {
-        "name": "Tomaten",
-        "quantity": 196,
-        "unit": "g"
-      },
-      {
-        "name": "Aubergine",
-        "quantity": 182,
-        "unit": "g"
-      },
-      {
-        "name": "Knoblauch",
-        "quantity": 232,
-        "unit": "g"
-      },
-      {
-        "name": "Bulgur",
-        "quantity": 139,
-        "unit": "g"
-      },
-      {
-        "name": "Frische Kräuter",
-        "quantity": 178,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Schweinefilet und Gemüse anbraten.",
-      "Mit Wasser oder Brühe aufgießen und köcheln lassen, bis alles weich ist.",
-      "Mit frischen Kräutern servieren."
-    ],
-    "estimatedCostPerServing": 2.9,
-    "isSimple": true,
-    "isVegetarian": false,
-    "isVegan": false,
-    "tags": [
-      "günstig",
-      "resteverwertung",
-      "defty",
-      "asian",
-      "mediterranean",
-      "light"
-    ]
-  },
-  {
-    "id": "rezept-10",
-    "name": "Nudeln-Auflauf mit Linsen",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Auflauf\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Linsen",
+        "name": "Greek Yogurt",
         "quantity": 150,
         "unit": "g"
       },
       {
-        "name": "Nudeln",
-        "quantity": 128,
+        "name": "Egg",
+        "quantity": 1,
+        "unit": "beaten"
+      },
+      {
+        "name": "Parmesan",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Tomato",
+        "quantity": 400,
         "unit": "g"
       },
       {
-        "name": "Brokkoli",
-        "quantity": 132,
-        "unit": "g"
+        "name": "Tomato Puree",
+        "quantity": 4,
+        "unit": "tbs"
       },
       {
-        "name": "Tomatensauce",
-        "quantity": 101,
-        "unit": "g"
-      },
-      {
-        "name": "geriebenem Käse",
-        "quantity": 236,
+        "name": "Potatoes",
+        "quantity": 350,
         "unit": "g"
       }
     ],
     "instructions": [
-      "Zutaten mischen, in eine Auflaufform geben.",
-      "Mit Tomatensauce übergießen und mit geriebenem Käse bestreuen.",
-      "Bei 180°C ca. 30 Minuten backen."
+      "Heat the grill to high.",
+      "Brown the beef in a deep ovenproof frying pan over a high heat for 5 mins.",
+      "Meanwhile, prick the aubergine with a fork, then microwave on High for 3-5 mins until soft.",
+      "Mix the yogurt, egg and parmesan together, then add a little seasoning.",
+      "Stir the tomatoes, purée and potatoes in with the beef with some seasoning and heat through.",
+      "Smooth the surface of the beef mixture with the back of a spoon, then slice the cooked aubergine and arrange on top.",
+      "Pour the yogurt mixture over the aubergines, smooth out evenly, then grill until the topping has set and turned golden."
     ],
-    "estimatedCostPerServing": 3.79,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": false,
-    "tags": [
-      "für gäste",
-      "defty",
-      "mediterranean",
-      "light"
-    ]
-  },
-  {
-    "id": "rezept-11",
-    "name": "Hähnchenbrust-Eintopf mit Pilze",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Eintopf\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Hähnchenbrust",
-        "quantity": 135,
-        "unit": "g"
-      },
-      {
-        "name": "Zwiebel",
-        "quantity": 106,
-        "unit": "g"
-      },
-      {
-        "name": "Rotkohl",
-        "quantity": 161,
-        "unit": "g"
-      },
-      {
-        "name": "Pilze",
-        "quantity": 204,
-        "unit": "g"
-      },
-      {
-        "name": "Bulgur",
-        "quantity": 169,
-        "unit": "g"
-      },
-      {
-        "name": "Röstzwiebeln",
-        "quantity": 102,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Hähnchenbrust und Gemüse anbraten.",
-      "Mit Wasser oder Brühe aufgießen und köcheln lassen, bis alles weich ist.",
-      "Mit Röstzwiebeln servieren."
-    ],
-    "estimatedCostPerServing": 3.19,
-    "isSimple": true,
     "isVegetarian": false,
     "isVegan": false,
     "tags": [
-      "light",
-      "asian",
-      "mediterranean",
-      "defty"
+      "Beef",
+      "Greek"
     ]
   },
   {
-    "id": "rezept-12",
-    "name": "Nudeln-Auflauf mit Tofu",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Auflauf\". Perfekt für jeden Anlass.",
+    "id": "rezept-api-52878",
+    "name": "Beef and Oyster pie",
+    "description": "A delicious Beef dish from British cuisine.",
     "ingredients": [
       {
-        "name": "Tofu",
-        "quantity": 221,
+        "name": "Beef",
+        "quantity": 900,
         "unit": "g"
       },
       {
-        "name": "Nudeln",
-        "quantity": 201,
-        "unit": "g"
+        "name": "Olive Oil",
+        "quantity": 3,
+        "unit": "tbs"
       },
       {
-        "name": "Knoblauch",
-        "quantity": 234,
-        "unit": "g"
+        "name": "Shallots",
+        "quantity": 3,
+        "unit": null
       },
       {
-        "name": "Sahnesauce",
-        "quantity": 103,
-        "unit": "g"
+        "name": "Garlic",
+        "quantity": 2,
+        "unit": "cloves minced"
       },
       {
-        "name": "geriebenem Käse",
-        "quantity": 218,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Zutaten mischen, in eine Auflaufform geben.",
-      "Mit Sahnesauce übergießen und mit geriebenem Käse bestreuen.",
-      "Bei 180°C ca. 30 Minuten backen."
-    ],
-    "estimatedCostPerServing": 3.51,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": false,
-    "tags": [
-      "für gäste",
-      "defty",
-      "asian",
-      "light"
-    ]
-  },
-  {
-    "id": "rezept-13",
-    "name": "Großer Salat mit Tofu",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Salat\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Tofu",
-        "quantity": 159,
-        "unit": "g"
-      },
-      {
-        "name": "Brot",
-        "quantity": 201,
-        "unit": "g"
-      },
-      {
-        "name": "Paprika",
-        "quantity": 214,
-        "unit": "g"
-      },
-      {
-        "name": "Zwiebel",
-        "quantity": 121,
-        "unit": "g"
-      },
-      {
-        "name": "Geröstete Kerne",
-        "quantity": 195,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Alle Zutaten vorbereiten und in einer Schüssel mischen.",
-      "Mit einem Dressing nach Wahl anmachen.",
-      "Mit gerösteten Kernen garnieren."
-    ],
-    "estimatedCostPerServing": 4.19,
-    "isSimple": true,
-    "isVegetarian": true,
-    "isVegan": true,
-    "tags": [
-      "schnell",
-      "asian",
-      "light",
-      "defty",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-14",
-    "name": "Gnocchi-Pfanne mit Schweinefilet",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Pfanne\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Schweinefilet",
-        "quantity": 141,
-        "unit": "g"
-      },
-      {
-        "name": "Gnocchi",
-        "quantity": 110,
-        "unit": "g"
-      },
-      {
-        "name": "Knoblauch",
-        "quantity": 113,
-        "unit": "g"
-      },
-      {
-        "name": "Paprika",
-        "quantity": 242,
-        "unit": "g"
-      },
-      {
-        "name": "Sojasauce",
-        "quantity": 184,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Gnocchi kochen.",
-      "Schweinefilet mit Knoblauch und Paprika anbraten.",
-      "Gekochte Gnocchi und Sojasauce zugeben und vermengen."
-    ],
-    "estimatedCostPerServing": 3.49,
-    "isSimple": false,
-    "isVegetarian": false,
-    "isVegan": false,
-    "tags": [
-      "schnell",
-      "mediterranean",
-      "defty",
-      "asian"
-    ]
-  },
-  {
-    "id": "rezept-15",
-    "name": "Bunter Salat mit Halloumi",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Salat\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Halloumi",
-        "quantity": 154,
-        "unit": "g"
-      },
-      {
-        "name": "Brot",
-        "quantity": 105,
-        "unit": "g"
-      },
-      {
-        "name": "Gurke",
-        "quantity": 235,
-        "unit": "g"
-      },
-      {
-        "name": "Tomaten",
-        "quantity": 179,
-        "unit": "g"
-      },
-      {
-        "name": "Geröstete Kerne",
-        "quantity": 157,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Alle Zutaten vorbereiten und in einer Schüssel mischen.",
-      "Mit einem Dressing nach Wahl anmachen.",
-      "Mit gerösteten Kernen garnieren."
-    ],
-    "estimatedCostPerServing": 4.54,
-    "isSimple": true,
-    "isVegetarian": true,
-    "isVegan": false,
-    "tags": [
-      "schnell",
-      "mediterranean",
-      "defty",
-      "light"
-    ]
-  },
-  {
-    "id": "rezept-16",
-    "name": "Quinoa-Pfanne mit Linsen",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Pfanne\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Linsen",
-        "quantity": 113,
-        "unit": "g"
-      },
-      {
-        "name": "Quinoa",
-        "quantity": 218,
-        "unit": "g"
-      },
-      {
-        "name": "Karotten",
-        "quantity": 105,
-        "unit": "g"
-      },
-      {
-        "name": "Zucchini",
-        "quantity": 139,
-        "unit": "g"
-      },
-      {
-        "name": "Pesto",
-        "quantity": 216,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Quinoa kochen.",
-      "Linsen mit Karotten und Zucchini anbraten.",
-      "Gekochte Quinoa und Pesto zugeben und vermengen."
-    ],
-    "estimatedCostPerServing": 3.75,
-    "isSimple": true,
-    "isVegetarian": true,
-    "isVegan": true,
-    "tags": [
-      "schnell",
-      "resteverwertung",
-      "light",
-      "defty",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-17",
-    "name": "Großer Salat mit Tofu",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Salat\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Tofu",
-        "quantity": 108,
-        "unit": "g"
-      },
-      {
-        "name": "Brot",
-        "quantity": 223,
-        "unit": "g"
-      },
-      {
-        "name": "Mais",
-        "quantity": 182,
-        "unit": "g"
-      },
-      {
-        "name": "Zwiebel",
-        "quantity": 169,
-        "unit": "g"
-      },
-      {
-        "name": "Frische Kräuter",
-        "quantity": 196,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Alle Zutaten vorbereiten und in einer Schüssel mischen.",
-      "Mit einem Dressing nach Wahl anmachen.",
-      "Mit frischen Kräutern garnieren."
-    ],
-    "estimatedCostPerServing": 4.13,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": true,
-    "tags": [
-      "schnell",
-      "asian",
-      "light",
-      "defty",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-18",
-    "name": "Kartoffel-Auflauf mit Schweinefilet",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Auflauf\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Schweinefilet",
-        "quantity": 199,
-        "unit": "g"
-      },
-      {
-        "name": "Kartoffeln",
-        "quantity": 212,
-        "unit": "g"
-      },
-      {
-        "name": "Brokkoli",
-        "quantity": 185,
-        "unit": "g"
-      },
-      {
-        "name": "Tomatensauce",
-        "quantity": 199,
-        "unit": "g"
-      },
-      {
-        "name": "geriebenem Käse",
-        "quantity": 139,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Zutaten mischen, in eine Auflaufform geben.",
-      "Mit Tomatensauce übergießen und mit geriebenem Käse bestreuen.",
-      "Bei 180°C ca. 30 Minuten backen."
-    ],
-    "estimatedCostPerServing": 4.34,
-    "isSimple": true,
-    "isVegetarian": false,
-    "isVegan": false,
-    "tags": [
-      "für gäste",
-      "defty",
-      "asian",
-      "light",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-19",
-    "name": "Quinoa-Pfanne mit Eier",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Pfanne\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Eier",
-        "quantity": 111,
-        "unit": "g"
-      },
-      {
-        "name": "Quinoa",
-        "quantity": 105,
-        "unit": "g"
-      },
-      {
-        "name": "Aubergine",
-        "quantity": 106,
-        "unit": "g"
-      },
-      {
-        "name": "Rotkohl",
-        "quantity": 140,
-        "unit": "g"
-      },
-      {
-        "name": "Sojasauce",
-        "quantity": 232,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Quinoa kochen.",
-      "Eier mit Aubergine und Rotkohl anbraten.",
-      "Gekochte Quinoa und Sojasauce zugeben und vermengen."
-    ],
-    "estimatedCostPerServing": 3.12,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": false,
-    "tags": [
-      "schnell",
-      "light",
-      "defty",
-      "mediterranean",
-      "asian"
-    ]
-  },
-  {
-    "id": "rezept-20",
-    "name": "Großer Salat mit Hähnchenbrust",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Salat\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Hähnchenbrust",
-        "quantity": 161,
-        "unit": "g"
-      },
-      {
-        "name": "Brot",
-        "quantity": 164,
-        "unit": "g"
-      },
-      {
-        "name": "Tomaten",
-        "quantity": 161,
-        "unit": "g"
-      },
-      {
-        "name": "Gurke",
-        "quantity": 166,
-        "unit": "g"
-      },
-      {
-        "name": "Frische Kräuter",
-        "quantity": 236,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Alle Zutaten vorbereiten und in einer Schüssel mischen.",
-      "Mit einem Dressing nach Wahl anmachen.",
-      "Mit frischen Kräutern garnieren."
-    ],
-    "estimatedCostPerServing": 4.19,
-    "isSimple": true,
-    "isVegetarian": false,
-    "isVegan": false,
-    "tags": [
-      "schnell",
-      "resteverwertung",
-      "light",
-      "asian",
-      "defty",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-21",
-    "name": "Großer Salat mit Tofu",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Salat\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Tofu",
-        "quantity": 242,
-        "unit": "g"
-      },
-      {
-        "name": "Brot",
-        "quantity": 178,
-        "unit": "g"
-      },
-      {
-        "name": "Oliven",
-        "quantity": 105,
-        "unit": "g"
-      },
-      {
-        "name": "Mais",
-        "quantity": 165,
-        "unit": "g"
-      },
-      {
-        "name": "Frische Kräuter",
-        "quantity": 234,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Alle Zutaten vorbereiten und in einer Schüssel mischen.",
-      "Mit einem Dressing nach Wahl anmachen.",
-      "Mit frischen Kräutern garnieren."
-    ],
-    "estimatedCostPerServing": 4.79,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": true,
-    "tags": [
-      "schnell",
-      "resteverwertung",
-      "asian",
-      "light",
-      "defty",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-22",
-    "name": "Hähnchenbrust-Eintopf mit Karotten",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Eintopf\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Hähnchenbrust",
-        "quantity": 170,
-        "unit": "g"
-      },
-      {
-        "name": "Tomaten",
-        "quantity": 218,
-        "unit": "g"
-      },
-      {
-        "name": "Rotkohl",
-        "quantity": 224,
-        "unit": "g"
-      },
-      {
-        "name": "Karotten",
-        "quantity": 115,
-        "unit": "g"
-      },
-      {
-        "name": "Kartoffeln",
-        "quantity": 213,
-        "unit": "g"
-      },
-      {
-        "name": "Frische Kräuter",
-        "quantity": 176,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Hähnchenbrust und Gemüse anbraten.",
-      "Mit Wasser oder Brühe aufgießen und köcheln lassen, bis alles weich ist.",
-      "Mit frischen Kräutern servieren."
-    ],
-    "estimatedCostPerServing": 2.89,
-    "isSimple": true,
-    "isVegetarian": false,
-    "isVegan": false,
-    "tags": [
-      "günstig",
-      "resteverwertung",
-      "light",
-      "asian",
-      "mediterranean",
-      "defty"
-    ]
-  },
-  {
-    "id": "rezept-23",
-    "name": "Hähnchenbrust-Eintopf mit Zucchini",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Eintopf\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Hähnchenbrust",
-        "quantity": 159,
-        "unit": "g"
-      },
-      {
-        "name": "Zucchini",
-        "quantity": 204,
-        "unit": "g"
-      },
-      {
-        "name": "Frühlingszwiebeln",
-        "quantity": 116,
-        "unit": "g"
-      },
-      {
-        "name": "Pilze",
-        "quantity": 182,
-        "unit": "g"
-      },
-      {
-        "name": "Kartoffeln",
-        "quantity": 128,
-        "unit": "g"
-      },
-      {
-        "name": "Geröstete Kerne",
-        "quantity": 203,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Hähnchenbrust und Gemüse anbraten.",
-      "Mit Wasser oder Brühe aufgießen und köcheln lassen, bis alles weich ist.",
-      "Mit gerösteten Kernen servieren."
-    ],
-    "estimatedCostPerServing": 3.42,
-    "isSimple": true,
-    "isVegetarian": false,
-    "isVegan": false,
-    "tags": [
-      "resteverwertung",
-      "light",
-      "asian",
-      "defty",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-24",
-    "name": "Großer Salat mit Kichererbsen",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Salat\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Kichererbsen",
-        "quantity": 222,
-        "unit": "g"
-      },
-      {
-        "name": "Brot",
-        "quantity": 149,
-        "unit": "g"
-      },
-      {
-        "name": "Oliven",
-        "quantity": 133,
-        "unit": "g"
-      },
-      {
-        "name": "Tomaten",
-        "quantity": 158,
-        "unit": "g"
-      },
-      {
-        "name": "Geröstete Kerne",
-        "quantity": 117,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Alle Zutaten vorbereiten und in einer Schüssel mischen.",
-      "Mit einem Dressing nach Wahl anmachen.",
-      "Mit gerösteten Kernen garnieren."
-    ],
-    "estimatedCostPerServing": 4.54,
-    "isSimple": true,
-    "isVegetarian": true,
-    "isVegan": true,
-    "tags": [
-      "schnell",
-      "light",
-      "mediterranean",
-      "defty"
-    ]
-  },
-  {
-    "id": "rezept-25",
-    "name": "Großer Salat mit Kichererbsen",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Salat\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Kichererbsen",
-        "quantity": 187,
-        "unit": "g"
-      },
-      {
-        "name": "Brot",
-        "quantity": 218,
-        "unit": "g"
-      },
-      {
-        "name": "Gurke",
-        "quantity": 161,
-        "unit": "g"
-      },
-      {
-        "name": "Paprika",
-        "quantity": 184,
-        "unit": "g"
-      },
-      {
-        "name": "Geröstete Kerne",
-        "quantity": 139,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Alle Zutaten vorbereiten und in einer Schüssel mischen.",
-      "Mit einem Dressing nach Wahl anmachen.",
-      "Mit gerösteten Kernen garnieren."
-    ],
-    "estimatedCostPerServing": 4.25,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": true,
-    "tags": [
-      "schnell",
-      "light",
-      "mediterranean",
-      "defty"
-    ]
-  },
-  {
-    "id": "rezept-26",
-    "name": "Nudeln-Auflauf mit Schweinefilet",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Auflauf\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Schweinefilet",
-        "quantity": 195,
-        "unit": "g"
-      },
-      {
-        "name": "Nudeln",
+        "name": "Bacon",
         "quantity": 125,
         "unit": "g"
       },
       {
-        "name": "Zucchini",
-        "quantity": 186,
+        "name": "Thyme",
+        "quantity": 1,
+        "unit": "tbs chopped"
+      },
+      {
+        "name": "Bay Leaf",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Stout",
+        "quantity": 330,
+        "unit": "ml"
+      },
+      {
+        "name": "Beef Stock",
+        "quantity": 400,
+        "unit": "ml"
+      },
+      {
+        "name": "Corn Flour",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Oysters",
+        "quantity": 8,
+        "unit": null
+      },
+      {
+        "name": "Plain Flour",
+        "quantity": 400,
         "unit": "g"
       },
       {
-        "name": "Tomatensauce",
-        "quantity": 149,
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Butter",
+        "quantity": 250,
         "unit": "g"
       },
       {
-        "name": "geriebenem Käse",
-        "quantity": 121,
-        "unit": "g"
+        "name": "Eggs",
+        "quantity": 1,
+        "unit": "To Glaze"
       }
     ],
     "instructions": [
-      "Zutaten mischen, in eine Auflaufform geben.",
-      "Mit Tomatensauce übergießen und mit geriebenem Käse bestreuen.",
-      "Bei 180°C ca. 30 Minuten backen."
+      "Season the beef cubes with salt and black pepper.",
+      "Heat a tablespoon of oil in the frying pan and fry the meat over a high heat.",
+      "Do this in three batches so that you don’t overcrowd the pan, transferring the meat to a large flameproof casserole dish once it is browned all over.",
+      "Add extra oil if the pan seems dry.",
+      "In the same pan, add another tablespoon of oil and cook the shallots for 4-5 minutes, then add the garlic and fry for 30 seconds.",
+      "Add the bacon and fry until slightly browned.",
+      "Transfer the onion and bacon mixture to the casserole dish and add the herbs.",
+      "Preheat the oven to 180C/350F/Gas 4.",
+      "Pour the stout into the frying pan and bring to the boil, stirring to lift any stuck-on browned bits from the bottom of the pan.",
+      "Pour the stout over the beef in the casserole dish and add the stock.",
+      "Cover the casserole and place it in the oven for 1½-2 hours, or until the beef is tender and the sauce is reduced.",
+      "Skim off any surface fat, taste and add salt and pepper if necessary, then stir in the cornflour paste.",
+      "Put the casserole dish on the hob – don’t forget that it will be hot – and simmer for 1-2 minutes, stirring, until thickened.",
+      "Leave to cool.",
+      "Increase the oven to 200C/400F/Gas 6.",
+      "To make the pastry, put the flour and salt in a very large bowl.",
+      "Grate the butter and stir it into the flour in three batches.",
+      "Gradually add 325ml/11fl oz cold water – you may not need it all – and stir with a round-bladed knife until the mixture just comes together.",
+      "Knead the pastry lightly into a ball on a lightly floured surface and set aside 250g/9oz for the pie lid.",
+      "Roll the rest of the pastry out until about 2cm/¾in larger than the dish you’re using.",
+      "Line the dish with the pastry then pile in the filling, tucking the oysters in as well.",
+      "Brush the edge of the pastry with beaten egg.",
+      "Roll the remaining pastry until slightly larger than your dish and gently lift over the filling, pressing the edges firmly to seal, then trim with a sharp knife.",
+      "Brush with beaten egg to glaze.",
+      "Put the dish on a baking tray and bake for 25-30 minutes, or until the pastry is golden-brown and the filling is bubbling."
     ],
-    "estimatedCostPerServing": 4.1,
-    "isSimple": false,
     "isVegetarian": false,
     "isVegan": false,
     "tags": [
-      "für gäste",
-      "defty",
-      "mediterranean",
-      "asian"
+      "Beef",
+      "British",
+      "Pie"
     ]
   },
   {
-    "id": "rezept-27",
-    "name": "Großer Salat mit Tofu",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Salat\". Perfekt für jeden Anlass.",
+    "id": "rezept-api-53069",
+    "name": "Bistek",
+    "description": "A delicious Beef dish from Filipino cuisine.",
     "ingredients": [
       {
-        "name": "Tofu",
-        "quantity": 108,
-        "unit": "g"
+        "name": "Beef",
+        "quantity": 1,
+        "unit": "lb"
       },
       {
-        "name": "Brot",
-        "quantity": 129,
-        "unit": "g"
+        "name": "Soy Sauce",
+        "quantity": 5,
+        "unit": "tablespoons"
       },
       {
-        "name": "Tomaten",
-        "quantity": 126,
-        "unit": "g"
+        "name": "Lemon",
+        "quantity": 1,
+        "unit": null
       },
       {
-        "name": "Gurke",
-        "quantity": 236,
-        "unit": "g"
+        "name": "Garlic",
+        "quantity": 3,
+        "unit": "cloves"
       },
       {
-        "name": "Frische Kräuter",
-        "quantity": 139,
-        "unit": "g"
+        "name": "Onion",
+        "quantity": 3,
+        "unit": "parts"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 4,
+        "unit": "tbs"
+      },
+      {
+        "name": "Water",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "pinch"
       }
     ],
     "instructions": [
-      "Alle Zutaten vorbereiten und in einer Schüssel mischen.",
-      "Mit einem Dressing nach Wahl anmachen.",
-      "Mit frischen Kräutern garnieren."
+      "0.",
+      "Marinate beef in soy sauce, lemon (or calamansi), and ground black pepper for at least 1 hour.",
+      "Note: marinate overnight for best result.",
+      "1.",
+      "Heat the cooking oil in a pan then pan-fry half of the onions until the texture becomes soft.",
+      "Set aside.",
+      "2.",
+      "Drain the marinade from the beef.",
+      "Set it aside.",
+      "Pan-fry the beef on the same pan where the onions were fried for 1 minute per side.",
+      "Remove from the pan.",
+      "Set aside.",
+      "3.",
+      "Add more oil if needed.",
+      "Saute garlic and remaining raw onions until onion softens.",
+      "4.",
+      "Pour the remaining marinade and water.",
+      "Bring to a boil.",
+      "5.",
+      "Add beef.",
+      "Cover the pan and simmer until the meat is tender.",
+      "Note: Add water as needed.",
+      "6.",
+      "Season with ground black pepper and salt as needed.",
+      "Top with pan-fried onions.",
+      "7.",
+      "Transfer to a serving plate.",
+      "Serve hot.",
+      "Share and Enjoy!"
     ],
-    "estimatedCostPerServing": 4.79,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": true,
-    "tags": [
-      "schnell",
-      "asian",
-      "light",
-      "defty",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-28",
-    "name": "Linsen-Eintopf mit Rotkohl",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Eintopf\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Linsen",
-        "quantity": 218,
-        "unit": "g"
-      },
-      {
-        "name": "Zwiebel",
-        "quantity": 211,
-        "unit": "g"
-      },
-      {
-        "name": "Aubergine",
-        "quantity": 210,
-        "unit": "g"
-      },
-      {
-        "name": "Rotkohl",
-        "quantity": 216,
-        "unit": "g"
-      },
-      {
-        "name": "Bulgur",
-        "quantity": 211,
-        "unit": "g"
-      },
-      {
-        "name": "Einem Klecks Joghurt",
-        "quantity": 124,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Linsen und Gemüse anbraten.",
-      "Mit Wasser oder Brühe aufgießen und köcheln lassen, bis alles weich ist.",
-      "Mit einem Klecks Joghurt servieren."
-    ],
-    "estimatedCostPerServing": 3.48,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": false,
-    "tags": [
-      "resteverwertung",
-      "light",
-      "defty",
-      "mediterranean"
-    ]
-  },
-  {
-    "id": "rezept-29",
-    "name": "Gnocchi-Pfanne mit Linsen",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Pfanne\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Linsen",
-        "quantity": 162,
-        "unit": "g"
-      },
-      {
-        "name": "Gnocchi",
-        "quantity": 126,
-        "unit": "g"
-      },
-      {
-        "name": "Knoblauch",
-        "quantity": 196,
-        "unit": "g"
-      },
-      {
-        "name": "Tomaten",
-        "quantity": 149,
-        "unit": "g"
-      },
-      {
-        "name": "Pesto",
-        "quantity": 113,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Gnocchi kochen.",
-      "Linsen mit Knoblauch und Tomaten anbraten.",
-      "Gekochte Gnocchi und Pesto zugeben und vermengen."
-    ],
-    "estimatedCostPerServing": 3.86,
-    "isSimple": false,
-    "isVegetarian": true,
-    "isVegan": true,
-    "tags": [
-      "schnell",
-      "mediterranean",
-      "defty",
-      "light"
-    ]
-  },
-  {
-    "id": "rezept-30",
-    "name": "Gnocchi-Pfanne mit Schweinefilet",
-    "description": "Ein leckeres Gericht aus der Kategorie \"Pfanne\". Perfekt für jeden Anlass.",
-    "ingredients": [
-      {
-        "name": "Schweinefilet",
-        "quantity": 204,
-        "unit": "g"
-      },
-      {
-        "name": "Gnocchi",
-        "quantity": 160,
-        "unit": "g"
-      },
-      {
-        "name": "Aubergine",
-        "quantity": 126,
-        "unit": "g"
-      },
-      {
-        "name": "Ingwer",
-        "quantity": 218,
-        "unit": "g"
-      },
-      {
-        "name": "Sojasauce",
-        "quantity": 123,
-        "unit": "g"
-      }
-    ],
-    "instructions": [
-      "Gnocchi kochen.",
-      "Schweinefilet mit Aubergine und Ingwer anbraten.",
-      "Gekochte Gnocchi und Sojasauce zugeben und vermengen."
-    ],
-    "estimatedCostPerServing": 3.44,
-    "isSimple": true,
     "isVegetarian": false,
     "isVegan": false,
     "tags": [
-      "schnell",
-      "mediterranean",
-      "defty",
-      "asian"
+      "Beef",
+      "Filipino"
+    ]
+  },
+  {
+    "id": "rezept-api-53071",
+    "name": "Beef Asado",
+    "description": "A delicious Beef dish from Filipino cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 1.5,
+        "unit": "kg"
+      },
+      {
+        "name": "Beef Stock Concentrate",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Tomato Puree",
+        "quantity": 8,
+        "unit": "ounces"
+      },
+      {
+        "name": "Water",
+        "quantity": 3,
+        "unit": "cups"
+      },
+      {
+        "name": "Soy Sauce",
+        "quantity": 6,
+        "unit": "tablespoons"
+      },
+      {
+        "name": "White Wine Vinegar",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Bay Leaf",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Lemon",
+        "quantity": 0.5,
+        "unit": null
+      },
+      {
+        "name": "Tomato Sauce",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Butter",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 0.5,
+        "unit": "cup"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 4,
+        "unit": "cloves"
+      }
+    ],
+    "instructions": [
+      "0.",
+      "Combine beef, crushed peppercorn, soy sauce, vinegar, dried bay leaves, lemon, and tomato sauce.",
+      "Mix well.",
+      "Marinate beef for at least 30 minutes.",
+      "1.",
+      "Put the marinated beef in a cooking pot along with remaining marinade.",
+      "Add water.",
+      "Let boil.",
+      "2.",
+      "Add Knorr Beef Cube.",
+      "Stir.",
+      "Cover the pot and cook for 40 minutes in low heat.",
+      "3.",
+      "Turn the beef over.",
+      "Add tomato paste.",
+      "Continue cooking until beef tenderizes.",
+      "Set aside.",
+      "4.",
+      "Heat oil in a pan.",
+      "Fry the potato until it browns.",
+      "Turn over and continue frying the opposite side.",
+      "Remove from the pan and place on a clean plate.",
+      "Do the same with the carrots.",
+      "5.",
+      "Save 3 tablespoons of cooking oil from the pan where the potato was fried.",
+      "Saute onion and garlic until onion softens.",
+      "6.",
+      "Pour-in the sauce from the beef stew.",
+      "Let boil.",
+      "Add the beef.",
+      "Cook for 2 minutes.",
+      "7.",
+      "Add butter and let it melt.",
+      "Continue cooking until the sauce reduces to half."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Filipino"
+    ]
+  },
+  {
+    "id": "rezept-api-53070",
+    "name": "Beef Caldereta",
+    "description": "A delicious Beef dish from Filipino cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 2,
+        "unit": "kg cut cubes"
+      },
+      {
+        "name": "Beef Stock",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Soy Sauce",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Water",
+        "quantity": 2,
+        "unit": "cups"
+      },
+      {
+        "name": "Green Pepper",
+        "quantity": 1,
+        "unit": "sliced"
+      },
+      {
+        "name": "Red Pepper",
+        "quantity": 1,
+        "unit": "sliced"
+      },
+      {
+        "name": "Potatoes",
+        "quantity": 1,
+        "unit": "sliced"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 1,
+        "unit": "sliced"
+      },
+      {
+        "name": "Tomato Puree",
+        "quantity": 8,
+        "unit": "ounces"
+      },
+      {
+        "name": "Peanut Butter",
+        "quantity": 3,
+        "unit": "tablespoons"
+      },
+      {
+        "name": "Chilli Powder",
+        "quantity": 5,
+        "unit": null
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 5,
+        "unit": "cloves"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 3,
+        "unit": "tbs"
+      }
+    ],
+    "instructions": [
+      "0.",
+      "Heat oil in a cooking pot.",
+      "Saute onion and garlic until onion softens.",
+      "1.",
+      "Add beef.",
+      "Saute until the outer part turns light brown.",
+      "2.",
+      "Add soy sauce.",
+      "Pour tomato sauce and water.",
+      "Let boil.",
+      "3.",
+      "Add Knorr Beef Cube.",
+      "Cover the pressure cooker.",
+      "Cook for 30 minutes.",
+      "4.",
+      "Pan-fry carrot and potato until it browns.",
+      "Set aside.",
+      "5.",
+      "Add chili pepper, liver spread and peanut butter.",
+      "Stir.",
+      "6.",
+      "Add bell peppers, fried potato and carrot.",
+      "Cover the pot.",
+      "Continue cooking for 5 to 7 minutes.",
+      "7.",
+      "Season with salt and ground black pepper.",
+      "Serve."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Filipino"
+    ]
+  },
+  {
+    "id": "rezept-api-53029",
+    "name": "Mulukhiyah",
+    "description": "A delicious Beef dish from Egyptian cuisine.",
+    "ingredients": [
+      {
+        "name": "Mulukhiyah",
+        "quantity": 800,
+        "unit": "g"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Beef",
+        "quantity": 300,
+        "unit": "g"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Water",
+        "quantity": 1,
+        "unit": "Litre"
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 0.5,
+        "unit": "cup"
+      }
+    ],
+    "instructions": [
+      "Saute the onions in the 3-4 tablespoons olive oil.",
+      "Add the beef cubes or the chicken cutlets, sear for 3-4 min on each side.",
+      "Add 1 liter of water or just enough to cover the meat.",
+      "Cook over medium heat until the meat is done (I usually do this in the pressure cooker and press them for 5 min).",
+      "Add the frozen mulukhyia and stir until it thaws completely and then comes to a boil.",
+      "In another pan add the 1/4 to 1/2 cup of olive oil and the cloves of garlic and cook over medium low heat until you can smell the garlic (don’t brown it, it will become bitter).",
+      "Add the oil and garlic to the mulukhyia and lower the heat and simmer for 5-10 minutes.",
+      "Add salt to taste.",
+      "Serve with a generous amount of lemon juice.",
+      "You can serve it with some short grain rice or some pita bread."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Egyptian"
+    ]
+  },
+  {
+    "id": "rezept-api-52941",
+    "name": "Red Peas Soup",
+    "description": "A delicious Beef dish from Jamaican cuisine.",
+    "ingredients": [
+      {
+        "name": "Kidney Beans",
+        "quantity": 2,
+        "unit": "cups"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 1,
+        "unit": "large"
+      },
+      {
+        "name": "Spring Onions",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Thyme",
+        "quantity": 4,
+        "unit": "sprigs"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "Diced"
+      },
+      {
+        "name": "Black Pepper",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Red Pepper",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 4,
+        "unit": "Mashed"
+      },
+      {
+        "name": "Allspice",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Beef",
+        "quantity": 2,
+        "unit": "Lbs"
+      },
+      {
+        "name": "Water",
+        "quantity": 2,
+        "unit": "L"
+      },
+      {
+        "name": "Potatoes",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Plain Flour",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Water",
+        "quantity": 0.25,
+        "unit": "cup"
+      },
+      {
+        "name": "Coconut Milk",
+        "quantity": 1,
+        "unit": "cup"
+      }
+    ],
+    "instructions": [
+      "Wash and rinse the dried kidney beans..",
+      "then cover with water in a deep bowl.",
+      "Remember as they soak they will expand to at least triple the size they were originally so add a lot of water to the bowl.",
+      "Soak them overnight or for at least 2 hrs to make the cooking step go quicker.",
+      "I tossed out the water they were soaked in after it did the job.",
+      "Have your butcher cut the salted pigtail into 2 inch pieces as it will be very difficult to cut with an ordinary kitchen knife.",
+      "Wash, then place a deep pot with water and bring to a boil.",
+      "Cook for 20 minutes, then drain + rinse and repeat (boil again in water).",
+      "The goal is to make the pieces of pig tails tender and to remove most of the salt it was cured in.",
+      "Time to start the soup.",
+      "Place everything in the pot (except the flour and potato), then cover with water and place on a high flame to bring to a boil.",
+      "As it comes to a boil, skim off any scum/froth at the top and discard.",
+      "Reduce the heat to a gentle boil and allow it to cook for 1 hr and 15 mins..",
+      "basically until the beans are tender and start falling apart.",
+      "It’s now time to add the potato (and Yams etc if you’re adding it) as well as the coconut milk and continue cooking for 15 minutes.",
+      "Now is a good time to start making the basic dough for the spinner dumplings.",
+      "Mix the flour and water (add a pinch of salt if you want) until you have a soft/smooth dough.",
+      "allow it to rest for 5 minutes, then pinch of a tablespoon at a time and roll between your hands to form a cigarette shape.",
+      "Add them to the pot, stir well and continue cooking for another 15 minutes on a rolling boil.",
+      "You’ll notice that I didn’t add any salt to the pot as the remaining salt from the salted pigtails will be enough to properly season this dish.",
+      "However you can taste and adjust accordingly.",
+      "Lets recap the timing part of things so you’re not confused.",
+      "Cook the base of the soup for 1 hr and 15 minute or until tender, then add the potatoes and cook for 15 minutes, then add the dumplings and cook for a further 15 minutes.",
+      "Keep in mind that this soup will thicken quite a bit as it cools.",
+      "While this is not a traditional recipe to any one specific island, versions of this soup (sometimes called stewed peas) can be found throughout the Caribbean, Latin America and Africa.",
+      "A hearty bowl of this soup will surely give you the sleepies (some may call it ethnic fatigue).",
+      "You can certainly freeze the leftovers and heat it up another day."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Jamaican",
+      "Soup",
+      "SideDish"
+    ]
+  },
+  {
+    "id": "rezept-api-52979",
+    "name": "Bitterballen (Dutch meatballs)",
+    "description": "A delicious Beef dish from Dutch cuisine.",
+    "ingredients": [
+      {
+        "name": "Butter",
+        "quantity": 100,
+        "unit": "g"
+      },
+      {
+        "name": "Flour",
+        "quantity": 150,
+        "unit": "g"
+      },
+      {
+        "name": "Beef Stock",
+        "quantity": 700,
+        "unit": "ml"
+      },
+      {
+        "name": "Onion",
+        "quantity": 30,
+        "unit": "g"
+      },
+      {
+        "name": "Parsley",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Beef",
+        "quantity": 400,
+        "unit": "g"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "Pinch"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "Pinch"
+      },
+      {
+        "name": "Nutmeg",
+        "quantity": 1,
+        "unit": "Pinch"
+      },
+      {
+        "name": "Flour",
+        "quantity": 50,
+        "unit": "g"
+      },
+      {
+        "name": "Eggs",
+        "quantity": 2,
+        "unit": "Beaten"
+      },
+      {
+        "name": "Breadcrumbs",
+        "quantity": 50,
+        "unit": "g"
+      }
+    ],
+    "instructions": [
+      "Melt the butter in a skillet or pan.",
+      "When melted, add the flour little by little and stir into a thick paste.",
+      "Slowly stir in the stock, making sure the roux absorbs the liquid.",
+      "Simmer for a couple of minutes on a low heat while you stir in the onion, parsley and the shredded meat.",
+      "The mixture should thicken and turn into a heavy, thick sauce.",
+      "Pour the mixture into a shallow container, cover and refrigerate for several hours, or until the sauce has solidified.",
+      "Take a heaping tablespoon of the cold, thick sauce and quickly roll it into a small ball.",
+      "Roll lightly through the flour, then the egg and finally the breadcrumbs.",
+      "Make sure that the egg covers the whole surface of the bitterbal.",
+      "When done, refrigerate the snacks while the oil in your fryer heats up to 190C (375F).",
+      "Fry four bitterballen at a time, until golden.",
+      "Serve on a plate with a nice grainy or spicy mustard."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Dutch",
+      "DinnerParty",
+      "HangoverFood",
+      "Alcoholic"
+    ]
+  },
+  {
+    "id": "rezept-api-52950",
+    "name": "Szechuan Beef",
+    "description": "A delicious Beef dish from Chinese cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 0.5,
+        "unit": "lb"
+      },
+      {
+        "name": "Salt",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Sesame Seed Oil",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Egg White",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Starch",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Oil",
+        "quantity": 4,
+        "unit": "tbs"
+      },
+      {
+        "name": "Ginger",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Onion",
+        "quantity": 0.75,
+        "unit": "cup"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 0.5,
+        "unit": "cup"
+      },
+      {
+        "name": "Green Pepper",
+        "quantity": 0.75,
+        "unit": "cup"
+      },
+      {
+        "name": "Celery",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Mushrooms",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Cooking wine",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Water",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Oyster Sauce",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Hotsauce",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Sugar",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Soy Sauce",
+        "quantity": 1,
+        "unit": "tbs"
+      }
+    ],
+    "instructions": [
+      "STEP 1 - MARINATING THE BEEF.",
+      "In a bowl, add the beef, salt, sesame seed oil, white pepper, egg white, 2 Tablespoon of corn starch and 1 Tablespoon of oil.",
+      "STEP 2 - STIR FRY.",
+      "First Cook the beef by adding 2 Tablespoon of oil until the beef is golden brown.",
+      "Set the beef aside.",
+      "In a wok add 1 Tablespoon of oil, minced ginger, minced garlic and stir-fry for few seconds.",
+      "Next add all of the vegetables and then add sherry cooking wine and 1 cup of water.",
+      "To make the sauce add oyster sauce, hot pepper sauce, and sugar.",
+      "add the cooked beef and 1 spoon of soy sauce.",
+      "To thicken the sauce, whisk together 1 Tablespoon of cornstarch and 2 Tablespoon of water in a bowl and slowly add to your stir-fry until it's the right thickness."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Chinese"
+    ]
+  },
+  {
+    "id": "rezept-api-52873",
+    "name": "Beef Dumpling Stew",
+    "description": "A delicious Beef dish from British cuisine.",
+    "ingredients": [
+      {
+        "name": "Olive Oil",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Butter",
+        "quantity": 25,
+        "unit": "g"
+      },
+      {
+        "name": "Beef",
+        "quantity": 750,
+        "unit": "g"
+      },
+      {
+        "name": "Plain Flour",
+        "quantity": 2,
+        "unit": "tblsp"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 2,
+        "unit": "cloves minced"
+      },
+      {
+        "name": "Onions",
+        "quantity": 175,
+        "unit": "g"
+      },
+      {
+        "name": "Celery",
+        "quantity": 150,
+        "unit": "g"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 150,
+        "unit": "g"
+      },
+      {
+        "name": "Leek",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Swede",
+        "quantity": 200,
+        "unit": "g"
+      },
+      {
+        "name": "Red Wine",
+        "quantity": 150,
+        "unit": "ml"
+      },
+      {
+        "name": "Beef Stock",
+        "quantity": 500,
+        "unit": "g"
+      },
+      {
+        "name": "Bay Leaf",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Thyme",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Parsley",
+        "quantity": 3,
+        "unit": "tblsp chopped"
+      },
+      {
+        "name": "Plain Flour",
+        "quantity": 125,
+        "unit": "g"
+      },
+      {
+        "name": "Baking Powder",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Suet",
+        "quantity": 60,
+        "unit": "g"
+      },
+      {
+        "name": "Water",
+        "quantity": 1,
+        "unit": "Splash"
+      }
+    ],
+    "instructions": [
+      "Preheat the oven to 180C/350F/Gas 4.",
+      "For the beef stew, heat the oil and butter in an ovenproof casserole and fry the beef until browned on all sides.",
+      "Sprinkle over the flour and cook for a further 2-3 minutes.",
+      "Add the garlic and all the vegetables and fry for 1-2 minutes.",
+      "Stir in the wine, stock and herbs, then add the Worcestershire sauce and balsamic vinegar, to taste.",
+      "Season with salt and freshly ground black pepper.",
+      "Cover with a lid, transfer to the oven and cook for about two hours, or until the meat is tender.",
+      "For the dumplings, sift the flour, baking powder and salt into a bowl.",
+      "Add the suet and enough water to form a thick dough.",
+      "With floured hands, roll spoonfuls of the dough into small balls.",
+      "After two hours, remove the lid from the stew and place the balls on top of the stew.",
+      "Cover, return to the oven and cook for a further 20 minutes, or until the dumplings have swollen and are tender.",
+      "(If you prefer your dumplings with a golden top, leave the lid off when returning to the oven.).",
+      "To serve, place a spoonful of mashed potato onto each of four serving plates and top with the stew and dumplings.",
+      "Sprinkle with chopped parsley."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "British",
+      "Stew",
+      "Baking"
+    ]
+  },
+  {
+    "id": "rezept-api-52824",
+    "name": "Beef Sunday Roast",
+    "description": "A delicious Beef dish from British cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 8,
+        "unit": "slices"
+      },
+      {
+        "name": "Broccoli",
+        "quantity": 12,
+        "unit": "florets"
+      },
+      {
+        "name": "Potatoes",
+        "quantity": 1,
+        "unit": "Packet"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 1,
+        "unit": "Packet"
+      },
+      {
+        "name": "plain flour",
+        "quantity": 140,
+        "unit": "g"
+      },
+      {
+        "name": "Eggs",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "milk",
+        "quantity": 200,
+        "unit": "ml"
+      },
+      {
+        "name": "sunflower oil",
+        "quantity": 1,
+        "unit": "drizzle (for cooking)"
+      }
+    ],
+    "instructions": [
+      "Cook the Broccoli and Carrots in a pan of boiling water until tender.",
+      "Roast the Beef and Potatoes in the oven for 45mins, the potatoes may need to be checked regularly to not overcook.",
+      "To make the Yorkshire puddings:.",
+      "Heat oven to 230C/fan 210C/gas 8.",
+      "Drizzle a little sunflower oil evenly into 2 x 4-hole Yorkshire pudding tins or a 12-hole non-stick muffin tin and place in the oven to heat through.",
+      "To make the batter, tip 140g plain flour into a bowl and beat in four eggs until smooth.",
+      "Gradually add 200ml milk and carry on beating until the mix is completely lump-free.",
+      "Season with salt and pepper.",
+      "Pour the batter into a jug, then remove the hot tins from the oven.",
+      "Carefully and evenly pour the batter into the holes.",
+      "Place the tins back in the oven and leave undisturbed for 20-25 mins until the puddings have puffed up and browned.",
+      "Serve immediately.",
+      "Plate up and add the Gravy as desired."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "British",
+      "MainMeal"
+    ]
+  },
+  {
+    "id": "rezept-api-52952",
+    "name": "Beef Lo Mein",
+    "description": "A delicious Beef dish from Chinese cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 0.5,
+        "unit": "lb"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Sesame Seed Oil",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Egg",
+        "quantity": 0.5,
+        "unit": null
+      },
+      {
+        "name": "Starch",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Oil",
+        "quantity": 5,
+        "unit": "tbs"
+      },
+      {
+        "name": "Noodles",
+        "quantity": 0.25,
+        "unit": "lb"
+      },
+      {
+        "name": "Onion",
+        "quantity": 0.5,
+        "unit": "cup"
+      },
+      {
+        "name": "Minced Garlic",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Ginger",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Bean Sprouts",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Mushrooms",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Water",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Oyster Sauce",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Sugar",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Soy Sauce",
+        "quantity": 1,
+        "unit": "tsp"
+      }
+    ],
+    "instructions": [
+      "STEP 1 - MARINATING THE BEEF.",
+      "In a bowl, add the beef, salt, 1 pinch white pepper, 1 Teaspoon sesame seed oil, 1/2 egg, corn starch,1 Tablespoon of oil and mix together.",
+      "STEP 2 - BOILING THE THE NOODLES.",
+      "In a 6 qt pot add your noodles to boiling water until the noodles are submerged and boil on high heat for 10 seconds.",
+      "After your noodles is done boiling strain and cool with cold water.",
+      "STEP 3 - STIR FRY.",
+      "Add 2 Tablespoons of oil, beef and cook on high heat untill beef is medium cooked.",
+      "Set the cooked beef aside.",
+      "In a wok add 2 Tablespoon of oil, onions, minced garlic, minced ginger, bean sprouts, mushrooms, peapods and 1.5 cups of water or until the vegetables are submerged in water.",
+      "Add the noodles to wok.",
+      "To make the sauce, add oyster sauce, 1 pinch white pepper, 1 teaspoon sesame seed oil, sugar, and 1 Teaspoon of soy sauce.",
+      "Next add the beef to wok and stir-fry."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Chinese"
+    ]
+  },
+  {
+    "id": "rezept-api-53031",
+    "name": "Egyptian Fatteh",
+    "description": "A delicious Beef dish from Egyptian cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 1,
+        "unit": "lb"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Chicken Stock Cube",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Tomatoes",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Tomato Puree",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Rice",
+        "quantity": 2,
+        "unit": "cups"
+      },
+      {
+        "name": "Noodles",
+        "quantity": 0.25,
+        "unit": "cup"
+      },
+      {
+        "name": "Butter",
+        "quantity": 0.25,
+        "unit": "cup"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 2,
+        "unit": "cups"
+      },
+      {
+        "name": "Pita Bread",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Cumin",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "White Wine Vinegar",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "To taste"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "To taste"
+      }
+    ],
+    "instructions": [
+      "To prepare bread for bottom of dish: Take pita bread and rip into bite size pieces.",
+      "In a frying pan, add about a 1/4 stick of butter, add bread pieces and fry until golden brown and crisp.",
+      "Put these pieces in a glass baking dish, preferably a square sized dish.",
+      "Set aside.",
+      "Then add to same pan, a little more butter, salt, approximately 2 cloves of crushed fresh garlic, and a teaspoon or so of cumin stir around a bit until you can smell aroma, then add fried bread pieces to this mixture, stir to coat bread and put back into glass baking dish.",
+      "Set aside.",
+      "To prepare meat: put some butter in a pot, stir fry meat until brown, add 1 onion quartered, salt & pepper, 1 cube of chicken bouillon and water to cover meat.",
+      "Bring to a boil, turn down to simmer, cover and cook until tender, approximately 2 hours.",
+      "After meat has cooled, take out chunks of meat and put in a bowl, set aside.",
+      "Reserve soup from the meat separately.",
+      "To prepare the rice: Put some butter into a pot, add shareya (fideo noodles) like a handful or so, keep stirring until golden brown, not too dark, but very golden.",
+      "Then add two cups of rice, stir a little bit until some of the rice turns an opaque white.",
+      "Add 2-1/4 cups of water and salt to taste.",
+      "Bring to a boil, cover and turn down to simmer, cook until tender.",
+      "Test the rice tenderness after about 35 minutes.",
+      "Now take some of the soup from meat and add to the top of the bread pieces in baking dish to saturate.Add cooked rice on top of bread pieces.",
+      "Slowly spoon remainder of soup onto rice, looking at glass dish sides to see level of soup, should reach just to top of rice, don’t worry, this doesn’t have to be exact.",
+      "Now you’re ready to make the sauce and fry the meat to put on top.",
+      "To prepare red sauce: In a pan, add a little oil or butter, crushed tomato, a half teaspoon of tomato paste, salt & pepper, 2 cloves of fresh crushed garlic and cumin.",
+      "Add also approximately 3 tablespoons of vinegar, stir this until you smell aroma and it is a bit smooth.",
+      "It should be a bit thick, not watery, but if too thick you can add a bit of water.",
+      "Spread with a wooden spoon atop the rice to cover.",
+      "To fry meat: In a pan add a bit of butter or oil, the meat, just a touch of tomato paste, about a tablespoon of fresh crushed garlic, salt & pepper, a teaspoon of cumin.",
+      "Cook until meat is golden fried.",
+      "Spoon this atop the rice and serve.",
+      "Enjoy!"
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Egyptian"
+    ]
+  },
+  {
+    "id": "rezept-api-52826",
+    "name": "Braised Beef Chilli",
+    "description": "A delicious Beef dish from Mexican cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 1,
+        "unit": "kg"
+      },
+      {
+        "name": "Onions",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Garlic",
+        "quantity": 4,
+        "unit": "cloves"
+      },
+      {
+        "name": "Olive oil",
+        "quantity": 1,
+        "unit": "Dash"
+      },
+      {
+        "name": "Chorizo",
+        "quantity": 300,
+        "unit": "g"
+      },
+      {
+        "name": "Cumin",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Allspice",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Cloves",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Cinnamon stick",
+        "quantity": 1,
+        "unit": "large"
+      },
+      {
+        "name": "Bay Leaves",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Oregano",
+        "quantity": 2,
+        "unit": "tsp dried"
+      },
+      {
+        "name": "Ancho Chillies",
+        "quantity": 2,
+        "unit": "ancho"
+      },
+      {
+        "name": "Balsamic Vinegar",
+        "quantity": 3,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Plum Tomatoes",
+        "quantity": 2,
+        "unit": "x 400g"
+      },
+      {
+        "name": "Tomato Ketchup",
+        "quantity": 2,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Dark Brown Sugar",
+        "quantity": 2,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Borlotti Beans",
+        "quantity": 2,
+        "unit": "x 400g tins"
+      }
+    ],
+    "instructions": [
+      "Preheat the oven to 120C/225F/gas mark 1.",
+      "Take the meat out of the fridge to de-chill.",
+      "Pulse the onions and garlic in a food processor until finely chopped.",
+      "Heat 2 tbsp olive oil in a large casserole and sear the meat on all sides until golden.",
+      "Set to one side and add another small slug of oil to brown the chorizo.",
+      "Remove and add the onion and garlic, spices, herbs and chillies then cook until soft in the chorizo oil.",
+      "Season with salt and pepper and add the vinegar, tomatoes, ketchup and sugar.",
+      "Put all the meat back into the pot with 400ml water (or red wine if you prefer), bring up to a simmer and cook, covered, in the low oven.",
+      "After 2 hours, check the meat and add the beans.",
+      "Cook for a further hour and just before serving, pull the meat apart with a pair of forks."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Mexican"
+    ]
+  },
+  {
+    "id": "rezept-api-52827",
+    "name": "Massaman Beef curry",
+    "description": "A delicious Beef dish from Thai cuisine.",
+    "ingredients": [
+      {
+        "name": "Peanuts",
+        "quantity": 85,
+        "unit": "g"
+      },
+      {
+        "name": "Coconut cream",
+        "quantity": 400,
+        "unit": "ml can"
+      },
+      {
+        "name": "Massaman curry paste",
+        "quantity": 4,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Beef",
+        "quantity": 600,
+        "unit": "g stewing cut into strips"
+      },
+      {
+        "name": "Potatoes",
+        "quantity": 450,
+        "unit": "g waxy"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "cut thin wedges"
+      },
+      {
+        "name": "Lime",
+        "quantity": 4,
+        "unit": "leaves"
+      },
+      {
+        "name": "Cinnamon stick",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Tamarind paste",
+        "quantity": 1,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Brown sugar",
+        "quantity": 1,
+        "unit": "tbsp palm or soft light"
+      },
+      {
+        "name": "Fish Sauce",
+        "quantity": 1,
+        "unit": "tbsp"
+      },
+      {
+        "name": "chilli",
+        "quantity": 1,
+        "unit": "red deseeded and finely sliced, to serve"
+      },
+      {
+        "name": "Jasmine Rice",
+        "quantity": 1,
+        "unit": "to serve"
+      }
+    ],
+    "instructions": [
+      "Heat oven to 200C/180C fan/gas 6, then roast the peanuts on a baking tray for 5 mins until golden brown.",
+      "When cool enough to handle, roughly chop.",
+      "Reduce oven to 180C/160C fan/gas 4.",
+      "Heat 2 tbsp coconut cream in a large casserole dish with a lid.",
+      "Add the curry paste and fry for 1 min, then stir in the beef and fry until well coated and sealed.",
+      "Stir in the rest of the coconut with half a can of water, the potatoes, onion, lime leaves, cinnamon, tamarind, sugar, fish sauce and most of the peanuts.",
+      "Bring to a simmer, then cover and cook for 2 hrs in the oven until the beef is tender.",
+      "Sprinkle with sliced chilli and the remaining peanuts, then serve straight from the dish with jasmine rice."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Thai",
+      "Curry"
+    ]
+  },
+  {
+    "id": "rezept-api-53068",
+    "name": "Beef Mechado",
+    "description": "A delicious Beef dish from Filipino cuisine.",
+    "ingredients": [
+      {
+        "name": "Garlic",
+        "quantity": 3,
+        "unit": "cloves"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "sliced"
+      },
+      {
+        "name": "Beef",
+        "quantity": 2,
+        "unit": "Lbs"
+      },
+      {
+        "name": "Tomato Puree",
+        "quantity": 8,
+        "unit": "ounces"
+      },
+      {
+        "name": "Water",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Lemon",
+        "quantity": 1,
+        "unit": "Slice"
+      },
+      {
+        "name": "Potatoes",
+        "quantity": 1,
+        "unit": "large"
+      },
+      {
+        "name": "Soy Sauce",
+        "quantity": 0.25,
+        "unit": "cup"
+      },
+      {
+        "name": "Black Pepper",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Bay Leaves",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "To taste"
+      }
+    ],
+    "instructions": [
+      "0.",
+      "Make the beef tenderloin marinade by combining soy sauce, vinegar, ginger, garlic, sesame oil, olive oil, sugar, salt, and ground black pepper in a large bowl.",
+      "Mix well.",
+      "1.",
+      "Add the cubed beef tenderloin to the bowl with the beef tenderloin marinade.",
+      "Gently toss to coat the beef.",
+      "Let it stay for 1 hour.",
+      "2.",
+      "Using a metal or bamboo skewer, assemble the beef kebob by skewering the vegetables and marinated beef tenderloin.",
+      "3.",
+      "Heat-up the grill and start grilling the beef kebobs for 3 minutes per side.",
+      "This will give you a medium beef that is juicy and tender on the inside.",
+      "Add more time if you want your beef well done, but it will be less tender.",
+      "4.",
+      "Transfer to a serving plate.",
+      "Serve with Saffron rice.",
+      "5.",
+      "Share and enjoy!"
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Filipino",
+      "Stew",
+      "Warming"
+    ]
+  },
+  {
+    "id": "rezept-api-53053",
+    "name": "Beef Rendang",
+    "description": "A delicious Beef dish from Malaysian cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 1,
+        "unit": "lb"
+      },
+      {
+        "name": "Vegetable Oil",
+        "quantity": 5,
+        "unit": "tbs"
+      },
+      {
+        "name": "Cinnamon Stick",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Cloves",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Star Anise",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Cardamom",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Coconut Cream",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Water",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Tamarind Paste",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Lime",
+        "quantity": 6,
+        "unit": null
+      },
+      {
+        "name": "Sugar",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Challots",
+        "quantity": 5,
+        "unit": null
+      }
+    ],
+    "instructions": [
+      "Chop the spice paste ingredients and then blend it in a food processor until fine.",
+      "Heat the oil in a stew pot, add the spice paste, cinnamon, cloves, star anise, and cardamom and stir-fry until aromatic.",
+      "Add the beef and the pounded lemongrass and stir for 1 minute.",
+      "Add the coconut milk, tamarind juice, water, and simmer on medium heat, stirring frequently until the meat is almost cooked.",
+      "Add the kaffir lime leaves, kerisik (toasted coconut), sugar or palm sugar, stirring to blend well with the meat.",
+      "Lower the heat to low, cover the lid, and simmer for 1 to 1 1/2 hours or until the meat is really tender and the gravy has dried up.",
+      "Add more salt and sugar to taste.",
+      "Serve immediately with steamed rice and save some for overnight."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Malaysian"
+    ]
+  },
+  {
+    "id": "rezept-api-53057",
+    "name": "Traditional Croatian Goulash",
+    "description": "A delicious Beef dish from Croatian cuisine.",
+    "ingredients": [
+      {
+        "name": "Beef",
+        "quantity": 500,
+        "unit": "g"
+      },
+      {
+        "name": "Onions",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 2,
+        "unit": "cloves"
+      },
+      {
+        "name": "Bay Leaf",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Red Wine",
+        "quantity": 200,
+        "unit": "ml"
+      },
+      {
+        "name": "Water",
+        "quantity": 2,
+        "unit": "Litres"
+      },
+      {
+        "name": "Mustard",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Paprika",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Vegetable Oil",
+        "quantity": 2,
+        "unit": "tbs"
+      }
+    ],
+    "instructions": [
+      "Clean the meat from the veins if there are some and cut it into smaller pieces, 3 × 3 cm.",
+      "Marinate the meat in the mustard and spices and let it sit in the refrigerator for one hour.",
+      "Heat one tablespoon of pork fat or vegetable oil in a pot and fry the meat on all sides until it gets browned.",
+      "Once the meat is cooked, transfer it to a plate and add another tablespoon of fat to the pot.",
+      "Cut the onions very fine, peel the carrots and shred it using a grater.",
+      "Cook the onions and carrots over low heat for 15 minutes.",
+      "You can salt the vegetables a little to make them soften faster.",
+      "Once the vegetables have browned and become slightly mushy, add the meat and bay leaves and garlic.",
+      "Pour over with wine and simmer for 10-15 minutes to allow the alcohol to evaporate.",
+      "Now is the right time to add 2/3 the amount of liquid.",
+      "Cover the pot and cook over low heat for an hour, stirring occasionally.",
+      "After the first hour, pour over the rest of the water or stock and cook for another 30-45 minutes.",
+      "Allow the stew to cool slightly and serve it with a sprinkle of chopped parsley and few slices of fresh hot pepper if you like to spice it up a bit.",
+      "Slice ​​some fresh bread, season the salad and simply enjoying these wonderful flavors."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Beef",
+      "Croatian",
+      "Soup"
+    ]
+  },
+  {
+    "id": "rezept-api-52956",
+    "name": "Chicken Congee",
+    "description": "A delicious Chicken dish from Chinese cuisine.",
+    "ingredients": [
+      {
+        "name": "Chicken",
+        "quantity": 8,
+        "unit": "oz"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Ginger Cordial",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Ginger",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Spring Onions",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Rice",
+        "quantity": 0.5,
+        "unit": "cup"
+      },
+      {
+        "name": "Water",
+        "quantity": 8,
+        "unit": "cups"
+      },
+      {
+        "name": "Coriander",
+        "quantity": 2,
+        "unit": "oz"
+      }
+    ],
+    "instructions": [
+      "STEP 1 - MARINATING THE CHICKEN.",
+      "In a bowl, add chicken, salt, white pepper, ginger juice and then mix it together well.",
+      "Set the chicken aside.",
+      "STEP 2 - RINSE THE WHITE RICE.",
+      "Rinse the rice in a metal bowl or pot a couple times and then drain the water.",
+      "STEP 2 - BOILING THE WHITE RICE.",
+      "Next add 8 cups of water and then set the stove on high heat until it is boiling.",
+      "Once rice porridge starts to boil, set the stove on low heat and then stir it once every 8-10 minutes for around 20-25 minutes.",
+      "After 25 minutes, this is optional but you can add a little bit more water to make rice porridge to make it less thick or to your preference.",
+      "Next add the marinated chicken to the rice porridge and leave the stove on low heat for another 10 minutes.",
+      "After an additional 10 minutes add the green onions, sliced ginger, 1 pinch of salt, 1 pinch of white pepper and stir for 10 seconds.",
+      "Serve the rice porridge in a bowl.",
+      "Optional: add Coriander on top of the rice porridge."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "Chinese"
+    ]
+  },
+  {
+    "id": "rezept-api-52774",
+    "name": "Pad See Ew",
+    "description": "A delicious Chicken dish from Thai cuisine.",
+    "ingredients": [
+      {
+        "name": "rice stick noodles",
+        "quantity": 6,
+        "unit": "oz/180g"
+      },
+      {
+        "name": "dark soy sauce",
+        "quantity": 2,
+        "unit": "tbsp"
+      },
+      {
+        "name": "oyster sauce",
+        "quantity": 2,
+        "unit": "tbsp"
+      },
+      {
+        "name": "soy sauce",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "white vinegar",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "sugar",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "water",
+        "quantity": 2,
+        "unit": "tbsp"
+      },
+      {
+        "name": "peanut oil",
+        "quantity": 2,
+        "unit": "tbsp"
+      },
+      {
+        "name": "garlic",
+        "quantity": 2,
+        "unit": "cloves"
+      },
+      {
+        "name": "Chicken",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Egg",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Chinese broccoli",
+        "quantity": 4,
+        "unit": "cups"
+      }
+    ],
+    "instructions": [
+      "Mix Sauce in small bowl.",
+      "Mince garlic into wok with oil.",
+      "Place over high heat, when hot, add chicken and Chinese broccoli stems, cook until chicken is light golden.",
+      "Push to the side of the wok, crack egg in and scramble.",
+      "Don't worry if it sticks to the bottom of the wok - it will char and which adds authentic flavour.",
+      "Add noodles, Chinese broccoli leaves and sauce.",
+      "Gently mix together until the noodles are stained dark and leaves are wilted.",
+      "Serve immediately!"
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "Thai",
+      "Pasta"
+    ]
+  },
+  {
+    "id": "rezept-api-52846",
+    "name": "Chicken & mushroom Hotpot",
+    "description": "A delicious Chicken dish from British cuisine.",
+    "ingredients": [
+      {
+        "name": "Butter",
+        "quantity": 50,
+        "unit": "g"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Mushrooms",
+        "quantity": 100,
+        "unit": "g"
+      },
+      {
+        "name": "Plain Flour",
+        "quantity": 40,
+        "unit": "g"
+      },
+      {
+        "name": "Chicken Stock Cube",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Nutmeg",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Mustard Powder",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Chicken",
+        "quantity": 250,
+        "unit": "g"
+      },
+      {
+        "name": "Sweetcorn",
+        "quantity": 2,
+        "unit": "Handfuls"
+      },
+      {
+        "name": "Potatoes",
+        "quantity": 2,
+        "unit": "large"
+      },
+      {
+        "name": "Butter",
+        "quantity": 1,
+        "unit": "knob"
+      }
+    ],
+    "instructions": [
+      "Heat oven to 200C/180C fan/gas 6.",
+      "Put the butter in a medium-size saucepan and place over a medium heat.",
+      "Add the onion and leave to cook for 5 mins, stirring occasionally.",
+      "Add the mushrooms to the saucepan with the onions.",
+      "Once the onion and mushrooms are almost cooked, stir in the flour – this will make a thick paste called a roux.",
+      "If you are using a stock cube, crumble the cube into the roux now and stir well.",
+      "Put the roux over a low heat and stir continuously for 2 mins – this will cook the flour and stop the sauce from having a floury taste.",
+      "Take the roux off the heat.",
+      "Slowly add the fresh stock, if using, or pour in 500ml water if you’ve used a stock cube, stirring all the time.",
+      "Once all the liquid has been added, season with pepper, a pinch of nutmeg and mustard powder.",
+      "Put the saucepan back onto a medium heat and slowly bring it to the boil, stirring all the time.",
+      "Once the sauce has thickened, place on a very low heat.",
+      "Add the cooked chicken and vegetables to the sauce and stir well.",
+      "Grease a medium-size ovenproof pie dish with a little butter and pour in the chicken and mushroom filling.",
+      "Carefully lay the potatoes on top of the hot-pot filling, overlapping them slightly, almost like a pie top.",
+      "Brush the potatoes with a little melted butter and cook in the oven for about 35 mins.",
+      "The hot-pot is ready once the potatoes are cooked and golden brown."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "British"
+    ]
+  },
+  {
+    "id": "rezept-api-52813",
+    "name": "Kentucky Fried Chicken",
+    "description": "A delicious Chicken dish from American cuisine.",
+    "ingredients": [
+      {
+        "name": "Chicken",
+        "quantity": 1,
+        "unit": "whole"
+      },
+      {
+        "name": "Oil",
+        "quantity": 2,
+        "unit": "quarts neutral frying"
+      },
+      {
+        "name": "Egg White",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Flour",
+        "quantity": 1,
+        "unit": "1/2 cups"
+      },
+      {
+        "name": "Brown Sugar",
+        "quantity": 1,
+        "unit": "tablespoon"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "tablespoon"
+      },
+      {
+        "name": "paprika",
+        "quantity": 1,
+        "unit": "tablespoon"
+      },
+      {
+        "name": "onion salt",
+        "quantity": 2,
+        "unit": "teaspoons"
+      },
+      {
+        "name": "chili powder",
+        "quantity": 1,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "black pepper",
+        "quantity": 1,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "celery salt",
+        "quantity": 0.5,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "sage",
+        "quantity": 0.5,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "garlic powder",
+        "quantity": 0.5,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "allspice",
+        "quantity": 0.5,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "oregano",
+        "quantity": 0.5,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "basil",
+        "quantity": 0.5,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "marjoram",
+        "quantity": 0.5,
+        "unit": "teaspoon"
+      }
+    ],
+    "instructions": [
+      "Preheat fryer to 350°F.",
+      "Thoroughly mix together all the spice mix ingredients.",
+      "Combine spice mix with flour, brown sugar and salt.",
+      "Dip chicken pieces in egg white to lightly coat them, then transfer to flour mixture.",
+      "Turn a few times and make sure the flour mix is really stuck to the chicken.",
+      "Repeat with all the chicken pieces.",
+      "Let chicken pieces rest for 5 minutes so crust has a chance to dry a bit.",
+      "Fry chicken in batches.",
+      "Breasts and wings should take 12-14 minutes, and legs and thighs will need a few more minutes.",
+      "Chicken pieces are done when a meat thermometer inserted into the thickest part reads 165°F.",
+      "Let chicken drain on a few paper towels when it comes out of the fryer.",
+      "Serve hot."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "American",
+      "Meat",
+      "Spicy"
+    ]
+  },
+  {
+    "id": "rezept-api-52940",
+    "name": "Brown Stew Chicken",
+    "description": "A delicious Chicken dish from Jamaican cuisine.",
+    "ingredients": [
+      {
+        "name": "Chicken",
+        "quantity": 1,
+        "unit": "whole"
+      },
+      {
+        "name": "Tomato",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Onions",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Red Pepper",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Lime",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Thyme",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Allspice",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Soy Sauce",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Cornstarch",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Coconut Milk",
+        "quantity": 2,
+        "unit": "cups"
+      },
+      {
+        "name": "Vegetable Oil",
+        "quantity": 1,
+        "unit": "tbs"
+      }
+    ],
+    "instructions": [
+      "Squeeze lime over chicken and rub well.",
+      "Drain off excess lime juice.",
+      "Combine tomato, scallion, onion, garlic, pepper, thyme, pimento and soy sauce in a large bowl with the chicken pieces.",
+      "Cover and marinate at least one hour.",
+      "Heat oil in a dutch pot or large saucepan.",
+      "Shake off the seasonings as you remove each piece of chicken from the marinade.",
+      "Reserve the marinade for sauce.",
+      "Lightly brown the chicken a few pieces at a time in very hot oil.",
+      "Place browned chicken pieces on a plate to rest while you brown the remaining pieces.",
+      "Drain off excess oil and return the chicken to the pan.",
+      "Pour the marinade over the chicken and add the carrots.",
+      "Stir and cook over medium heat for 10 minutes.",
+      "Mix flour and coconut milk and add to stew, stirring constantly.",
+      "Turn heat down to minimum and cook another 20 minutes or until tender."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "Jamaican",
+      "Stew"
+    ]
+  },
+  {
+    "id": "rezept-api-52831",
+    "name": "Chicken Karaage",
+    "description": "A delicious Chicken dish from Japanese cuisine.",
+    "ingredients": [
+      {
+        "name": "Chicken",
+        "quantity": 450,
+        "unit": "grams Boneless skin"
+      },
+      {
+        "name": "Ginger",
+        "quantity": 1,
+        "unit": "tablespoon"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 1,
+        "unit": "clove"
+      },
+      {
+        "name": "Soy sauce",
+        "quantity": 2,
+        "unit": "tablespoons"
+      },
+      {
+        "name": "Sake",
+        "quantity": 1,
+        "unit": "tablespoon"
+      },
+      {
+        "name": "Granulated sugar",
+        "quantity": 2,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "Potato starch",
+        "quantity": 0.3333333333333333,
+        "unit": "cup"
+      },
+      {
+        "name": "Vegetable oil",
+        "quantity": 0.3333333333333333,
+        "unit": "cup"
+      },
+      {
+        "name": "Lemon",
+        "quantity": 0.3333333333333333,
+        "unit": "cup"
+      }
+    ],
+    "instructions": [
+      "Add the ginger, garlic, soy sauce, sake and sugar to a bowl and whisk to combine.",
+      "Add the chicken, then stir to coat evenly.",
+      "Cover and refrigerate for at least 1 hour.",
+      "Add 1 inch of vegetable oil to a heavy bottomed pot and heat until the oil reaches 360 degrees F.",
+      "Line a wire rack with 2 sheets of paper towels and get your tongs out.",
+      "Put the potato starch in a bowl.",
+      "Add a handful of chicken to the potato starch and toss to coat each piece evenly.",
+      "Fry the karaage in batches until the exterior is a medium brown and the chicken is cooked through.",
+      "Transfer the fried chicken to the paper towel lined rack.",
+      "If you want the karaage to stay crispy longer, you can fry the chicken a second time, until it's a darker color after it's cooled off once.",
+      "Serve with lemon wedges."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "Japanese"
+    ]
+  },
+  {
+    "id": "rezept-api-52796",
+    "name": "Chicken Alfredo Primavera",
+    "description": "A delicious Chicken dish from Italian cuisine.",
+    "ingredients": [
+      {
+        "name": "Butter",
+        "quantity": 2,
+        "unit": "tablespoons"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 3,
+        "unit": "tablespoons"
+      },
+      {
+        "name": "Chicken",
+        "quantity": 5,
+        "unit": "boneless"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "Squash",
+        "quantity": 1,
+        "unit": "cut into 1/2-inch cubes"
+      },
+      {
+        "name": "Broccoli",
+        "quantity": 1,
+        "unit": "Head chopped"
+      },
+      {
+        "name": "mushrooms",
+        "quantity": 8,
+        "unit": "-ounce sliced"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "red"
+      },
+      {
+        "name": "onion",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "garlic",
+        "quantity": 3,
+        "unit": "cloves"
+      },
+      {
+        "name": "red pepper flakes",
+        "quantity": 0.5,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "white wine",
+        "quantity": 0.5,
+        "unit": "cup"
+      },
+      {
+        "name": "milk",
+        "quantity": 0.5,
+        "unit": "cup"
+      },
+      {
+        "name": "heavy cream",
+        "quantity": 0.5,
+        "unit": "cup"
+      },
+      {
+        "name": "Parmesan cheese",
+        "quantity": 1,
+        "unit": "cup grated"
+      },
+      {
+        "name": "bowtie pasta",
+        "quantity": 16,
+        "unit": "ounces"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Parsley",
+        "quantity": 1,
+        "unit": "chopped"
+      }
+    ],
+    "instructions": [
+      "Heat 1 tablespoon of butter and 2 tablespoons of olive oil in a large skillet over medium-high heat.",
+      "Season both sides of each chicken breast with seasoned salt and a pinch of pepper.",
+      "Add the chicken to the skillet and cook for 5-7 minutes on each side, or until cooked through.",
+      "While the chicken is cooking, bring a large pot of water to a boil.",
+      "Season the boiling water with a few generous pinches of kosher salt.",
+      "Add the pasta and give it a stir.",
+      "Cook, stirring occasionally, until al dente, about 12 minutes.",
+      "Reserve 1/2 cup of  pasta water before draining the pasta.",
+      "Remove the chicken from the pan and transfer it to a cutting board; allow it to rest.",
+      "Turn the heat down to medium and dd the remaining 1 tablespoon of butter and olive oil to the same pan you used to cook the chicken.",
+      "Add the veggies (minus the garlic) and red pepper flakes to the pan and stir to coat with the oil and butter (refrain from seasoning with salt until the veggies are finished browning).",
+      "Cook, stirring often, until the veggies are tender, about 5 minutes.",
+      "Add the garlic and a generous pinch of salt and pepper to the pan and cook for 1 minute.",
+      "Deglaze the pan with the white wine.",
+      "Continue to cook until the wine has reduced by half, about 3 minutes.",
+      "Stir in the milk, heavy cream, and reserved pasta water.",
+      "Bring the mixture to a gentle boil and allow to simmer and reduce for 2-3 minutes.",
+      "Turn off the heat and add the Parmesan cheese and cooked pasta.",
+      "Season with salt and pepper to taste.",
+      "Garnish with Parmesan cheese and chopped parsley, if desired."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "Italian",
+      "Pasta",
+      "Meat",
+      "Dairy"
+    ]
+  },
+  {
+    "id": "rezept-api-53039",
+    "name": "Piri-piri chicken and slaw",
+    "description": "A delicious Chicken dish from Portuguese cuisine.",
+    "ingredients": [
+      {
+        "name": "Chicken",
+        "quantity": 1.5,
+        "unit": "kg"
+      },
+      {
+        "name": "Red Chilli",
+        "quantity": 3,
+        "unit": "chopped"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 2,
+        "unit": "cloves"
+      },
+      {
+        "name": "Ginger",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Dried Oregano",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Coriander",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Paprika",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Red Wine Vinegar",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Oil",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Red Onions",
+        "quantity": 1,
+        "unit": "sliced"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Beetroot",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Cabbage",
+        "quantity": 4,
+        "unit": "leaves"
+      },
+      {
+        "name": "Mayonnaise",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Greek Yogurt",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Red Wine Vinegar",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Cumin Seeds",
+        "quantity": 1,
+        "unit": "tsp"
+      }
+    ],
+    "instructions": [
+      "STEP 1.",
+      "Whizz together all of the marinade ingredients in a small food processor.",
+      "Rub the marinade onto the chicken and leave for 1 hour at room temperature.",
+      "STEP 2.",
+      "Heat the oven to 190C/fan 170C/gas 5.",
+      "Put the chicken in a roasting tray and cook for 1 hour 20 minutes.",
+      "Rest under loose foil for 20 minutes.",
+      "While the chicken is resting, mix together the slaw ingredients and season.",
+      "Serve the chicken with slaw, fries and condiments."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "Portuguese"
+    ]
+  },
+  {
+    "id": "rezept-api-52945",
+    "name": "Kung Pao Chicken",
+    "description": "A delicious Chicken dish from Chinese cuisine.",
+    "ingredients": [
+      {
+        "name": "Sake",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Soy Sauce",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Sesame Seed Oil",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Corn Flour",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Water",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Chicken",
+        "quantity": 500,
+        "unit": "g"
+      },
+      {
+        "name": "Chilli Powder",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Rice Vinegar",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Brown Sugar",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Spring Onions",
+        "quantity": 4,
+        "unit": "Chopped"
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 6,
+        "unit": "cloves"
+      },
+      {
+        "name": "Water Chestnut",
+        "quantity": 220,
+        "unit": "g"
+      },
+      {
+        "name": "Peanuts",
+        "quantity": 100,
+        "unit": "g"
+      }
+    ],
+    "instructions": [
+      "Combine the sake or rice wine, soy sauce, sesame oil and cornflour dissolved in water.",
+      "Divide mixture in half.",
+      "In a glass dish or bowl, combine half of the sake mixture with the chicken pieces and toss to coat.",
+      "Cover dish and place in refrigerator for about 30 minutes.",
+      "In a medium frying pan, combine remaining sake mixture, chillies, vinegar and sugar.",
+      "Mix together and add spring onion, garlic, water chestnuts and peanuts.",
+      "Heat sauce slowly over medium heat until aromatic.",
+      "Meanwhile, remove chicken from marinade and sauté in a large frying pan until juices run clear.",
+      "When sauce is aromatic, add sautéed chicken and let simmer together until sauce thickens."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "Chinese"
+    ]
+  },
+  {
+    "id": "rezept-api-52934",
+    "name": "Chicken Basquaise",
+    "description": "A delicious Chicken dish from French cuisine.",
+    "ingredients": [
+      {
+        "name": "Chicken",
+        "quantity": 1.5,
+        "unit": "kg"
+      },
+      {
+        "name": "Butter",
+        "quantity": 25,
+        "unit": "g"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 6,
+        "unit": "tblsp"
+      },
+      {
+        "name": "Red Onions",
+        "quantity": 2,
+        "unit": "sliced"
+      },
+      {
+        "name": "Red Pepper",
+        "quantity": 3,
+        "unit": "Large"
+      },
+      {
+        "name": "Chorizo",
+        "quantity": 130,
+        "unit": "g"
+      },
+      {
+        "name": "Sun-Dried Tomatoes",
+        "quantity": 8,
+        "unit": null
+      },
+      {
+        "name": "Garlic",
+        "quantity": 6,
+        "unit": "cloves sliced"
+      },
+      {
+        "name": "Basmati Rice",
+        "quantity": 300,
+        "unit": "g"
+      },
+      {
+        "name": "Tomato Puree",
+        "quantity": 1,
+        "unit": "drizzle"
+      },
+      {
+        "name": "Paprika",
+        "quantity": 1,
+        "unit": "½ tsp"
+      },
+      {
+        "name": "Bay Leaves",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Thyme",
+        "quantity": 1,
+        "unit": "Handful"
+      },
+      {
+        "name": "Chicken Stock",
+        "quantity": 350,
+        "unit": "ml"
+      },
+      {
+        "name": "Dry White Wine",
+        "quantity": 180,
+        "unit": "g"
+      },
+      {
+        "name": "Lemons",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Black Olives",
+        "quantity": 100,
+        "unit": "g"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "to serve"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "to serve"
+      }
+    ],
+    "instructions": [
+      "Preheat the oven to 180°C/Gas mark 4.",
+      "Have the chicken joints ready to cook.",
+      "Heat the butter and 3 tbsp olive oil in a flameproof casserole or large frying pan.",
+      "Brown the chicken pieces in batches on both sides, seasoning them with salt and pepper as you go.",
+      "Don't crowd the pan - fry the chicken in small batches, removing the pieces to kitchen paper as they are done.",
+      "Add a little more olive oil to the casserole and fry the onions over a medium heat for 10 minutes, stirring frequently, until softened but not browned.",
+      "Add the rest of the oil, then the peppers and cook for another 5 minutes.",
+      "Add the chorizo, sun-dried tomatoes and garlic and cook for 2-3 minutes.",
+      "Add the rice, stirring to ensure it is well coated in the oil.",
+      "Stir in the tomato paste, paprika, bay leaves and chopped thyme.",
+      "Pour in the stock and wine.",
+      "When the liquid starts to bubble, turn the heat down to a gentle simmer.",
+      "Press the rice down into the liquid if it isn't already submerged and place the chicken on top.",
+      "Add the lemon wedges and olives around the chicken.",
+      "Cover and cook in the oven for 50 minutes.",
+      "The rice should be cooked but still have some bite, and the chicken should have juices that run clear when pierced in the thickest part with a knife.",
+      "If not, cook for another 5 minutes and check again."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "French",
+      "Meat"
+    ]
+  },
+  {
+    "id": "rezept-api-52814",
+    "name": "Thai Green Curry",
+    "description": "A delicious Chicken dish from Thai cuisine.",
+    "ingredients": [
+      {
+        "name": "Potatoes",
+        "quantity": 225,
+        "unit": "g new"
+      },
+      {
+        "name": "green beans",
+        "quantity": 100,
+        "unit": "g"
+      },
+      {
+        "name": "sunflower oil",
+        "quantity": 1,
+        "unit": "tbsp"
+      },
+      {
+        "name": "garlic",
+        "quantity": 1,
+        "unit": "clove"
+      },
+      {
+        "name": "Thai green curry paste",
+        "quantity": 4,
+        "unit": "tsp"
+      },
+      {
+        "name": "coconut milk",
+        "quantity": 400,
+        "unit": "ml"
+      },
+      {
+        "name": "Thai fish sauce",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Sugar",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Chicken",
+        "quantity": 450,
+        "unit": "g boneless"
+      },
+      {
+        "name": "lime",
+        "quantity": 2,
+        "unit": "fresh kaffir leaves"
+      },
+      {
+        "name": "basil",
+        "quantity": 1,
+        "unit": "handfull"
+      },
+      {
+        "name": "Rice",
+        "quantity": 1,
+        "unit": "Boiled"
+      }
+    ],
+    "instructions": [
+      "Put the potatoes in a pan of boiling water and cook for 5 minutes.",
+      "Throw in the beans and cook for a further 3 minutes, by which time both should be just tender but not too soft.",
+      "Drain and put to one side.",
+      "In a wok or large frying pan, heat the oil until very hot, then drop in the garlic and cook until golden, this should take only a few seconds.",
+      "Don’t let it go very dark or it will spoil the taste.",
+      "Spoon in the curry paste and stir it around for a few seconds to begin to cook the spices and release all the flavours.",
+      "Next, pour in the coconut milk and let it come to a bubble.",
+      "Stir in the fish sauce and sugar, then the pieces of chicken.",
+      "Turn the heat down to a simmer and cook, covered, for about 8 minutes until the chicken is cooked.",
+      "Tip in the potatoes and beans and let them warm through in the hot coconut milk, then add a lovely citrussy flavour by stirring in the shredded lime leaves (or lime zest).",
+      "The basil leaves go in next, but only leave them briefly on the heat or they will quickly lose their brightness.",
+      "Scatter with the lime garnish and serve immediately with boiled rice."
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "Thai",
+      "Curry",
+      "Mild"
+    ]
+  },
+  {
+    "id": "rezept-api-52795",
+    "name": "Chicken Handi",
+    "description": "A delicious Chicken dish from Indian cuisine.",
+    "ingredients": [
+      {
+        "name": "Chicken",
+        "quantity": 1.2,
+        "unit": "kg"
+      },
+      {
+        "name": "Onion",
+        "quantity": 5,
+        "unit": "thinly sliced"
+      },
+      {
+        "name": "Tomatoes",
+        "quantity": 2,
+        "unit": "finely chopped"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 8,
+        "unit": "cloves chopped"
+      },
+      {
+        "name": "Ginger paste",
+        "quantity": 1,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Vegetable oil",
+        "quantity": 1,
+        "unit": "¼ cup"
+      },
+      {
+        "name": "Cumin seeds",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Coriander seeds",
+        "quantity": 3,
+        "unit": "tsp"
+      },
+      {
+        "name": "Turmeric powder",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Chilli powder",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Green chilli",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Yogurt",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Cream",
+        "quantity": 1,
+        "unit": "¾ cup"
+      },
+      {
+        "name": "fenugreek",
+        "quantity": 3,
+        "unit": "tsp Dried"
+      },
+      {
+        "name": "Garam masala",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "To taste"
+      }
+    ],
+    "instructions": [
+      "Take a large pot or wok, big enough to cook all the chicken, and heat the oil in it.",
+      "Once the oil is hot, add sliced onion and fry them until deep golden brown.",
+      "Then take them out on a plate and set aside.",
+      "To the same pot, add the chopped garlic and sauté for a minute.",
+      "Then add the chopped tomatoes and cook until tomatoes turn soft.",
+      "This would take about 5 minutes.",
+      "Then return the fried onion to the pot and stir.",
+      "Add ginger paste and sauté well.",
+      "Now add the cumin seeds, half of the coriander seeds and chopped green chillies.",
+      "Give them a quick stir.",
+      "Next goes in the spices – turmeric powder and red chilli powder.",
+      "Sauté the spices well for couple of minutes.",
+      "Add the chicken pieces to the wok, season it with salt to taste and cook the chicken covered on medium-low heat until the chicken is almost cooked through.",
+      "This would take about 15 minutes.",
+      "Slowly sautéing the chicken will enhance the flavor, so do not expedite this step by putting it on high heat.",
+      "When the oil separates from the spices, add the beaten yogurt keeping the heat on lowest so that the yogurt doesn’t split.",
+      "Sprinkle the remaining coriander seeds and add half of the dried fenugreek leaves.",
+      "Mix well.",
+      "Finally add the cream and give a final mix to combine everything well.",
+      "Sprinkle the remaining kasuri methi and garam masala and serve the chicken handi hot with naan or rotis.",
+      "Enjoy!"
+    ],
+    "isVegetarian": false,
+    "isVegan": false,
+    "tags": [
+      "Chicken",
+      "Indian"
+    ]
+  },
+  {
+    "id": "rezept-api-53026",
+    "name": "Tamiya",
+    "description": "A delicious Vegetarian dish from Egyptian cuisine.",
+    "ingredients": [
+      {
+        "name": "Broad Beans",
+        "quantity": 3,
+        "unit": "cups"
+      },
+      {
+        "name": "Spring Onions",
+        "quantity": 6,
+        "unit": null
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Parsley",
+        "quantity": 0.25,
+        "unit": "cup"
+      },
+      {
+        "name": "Cumin",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Baking Powder",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Cayenne Pepper",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Flour",
+        "quantity": 1,
+        "unit": "Spinkling"
+      },
+      {
+        "name": "Vegetable Oil",
+        "quantity": 1,
+        "unit": "As required"
+      }
+    ],
+    "instructions": [
+      "oak the beans in water to cover overnight.Drain.",
+      "If skinless beans are unavailable, rub to loosen the skins, then discard the skins.",
+      "Pat the beans dry with a towel.",
+      "Grind the beans in a food mill or meat grinder.If neither appliance is available, process them in a food processor but only until the beans form a paste.",
+      "(If blended too smoothly, the batter tends to fall apart during cooking.) Add the scallions, garlic, cilantro, cumin, baking powder, cayenne, salt, pepper, and coriander, if using.",
+      "Refrigerate for at least 30 minutes.",
+      "Shape the bean mixture into 1-inch balls.Flatten slightly and coat with flour.",
+      "Heat at least 1½-inches of oil over medium heat to 365 degrees.",
+      "Fry the patties in batches, turning once, until golden brown on all sides, about 5 minutes.Remove with a wire mesh skimmer or slotted spoon.",
+      "Serve as part of a meze or in pita bread with tomato-cucumber salad and tahina sauce."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "Egyptian",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52973",
+    "name": "Leblebi Soup",
+    "description": "A delicious Vegetarian dish from Tunisian cuisine.",
+    "ingredients": [
+      {
+        "name": "Olive Oil",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "medium finely diced"
+      },
+      {
+        "name": "Chickpeas",
+        "quantity": 250,
+        "unit": "g"
+      },
+      {
+        "name": "Vegetable Stock",
+        "quantity": 1.5,
+        "unit": "L"
+      },
+      {
+        "name": "Cumin",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 5,
+        "unit": "cloves"
+      },
+      {
+        "name": "Salt",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Harissa Spice",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "Pinch"
+      },
+      {
+        "name": "Lime",
+        "quantity": 0.5,
+        "unit": null
+      }
+    ],
+    "instructions": [
+      "Heat the oil in a large pot.",
+      "Add the onion and cook until translucent.",
+      "Drain the soaked chickpeas and add them to the pot together with the vegetable stock.",
+      "Bring to the boil, then reduce the heat and cover.",
+      "Simmer for 30 minutes.",
+      "In the meantime toast the cumin in a small ungreased frying pan, then grind them in a mortar.",
+      "Add the garlic and salt and pound to a fine paste.",
+      "Add the paste and the harissa to the soup and simmer until the chickpeas are tender, about 30 minutes.",
+      "Season to taste with salt, pepper and lemon juice and serve hot."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "Tunisian",
+      "Soup",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-53047",
+    "name": "Moroccan Carrot Soup",
+    "description": "A delicious Vegetarian dish from Moroccan cuisine.",
+    "ingredients": [
+      {
+        "name": "Carrots",
+        "quantity": 6,
+        "unit": "chopped"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "sliced"
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Cumin",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Coriander",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Garam Masala",
+        "quantity": 0.25,
+        "unit": "tsp"
+      },
+      {
+        "name": "Lemon Juice",
+        "quantity": 1,
+        "unit": "tsp"
+      }
+    ],
+    "instructions": [
+      "Step 1.",
+      "Preheat oven to 180° C.",
+      "Step 2.",
+      "Combine carrots, onion, garlic, cumin seeds, coriander seeds, salt and olive oil in a bowl and mix well.",
+      "Transfer on a baking tray.",
+      "Step 3.",
+      "Put the baking tray in preheated oven and roast for 10-12 minutes or till carrots soften.",
+      "Remove from heat and cool.",
+      "Step 4.",
+      "Grind the baked carrot mixture along with some water to make a smooth paste and strain in a bowl.",
+      "Step 5.",
+      "Heat the carrot mixture in a non-stick pan.",
+      "Add two cups of water and bring to a boil.",
+      "Add garam masala powder and mix.",
+      "Add salt and mix well.",
+      "Step 6.",
+      "Remove from heat, add lemon juice and mix well.",
+      "Step 7.",
+      "Serve hot."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "Moroccan",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52871",
+    "name": "Yaki Udon",
+    "description": "A delicious Vegetarian dish from Japanese cuisine.",
+    "ingredients": [
+      {
+        "name": "Udon Noodles",
+        "quantity": 250,
+        "unit": "g"
+      },
+      {
+        "name": "Sesame Seed Oil",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "sliced"
+      },
+      {
+        "name": "Cabbage",
+        "quantity": 0.25,
+        "unit": null
+      },
+      {
+        "name": "Shiitake Mushrooms",
+        "quantity": 10,
+        "unit": null
+      },
+      {
+        "name": "Spring Onions",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Mirin",
+        "quantity": 4,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Soy Sauce",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Caster Sugar",
+        "quantity": 1,
+        "unit": "tblsp"
+      },
+      {
+        "name": "Worcestershire Sauce",
+        "quantity": 1,
+        "unit": "tblsp"
+      }
+    ],
+    "instructions": [
+      "Boil some water in a large saucepan.",
+      "Add 250ml cold water and the udon noodles.",
+      "(As they are so thick, adding cold water helps them to cook a little bit slower so the middle cooks through).",
+      "If using frozen or fresh noodles, cook for 2 mins or until al dente; dried will take longer, about 5-6 mins.",
+      "Drain and leave in the colander.",
+      "Heat 1 tbsp of the oil, add the onion and cabbage and sauté for 5 mins until softened.",
+      "Add the mushrooms and some spring onions, and sauté for 1 more min.",
+      "Pour in the remaining sesame oil and the noodles.",
+      "If using cold noodles, let them heat through before adding the ingredients for the sauce – otherwise tip in straight away and keep stir-frying until sticky and piping hot.",
+      "Sprinkle with the remaining spring onions."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "Japanese",
+      "LowCalorie",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-53025",
+    "name": "Ful Medames",
+    "description": "A delicious Vegetarian dish from Egyptian cuisine.",
+    "ingredients": [
+      {
+        "name": "Broad Beans",
+        "quantity": 2,
+        "unit": "cups"
+      },
+      {
+        "name": "Parsley",
+        "quantity": 0.3333333333333333,
+        "unit": "cup"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 1,
+        "unit": "Dash"
+      },
+      {
+        "name": "Lemons",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Cumin",
+        "quantity": 1,
+        "unit": "Sprinking"
+      }
+    ],
+    "instructions": [
+      "As the cooking time varies depending on the quality and age of the beans, it is good to cook them in advance and to reheat them when you are ready to serve.",
+      "Cook the drained beans in a fresh portion of unsalted water in a large saucepan with the lid on until tender, adding water to keep them covered, and salt when the beans have softened.",
+      "They take 2–2 1/2 hours of gentle simmering.",
+      "When the beans are soft, let the liquid reduce.",
+      "It is usual to take out a ladle or two of the beans and to mash them with some of the cooking liquid, then stir this back into the beans.",
+      "This is to thicken the sauce.",
+      "Serve the beans in soup bowls sprinkled with chopped parsley and accompanied by Arab bread.",
+      "Pass round the dressing ingredients for everyone to help themselves: a bottle of extra-virgin olive oil, the quartered lemons, salt and pepper, a little saucer with the crushed garlic, one with chili-pepper flakes, and one with ground cumin.",
+      "The beans are eaten gently crushed with the fork, so that they absorb the dressing.",
+      "Optional Garnishes.",
+      "Peel hard-boiled eggs—1 per person—to cut up in the bowl with the beans.",
+      "Top the beans with a chopped cucumber-and-tomato salad and thinly sliced mild onions or scallions.",
+      "Otherwise, pass round a good bunch of scallions and quartered tomatoes and cucumbers cut into sticks.",
+      "Serve with tahina cream sauce (page 65) or salad (page 67), with pickles and sliced onions soaked in vinegar for 30 minutes.",
+      "Another way of serving ful medames is smothered in a garlicky tomato sauce (see page 464).",
+      "In Syria and Lebanon, they eat ful medames with yogurt or feta cheese, olives, and small cucumbers.",
+      "Variations.",
+      "A traditional way of thickening the sauce is to throw a handful of red lentils (1/4 cup) into the water at the start of the cooking.",
+      "In Iraq, large brown beans are used instead of the small Egyptian ones, in a dish called badkila, which is also sold for breakfast in the street."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "Egyptian",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52908",
+    "name": "Ratatouille",
+    "description": "A delicious Vegetarian dish from French cuisine.",
+    "ingredients": [
+      {
+        "name": "Aubergine",
+        "quantity": 2,
+        "unit": "large"
+      },
+      {
+        "name": "Courgettes",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Yellow Pepper",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Tomato",
+        "quantity": 4,
+        "unit": "large"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 5,
+        "unit": "tbs"
+      },
+      {
+        "name": "Basil",
+        "quantity": 1,
+        "unit": "Bunch"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "medium"
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 3,
+        "unit": "finely chopped"
+      },
+      {
+        "name": "Red Wine Vinegar",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Sugar",
+        "quantity": 1,
+        "unit": "tsp"
+      }
+    ],
+    "instructions": [
+      "Cut the aubergines in half lengthways.",
+      "Place them on the board, cut side down, slice in half lengthways again and then across into 1.5cm chunks.",
+      "Cut off the courgettes ends, then across into 1.5cm slices.",
+      "Peel the peppers from stalk to bottom.",
+      "Hold upright, cut around the stalk, then cut into 3 pieces.",
+      "Cut away any membrane, then chop into bite-size chunks.",
+      "Score a small cross on the base of each tomato, then put them into a heatproof bowl.",
+      "Pour boiling water over the tomatoes, leave for 20 secs, then remove.",
+      "Pour the water away, replace the tomatoes and cover with cold water.",
+      "Leave to cool, then peel the skin away.",
+      "Quarter the tomatoes, scrape away the seeds with a spoon, then roughly chop the flesh.",
+      "Set a sauté pan over medium heat and when hot, pour in 2 tbsp olive oil.",
+      "Brown the aubergines for 5 mins on each side until the pieces are soft.",
+      "Set them aside and fry the courgettes in another tbsp oil for 5 mins, until golden on both sides.",
+      "Repeat with the peppers.",
+      "Don’t overcook the vegetables at this stage, as they have some more cooking left in the next step.",
+      "Tear up the basil leaves and set aside.",
+      "Cook the onion in the pan for 5 mins.",
+      "Add the garlic and fry for a further min.",
+      "Stir in the vinegar and sugar, then tip in the tomatoes and half the basil.",
+      "Return the vegetables to the pan with some salt and pepper and cook for 5 mins.",
+      "Serve with basil."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "French",
+      "Vegetables",
+      "SideDish",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52863",
+    "name": "Vegetarian Casserole",
+    "description": "A delicious Vegetarian dish from British cuisine.",
+    "ingredients": [
+      {
+        "name": "Rapeseed Oil",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Garlic",
+        "quantity": 3,
+        "unit": "cloves"
+      },
+      {
+        "name": "Paprika",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Cumin",
+        "quantity": 1,
+        "unit": "½ tsp"
+      },
+      {
+        "name": "Thyme",
+        "quantity": 1,
+        "unit": "tblsp"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 3,
+        "unit": "Medium"
+      },
+      {
+        "name": "Celery",
+        "quantity": 2,
+        "unit": "small stalks"
+      },
+      {
+        "name": "Red Pepper",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Yellow Pepper",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Tomato",
+        "quantity": 2,
+        "unit": "x 400g tins"
+      },
+      {
+        "name": "Vegetable Stock Cube",
+        "quantity": 250,
+        "unit": "ml"
+      },
+      {
+        "name": "Courgettes",
+        "quantity": 2,
+        "unit": "sliced"
+      },
+      {
+        "name": "Thyme",
+        "quantity": 2,
+        "unit": "sprigs"
+      },
+      {
+        "name": "Lentils",
+        "quantity": 250,
+        "unit": "g"
+      }
+    ],
+    "instructions": [
+      "Heat the oil in a large, heavy-based pan.",
+      "Add the onions and cook gently for 5 – 10 mins until softened.",
+      "Add the garlic, spices, dried thyme, carrots, celery and peppers and cook for 5 minutes.",
+      "Add the tomatoes, stock, courgettes and fresh thyme and cook for 20 - 25 minutes.",
+      "Take out the thyme sprigs.",
+      "Stir in the lentils and bring back to a simmer.",
+      "Serve with wild and white basmati rice, mash or quinoa."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "British",
+      "Casserole",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-53027",
+    "name": "Koshari",
+    "description": "A delicious Vegetarian dish from Egyptian cuisine.",
+    "ingredients": [
+      {
+        "name": "Brown Lentils",
+        "quantity": 1,
+        "unit": "1/2 cups"
+      },
+      {
+        "name": "Rice",
+        "quantity": 1,
+        "unit": "1/2 cups"
+      },
+      {
+        "name": "Coriander",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Macaroni",
+        "quantity": 2,
+        "unit": "cups"
+      },
+      {
+        "name": "Chickpeas",
+        "quantity": 1,
+        "unit": "Can"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "large"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "Sprinking"
+      },
+      {
+        "name": "Vegetable Oil",
+        "quantity": 0.5,
+        "unit": "cup"
+      }
+    ],
+    "instructions": [
+      "Cook the lentils.",
+      "Bring lentils and 4 cups of water to a boil in a medium pot or saucepan over high heat.",
+      "Reduce the heat to low and cook until lentils are just tender (15-17 minutes).",
+      "Drain from water and season with a little salt.",
+      "(Note: when the lentils are ready, they should not be fully cooked.",
+      "They should be only par-cooked and still have a bite to them as they need to finish cooking with the rice).",
+      "Now, for the rice.",
+      "Drain the rice from its soaking water.",
+      "Combine the par-cooked lentils and the rice in the saucepan over medium-high heat with 1 tbsp cooking oil, salt, pepper, and coriander.",
+      "Cook for 3 minutes, stirring regularly.",
+      "Add warm water to cover the rice and lentil mixture by about 1 1/2 inches (you’ll probably use about 3 cups of water here).",
+      "Bring to a boil; the water should reduce a bit.",
+      "Now cover and cook until all the liquid has been absorbed and both the rice and lentils are well cooked through (about 20 minutes).",
+      "Keep covered and undisturbed for 5 minutes or so.",
+      "Now make the pasta.",
+      "While the rice and lentils are cooking, make the pasta according to package instructions by adding the elbow pasta to boiling water with a dash of salt and a little oil.",
+      "Cook until the pasta is al dente.",
+      "Drain.",
+      "Cover the chickpeas and warm in the microwave briefly before serving.",
+      "Make the crispy onion topping.",
+      "Sprinkle the onion rings with salt, then toss them in the flour to coat.",
+      "Shake off excess flour.",
+      "In a large skillet, heat the cooking oil over medium-high heat, cook the onion rings, stirring often, until they turn a nice caramelized brown.",
+      "Onions must be crispy, but not burned (15-20 minutes)."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "Egyptian",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52911",
+    "name": "Summer Pistou",
+    "description": "A delicious Vegetarian dish from French cuisine.",
+    "ingredients": [
+      {
+        "name": "Rapeseed Oil",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Leek",
+        "quantity": 2,
+        "unit": "finely chopped"
+      },
+      {
+        "name": "Courgettes",
+        "quantity": 1,
+        "unit": "large"
+      },
+      {
+        "name": "Vegetable Stock",
+        "quantity": 1,
+        "unit": "L"
+      },
+      {
+        "name": "Cannellini Beans",
+        "quantity": 400,
+        "unit": "g"
+      },
+      {
+        "name": "Green Beans",
+        "quantity": 200,
+        "unit": "g"
+      },
+      {
+        "name": "Tomatoes",
+        "quantity": 3,
+        "unit": "chopped"
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 3,
+        "unit": "chopped"
+      },
+      {
+        "name": "Basil",
+        "quantity": 1,
+        "unit": "Small pack"
+      },
+      {
+        "name": "Parmesan",
+        "quantity": 40,
+        "unit": "g"
+      }
+    ],
+    "instructions": [
+      "Heat the oil in a large pan and fry the leeks and courgette for 5 mins to soften.",
+      "Pour in the stock, add three-quarters of the haricot beans with the green beans, half the tomatoes, and simmer for 5-8 mins until the vegetables are tender.",
+      "Meanwhile, blitz the remaining beans and tomatoes, the garlic and basil in a food processor (or in a bowl with a stick blender) until smooth, then stir in the Parmesan.",
+      "Stir the sauce into the soup, cook for 1 min, then ladle half into bowls or pour into a flask for a packed lunch.",
+      "Chill the remainder.",
+      "Will keep for a couple of days."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "French",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52869",
+    "name": "Tahini Lentils",
+    "description": "A delicious Vegetarian dish from Moroccan cuisine.",
+    "ingredients": [
+      {
+        "name": "Tahini",
+        "quantity": 50,
+        "unit": "g"
+      },
+      {
+        "name": "Lemon",
+        "quantity": 1,
+        "unit": "zest and juice of 1"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 2,
+        "unit": "tblsp"
+      },
+      {
+        "name": "Red Onions",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 1,
+        "unit": "clove peeled crushed"
+      },
+      {
+        "name": "Yellow Pepper",
+        "quantity": 1,
+        "unit": "thinly sliced"
+      },
+      {
+        "name": "Green Beans",
+        "quantity": 200,
+        "unit": "g"
+      },
+      {
+        "name": "Courgettes",
+        "quantity": 1,
+        "unit": "sliced"
+      },
+      {
+        "name": "Kale",
+        "quantity": 100,
+        "unit": "g shredded"
+      },
+      {
+        "name": "Lentils",
+        "quantity": 250,
+        "unit": "g pack"
+      }
+    ],
+    "instructions": [
+      "In a jug, mix the tahini with the zest and juice of the lemon and 50ml of cold water to make a runny dressing.",
+      "Season to taste, then set aside.",
+      "Heat the oil in a wok or large frying pan over a medium-high heat.",
+      "Add the red onion, along with a pinch of salt, and fry for 2 mins until starting to soften and colour.",
+      "Add the garlic, pepper, green beans and courgette and fry for 5 min, stirring frequently.",
+      "Tip in the kale, lentils and the tahini dressing.",
+      "Keep the pan on the heat for a couple of mins, stirring everything together until the kale is wilted and it’s all coated in the creamy dressing."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "Moroccan",
+      "Pulse",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52868",
+    "name": "Kidney Bean Curry",
+    "description": "A delicious Vegetarian dish from Indian cuisine.",
+    "ingredients": [
+      {
+        "name": "Vegetable Oil",
+        "quantity": 1,
+        "unit": "tbls"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "finely chopped"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 2,
+        "unit": "cloves chopped"
+      },
+      {
+        "name": "Ginger",
+        "quantity": 1,
+        "unit": "part"
+      },
+      {
+        "name": "Coriander",
+        "quantity": 1,
+        "unit": "Packet"
+      },
+      {
+        "name": "Cumin",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Paprika",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Garam Masala",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Chopped Tomatoes",
+        "quantity": 400,
+        "unit": "g"
+      },
+      {
+        "name": "Kidney Beans",
+        "quantity": 400,
+        "unit": "g"
+      },
+      {
+        "name": "Basmati Rice",
+        "quantity": 1,
+        "unit": "to serve"
+      }
+    ],
+    "instructions": [
+      "Heat the oil in a large frying pan over a low-medium heat.",
+      "Add the onion and a pinch of salt and cook slowly, stirring occasionally, until softened and just starting to colour.",
+      "Add the garlic, ginger and coriander stalks and cook for a further 2 mins, until fragrant.",
+      "Add the spices to the pan and cook for another 1 min, by which point everything should smell aromatic.",
+      "Tip in the chopped tomatoes and kidney beans in their water, then bring to the boil.",
+      "Turn down the heat and simmer for 15 mins until the curry is nice and thick.",
+      "Season to taste, then serve with the basmati rice and the coriander leaves."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "Indian",
+      "Curry",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52867",
+    "name": "Vegetarian Chilli",
+    "description": "A delicious Vegetarian dish from British cuisine.",
+    "ingredients": [
+      {
+        "name": "Roasted Vegetables",
+        "quantity": 400,
+        "unit": "g"
+      },
+      {
+        "name": "Kidney Beans",
+        "quantity": 1,
+        "unit": "can"
+      },
+      {
+        "name": "Chopped Tomatoes",
+        "quantity": 1,
+        "unit": "can"
+      },
+      {
+        "name": "Mixed Grain",
+        "quantity": 1,
+        "unit": "Packet"
+      }
+    ],
+    "instructions": [
+      "Heat oven to 200C/180C fan/ gas 6.",
+      "Cook the vegetables in a casserole dish for 15 mins.",
+      "Tip in the beans and tomatoes, season, and cook for another 10-15 mins until piping hot.",
+      "Heat the pouch in the microwave on High for 1 min and serve with the chilli."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "British",
+      "Chilli",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52864",
+    "name": "Mushroom & Chestnut Rotolo",
+    "description": "A delicious Vegetarian dish from British cuisine.",
+    "ingredients": [
+      {
+        "name": "Mushrooms",
+        "quantity": 30,
+        "unit": "g"
+      },
+      {
+        "name": "Chestnuts",
+        "quantity": 240,
+        "unit": "g"
+      },
+      {
+        "name": "Challots",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Garlic",
+        "quantity": 3,
+        "unit": "cloves"
+      },
+      {
+        "name": "Rosemary",
+        "quantity": 3,
+        "unit": "sprigs"
+      },
+      {
+        "name": "Wild Mushrooms",
+        "quantity": 500,
+        "unit": "g"
+      },
+      {
+        "name": "Soy Sauce",
+        "quantity": 2,
+        "unit": "tblsp"
+      },
+      {
+        "name": "White Wine",
+        "quantity": 125,
+        "unit": "ml"
+      },
+      {
+        "name": "Lasagne Sheets",
+        "quantity": 350,
+        "unit": "g"
+      },
+      {
+        "name": "Breadcrumbs",
+        "quantity": 4,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Sage",
+        "quantity": 0.5,
+        "unit": "handful"
+      },
+      {
+        "name": "Truffle Oil",
+        "quantity": 1,
+        "unit": "to serve"
+      }
+    ],
+    "instructions": [
+      "Soak the dried mushrooms in 350ml boiling water and set aside until needed.",
+      "Blitz ¾ of the chestnuts with 150ml water until creamy.",
+      "Roughly chop the remaining chestnuts.",
+      "Heat 2 tbsp olive oil in a large non-stick frying pan.",
+      "Fry the shallots with a pinch of salt until softened, then add the garlic, chopped chestnuts and rosemary, and fry for 2 mins more.",
+      "Add the wild mushrooms, 2 tbsp oil and some seasoning.",
+      "Cook for 3 mins until they begin to soften.",
+      "Drain and roughly chop the dried mushrooms (reserve the soaking liquid), then add those too, along with the soy sauce, and fry for 2 mins more.",
+      "Whisk the wine, reserved mushroom liquid and chestnut cream together to create a sauce.",
+      "Season, then add half to the mushroom mixture in the pan and cook for 1 min until the sauce becomes glossy.",
+      "Remove and discard the rosemary sprigs, then set the mixture aside.",
+      "Heat oven to 180C/160C fan/gas 4.",
+      "Bring a large pan of salted water to the boil and get a large bowl of ice water ready.",
+      "Drop the lasagne sheets into the boiling water for 2 mins or until pliable and a little cooked, then immediately plunge them into the cold water.",
+      "Using your fingers, carefully separate the sheets and transfer to a clean tea towel.",
+      "Spread a good spoonful of the sauce on the bottom two thirds of each sheet, then, rolling away from yourself, roll up the shorter ends.",
+      "Cut each roll in half, then position the rolls of pasta cut-side up in a pie dish that you are happy to serve from at the table.",
+      "If you have any mushroom sauce remaining after you’ve rolled up all the sheets, simply push it into some of the exposed rolls of pasta.",
+      "Pour the rest of the sauce over the top of the pasta, then bake for 10 mins or until the pasta no longer has any resistance when tested with a skewer.",
+      "Meanwhile, put the breadcrumbs, the last 2 tbsp olive oil, sage leaves and some seasoning in a bowl, and toss everything together.",
+      "Scatter the rotolo with the crumbs and sage, then bake for another 10 mins, until the top is golden and the sage leaves are crispy.",
+      "Leave to cool for 10 mins to allow the pasta to absorb the sauce, then drizzle with a little truffle oil, if you like, before taking your dish to the table."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "British",
+      "Nutty",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52797",
+    "name": "Spicy North African Potato Salad",
+    "description": "A delicious Vegetarian dish from Moroccan cuisine.",
+    "ingredients": [
+      {
+        "name": "Small Potatoes",
+        "quantity": 650,
+        "unit": "g/1lb 8 oz"
+      },
+      {
+        "name": "Harissa Spice",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "olive oil",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Lemon",
+        "quantity": 1,
+        "unit": "juice of half"
+      },
+      {
+        "name": "Spring onions",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Rocket",
+        "quantity": 150,
+        "unit": "g/6oz"
+      },
+      {
+        "name": "Feta",
+        "quantity": 80,
+        "unit": "g/3oz"
+      },
+      {
+        "name": "Mint",
+        "quantity": 20,
+        "unit": "chopped"
+      },
+      {
+        "name": "Pine nuts",
+        "quantity": 2,
+        "unit": "tablespoons"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "Pinch"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "Pinch"
+      }
+    ],
+    "instructions": [
+      "Cook potatoes - place potatoes in a pot of cold water, and bring to the boil.",
+      "Boil 20 minutes, or until potatoes are tender.",
+      "You know they are cooked when you can stick a knife in them and the knife goes straight through.",
+      "Combine harissa spice, olive oil, salt and pepper and lemon juice in a small bowl and whisk until combined.",
+      "Once potatoes are cooked, drain water and roughly chop potatoes in half.",
+      "Add harissa mix and spring onions/green onions to potatoes and stir.",
+      "In a large salad bowl, lay out arugula/rocket.",
+      "Top with potato mix and toss.",
+      "Add fetta, mint and sprinkle over pine nuts.",
+      "Adjust salt and pepper to taste."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "Moroccan",
+      "Spicy",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52807",
+    "name": "Baingan Bharta",
+    "description": "A delicious Vegetarian dish from Indian cuisine.",
+    "ingredients": [
+      {
+        "name": "Aubergine",
+        "quantity": 1,
+        "unit": "large"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "½ cup"
+      },
+      {
+        "name": "Tomatoes",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 6,
+        "unit": "cloves"
+      },
+      {
+        "name": "Green Chilli",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Red Chilli Powder",
+        "quantity": 1,
+        "unit": "¼ teaspoon"
+      },
+      {
+        "name": "Oil",
+        "quantity": 1.5,
+        "unit": "tablespoon"
+      },
+      {
+        "name": "Coriander Leaves",
+        "quantity": 1,
+        "unit": "tablespoon chopped"
+      },
+      {
+        "name": "salt",
+        "quantity": 1,
+        "unit": "as required"
+      }
+    ],
+    "instructions": [
+      "Rinse the baingan (eggplant or aubergine) in water.",
+      "Pat dry with a kitchen napkin.",
+      "Apply some oil all over and.",
+      "keep it for roasting on an open flame.",
+      "You can also grill the baingan or roast in the oven.",
+      "But then you won't get.",
+      "the smoky flavor of the baingan.",
+      "Keep the eggplant turning after a 2 to 3 minutes on the flame, so that its evenly.",
+      "cooked.",
+      "You could also embed some garlic cloves in the baingan and then roast it.",
+      "2.",
+      "Roast the aubergine till its completely cooked and tender.",
+      "With a knife check the doneness.",
+      "The knife should slid.",
+      "easily in aubergines without any resistance.",
+      "Remove the baingan and immerse in a bowl of water till it cools.",
+      "down.",
+      "3.",
+      "You can also do the dhungar technique of infusing charcoal smoky flavor in the baingan.",
+      "This is an optional step.",
+      "Use natural charcoal for this method.",
+      "Heat a small piece of charcoal on flame till it becomes smoking hot and red.",
+      "4.",
+      "Make small cuts on the baingan with a knife.",
+      "Place the red hot charcoal in the same plate where the roasted.",
+      "aubergine is kept.",
+      "Add a few drops of oil on the charcoal.",
+      "The charcoal would begin to smoke.",
+      "5.",
+      "As soon as smoke begins to release from the charcoal, cover the entire plate tightly with a large bowl.",
+      "Allow the.",
+      "charcoal smoke to get infused for 1 to 2 minutes.",
+      "The more you do, the more smoky the baingan bharta will.",
+      "become.",
+      "I just keep for a minute.",
+      "Alternatively, you can also do this dhungar method once the baingan bharta is.",
+      "cooked, just like the way we do for Dal Tadka.",
+      "6.",
+      "Peel the skin from the roasted and smoked eggplant.",
+      "7.",
+      "Chop the cooked eggplant finely or you can even mash it.",
+      "8.",
+      "In a kadai or pan, heat oil.",
+      "Then add finely chopped onions and garlic.",
+      "9.",
+      "Saute the onions till translucent.",
+      "Don't brown them.",
+      "10.",
+      "Add chopped green chilies and saute for a minute.",
+      "11.",
+      "Add the chopped tomatoes and mix it well.",
+      "12.",
+      "Bhuno (saute) the tomatoes till the oil starts separating from the mixture.",
+      "13.",
+      "Now add the red chili powder.",
+      "Stir and mix well.",
+      "14.",
+      "Add the chopped cooked baingan.",
+      "15.",
+      "Stir and mix the chopped baingan very well with the onion­tomato masala mixture.",
+      "16.",
+      "Season with salt.",
+      "Stir and saute for some more 4 to 5 minutes more.",
+      "17.",
+      "Finally stir in the coriander leaves with the baingan bharta or garnish it with them.",
+      "Serve Baingan Bharta with.",
+      "phulkas, rotis or chapatis.",
+      "It goes well even with bread, toasted or grilled bread and plain rice or jeera rice."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "Indian",
+      "Spicy",
+      "Bun",
+      "Calorific",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52784",
+    "name": "Smoky Lentil Chili with Squash",
+    "description": "A delicious Vegetarian dish from British cuisine.",
+    "ingredients": [
+      {
+        "name": "Olive Oil",
+        "quantity": 1,
+        "unit": "tbls"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Leek",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 3,
+        "unit": "cloves"
+      },
+      {
+        "name": "Cumin",
+        "quantity": 4,
+        "unit": "tsp ground"
+      },
+      {
+        "name": "Coriander",
+        "quantity": 2,
+        "unit": "tsp ground"
+      },
+      {
+        "name": "Smoked Paprika",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Cinnamon",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Chili Powder",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Cocoa",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Dried Oregano",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Diced Tomatoes",
+        "quantity": 1,
+        "unit": "can"
+      },
+      {
+        "name": "Water",
+        "quantity": 3,
+        "unit": "cups"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 3,
+        "unit": "chopped"
+      },
+      {
+        "name": "Brown Lentils",
+        "quantity": 1,
+        "unit": "1/2 cups"
+      },
+      {
+        "name": "Sea Salt",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Squash",
+        "quantity": 1,
+        "unit": "Small"
+      },
+      {
+        "name": "Cashews",
+        "quantity": 1,
+        "unit": "Cup"
+      },
+      {
+        "name": "Apple Cider Vinegar",
+        "quantity": 1,
+        "unit": "tsp"
+      }
+    ],
+    "instructions": [
+      "Begin by roasting the squash.",
+      "Slice it into thin crescents and drizzle with a little oil and sprinkle with sea salt.",
+      "I added a fresh little sage I had in the fridge, but it’s unnecessary.",
+      "Roast the squash a 205 C (400 F) for 20-30 minutes, flipping halfway through, until soft and golden.",
+      "Let cool and chop into cubes.",
+      "Meanwhile, rinse the lentils and cover them with water.",
+      "Bring them to the boil then turn down to a simmer and let cook (uncovered) for 20-30 minutes, or until tender.",
+      "Drain and set aside.",
+      "While the lentils are cooking heat the 1 Tbsp.",
+      "of oil on low in a medium pot.",
+      "Add the onions and leeks and sauté for 5 or so minutes, or until they begin to soften.",
+      "Add the garlic next along with the cumin and coriander, cooking for a few more minutes.",
+      "Add the remaining spices – paprika, cinnamon, chilli, cocoa, Worcestershire sauce, salt, and oregano.",
+      "Next add the can of tomatoes, the water or stock, and carrots.",
+      "Let simmer, covered, for 20 minutes or until the veg is tender and the mixture has thickened up.",
+      "You’ll need to check on the pot periodically for a stir and a top of of liquid if needed.",
+      "Add the lentils and chopped roasted squash.",
+      "Let cook for 10 more minutes to heat through.",
+      "Serve with sliced jalapeno, lime wedges, cilantro, green onions, and cashew sour cream.",
+      "SIMPLE CASHEW SOUR CREAM.",
+      "1 Cup Raw Unsalted Cashews.",
+      "Pinch Sea Salt.",
+      "1 tsp.",
+      "Apple Cider Vinegar.",
+      "Water.",
+      "Bring some water to the boil, and use it to soak the cashews for at least four hours.",
+      "Alternatively, you can use cold water and let the cashews soak overnight, but I’m forgetful/lazy, so often use the boil method which is much faster.",
+      "After the cashews have soaked, drain them and add to a high speed blender.",
+      "Begin to puree, slowly adding about 1/2 cup fresh water, until a creamy consistency is reached.",
+      "You may need to add less or more water to reach the desired consistency.",
+      "Add a pinch of sea salt and vinegar (or lemon juice)."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "British",
+      "Pulse",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52811",
+    "name": "Ribollita",
+    "description": "A delicious Vegetarian dish from Italian cuisine.",
+    "ingredients": [
+      {
+        "name": "Olive Oil",
+        "quantity": 5,
+        "unit": "tablespoons"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Celery",
+        "quantity": 1,
+        "unit": "stalk chopped"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 1,
+        "unit": "tablespoon minced"
+      },
+      {
+        "name": "Cannellini Beans",
+        "quantity": 2,
+        "unit": "cups"
+      },
+      {
+        "name": "Canned tomatoes",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Water",
+        "quantity": 4,
+        "unit": "cups"
+      },
+      {
+        "name": "Rosemary",
+        "quantity": 1,
+        "unit": "fresh sprig"
+      },
+      {
+        "name": "Thyme",
+        "quantity": 1,
+        "unit": "fresh sprig"
+      },
+      {
+        "name": "Kale",
+        "quantity": 1,
+        "unit": "pound chopped"
+      },
+      {
+        "name": "Wholegrain Bread",
+        "quantity": 4,
+        "unit": "thick slices"
+      },
+      {
+        "name": "Red Onions",
+        "quantity": 1,
+        "unit": "thinly sliced"
+      },
+      {
+        "name": "Parmesan",
+        "quantity": 1,
+        "unit": "½ cup freshly grated"
+      }
+    ],
+    "instructions": [
+      "Put 2 tablespoons of the oil in a large pot over medium heat.",
+      "When it’s hot, add onion, carrot, celery and garlic; sprinkle with salt and pepper and cook, stirring occasionally, until vegetables are soft, 5 to 10 minutes.",
+      "Heat the oven to 500 degrees.",
+      "Drain the beans; if they’re canned, rinse them as well.",
+      "Add them to the pot along with tomatoes and their juices and stock, rosemary and thyme.",
+      "Bring to a boil, then reduce heat so the soup bubbles steadily; cover and cook, stirring once or twice to break up the tomatoes, until the flavors meld, 15 to 20 minutes.",
+      "Fish out and discard rosemary and thyme stems, if you like, and stir in kale.",
+      "Taste and adjust seasoning.",
+      "Lay bread slices on top of the stew so they cover the top and overlap as little as possible.",
+      "Scatter red onion slices over the top, drizzle with the remaining 3 tablespoons oil and sprinkle with Parmesan.",
+      "Put the pot in the oven and bake until the bread, onions and cheese are browned and crisp, 10 to 15 minutes.",
+      "(If your pot fits under the broiler, you can also brown the top there.) Divide the soup and bread among 4 bowls and serve."
+    ],
+    "isVegetarian": true,
+    "isVegan": true,
+    "tags": [
+      "Vegetarian",
+      "Italian",
+      "vegetarian",
+      "vegan"
+    ]
+  },
+  {
+    "id": "rezept-api-52816",
+    "name": "Roasted Eggplant With Tahini, Pine Nuts, and Lentils",
+    "description": "A delicious Vegetarian dish from American cuisine.",
+    "ingredients": [
+      {
+        "name": "Olive Oil",
+        "quantity": 2,
+        "unit": "tablespoons"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 2,
+        "unit": "small cut into chunks"
+      },
+      {
+        "name": "Celery",
+        "quantity": 2,
+        "unit": "small stalks"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "medium finely diced"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 6,
+        "unit": "medium cloves sliced"
+      },
+      {
+        "name": "Brown Lentils",
+        "quantity": 12,
+        "unit": "ounces (340g)"
+      },
+      {
+        "name": "Bay Leaves",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Water",
+        "quantity": 4,
+        "unit": "cups"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "Pinch"
+      },
+      {
+        "name": "Apple Cider Vinegar",
+        "quantity": 2,
+        "unit": "teaspoons (10ml)"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "Pinch"
+      },
+      {
+        "name": "Egg Plants",
+        "quantity": 2,
+        "unit": "large"
+      },
+      {
+        "name": "Rosemary",
+        "quantity": 4,
+        "unit": "sprigs"
+      },
+      {
+        "name": "Pine nuts",
+        "quantity": 0.25,
+        "unit": "cup"
+      },
+      {
+        "name": "Parsley",
+        "quantity": 2,
+        "unit": "tablespoons"
+      }
+    ],
+    "instructions": [
+      "For the Lentils: Adjust oven rack to center position and preheat oven to 450°F to prepare for roasting eggplant.",
+      "Meanwhile, heat 2 tablespoons olive oil in a medium saucepan over medium heat until shimmering.",
+      "Add carrots, celery, and onion and cook, stirring, until softened but not browned, about 4 minutes.",
+      "Add garlic and cook, stirring, until fragrant, about 30 seconds.",
+      "Add lentils, bay leaves, stock or water, and a pinch of salt.",
+      "Bring to a simmer, cover with the lid partially ajar, and cook until lentils are tender, about 30 minutes.",
+      "(Top up with water if lentils are at any point not fully submerged.) Remove lid, stir in vinegar, and reduce until lentils are moist but not soupy.",
+      "Season to taste with salt and pepper, cover, and keep warm until ready to serve.",
+      "2.",
+      "For the Eggplant: While lentils cook, cut each eggplant in half.",
+      "Score flesh with the tip of a paring knife in a cross-hatch pattern at 1-inch intervals.",
+      "Transfer to a foil-lined rimmed baking sheet, cut side up, and brush each eggplant half with 1 tablespoon oil, letting each brushstroke be fully absorbed before brushing with more.",
+      "Season with salt and pepper.",
+      "Place a rosemary sprig on top of each one.",
+      "Transfer to oven and roast until completely tender and well charred, 25 to 35 minutes.",
+      "Remove from oven and discard rosemary.",
+      "3.",
+      "To Serve: Heat 2 tablespoons olive oil and pine nuts in a medium skillet set over medium heat.",
+      "Cook, tossing nuts frequently, until golden brown and aromatic, about 4 minutes.",
+      "Transfer to a bowl to halt cooking.",
+      "Stir half of parsley and rosemary into lentils and transfer to a serving platter.",
+      "Arrange eggplant halves on top.",
+      "Spread a few tablespoons of tahini sauce over each eggplant half and sprinkle with pine nuts.",
+      "Sprinkle with remaining parsley and rosemary, drizzle with additional olive oil, and serve."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "American",
+      "Pulse",
+      "Nutty",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52906",
+    "name": "Flamiche",
+    "description": "A delicious Vegetarian dish from French cuisine.",
+    "ingredients": [
+      {
+        "name": "Butter",
+        "quantity": 75,
+        "unit": "g"
+      },
+      {
+        "name": "Leek",
+        "quantity": 1,
+        "unit": "kg"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "½ tsp"
+      },
+      {
+        "name": "Creme Fraiche",
+        "quantity": 300,
+        "unit": "ml"
+      },
+      {
+        "name": "Egg",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Egg Yolks",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Nutmeg",
+        "quantity": 1,
+        "unit": "¼ teaspoon"
+      },
+      {
+        "name": "Plain Flour",
+        "quantity": 225,
+        "unit": "g"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "½ tsp"
+      },
+      {
+        "name": "Butter",
+        "quantity": 60,
+        "unit": "g"
+      },
+      {
+        "name": "Lard",
+        "quantity": 60,
+        "unit": "g"
+      },
+      {
+        "name": "Cheddar Cheese",
+        "quantity": 50,
+        "unit": "g"
+      },
+      {
+        "name": "Water",
+        "quantity": 2,
+        "unit": "tbs"
+      }
+    ],
+    "instructions": [
+      "For the pastry, sift the flour and salt into the bowl of a food processor, add the butter and lard, then whizz together briefly until the mixture looks like fine breadcrumbs.",
+      "Tip the mixture into a bowl, then stir in the cheese and enough of the water for the mixture to come together.",
+      "Tip out onto a lightly floured surface and knead briefly until smooth.",
+      "Roll out thinly and line a 23cm x 4cm loose-?bottomed fluted flan tin.",
+      "Prick the base with a fork.",
+      "Chill for 20 minutes.",
+      "02.Melt the 75g butter in a saucepan over a low heat, then add the leeks and the salt.",
+      "Cover and cook for ?10 minutes until soft.",
+      "Uncover the pan, increase the heat and cook ?for 2 minutes, stirring occasionally, until the liquid has evaporated.",
+      "Spoon onto a plate and leave to cool.",
+      "03.Preheat the oven to 200°C/fan180°C/gas 6.",
+      "Line the pastry case with baking paper and baking beans or rice and blind bake for 15-20 minutes until the edges are biscuit-coloured.",
+      "Remove the paper and beans/rice and return the case to the oven for 7-10 minutes until the base is crisp and lightly golden.",
+      "Remove and set aside.",
+      "Reduce the oven temperature to 190°C/fan170°C/gas 5.",
+      "04.Put the crème fraîche into a bowl with the whole egg, egg yolks and nutmeg.",
+      "Lightly beat together, then season.",
+      "Stir in the leeks.",
+      "Spoon ?the mixture into the tart case and bake for 35-40 minutes until set ?and lightly golden.",
+      "Remove from ?the oven and leave for 10 minutes.",
+      "Take out of the tin and serve."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "French",
+      "Tart",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52870",
+    "name": "Chickpea Fajitas",
+    "description": "A delicious Vegetarian dish from Mexican cuisine.",
+    "ingredients": [
+      {
+        "name": "Chickpeas",
+        "quantity": 400,
+        "unit": "g"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 1,
+        "unit": "tblsp"
+      },
+      {
+        "name": "Paprika",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Tomatoes",
+        "quantity": 2,
+        "unit": "small cut chunks"
+      },
+      {
+        "name": "Red Onions",
+        "quantity": 1,
+        "unit": "finely sliced"
+      },
+      {
+        "name": "Red Wine Vinegar",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Avocado",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Lime",
+        "quantity": 1,
+        "unit": "Juice of 1"
+      },
+      {
+        "name": "Lime",
+        "quantity": 1,
+        "unit": "Chopped"
+      },
+      {
+        "name": "Sour Cream",
+        "quantity": 100,
+        "unit": "g"
+      },
+      {
+        "name": "Harissa Spice",
+        "quantity": 2,
+        "unit": "tsp"
+      },
+      {
+        "name": "Corn Tortillas",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Coriander",
+        "quantity": 1,
+        "unit": "to serve"
+      }
+    ],
+    "instructions": [
+      "Heat oven to 200C/180C fan/gas 6 and line a baking tray with foil.",
+      "Drain the chickpeas, pat dry and tip onto the prepared baking tray.",
+      "Add the oil and paprika, toss to coat, then roast for 20-25 mins until browned and crisp, shaking halfway through cooking.",
+      "Meanwhile, put the tomatoes and onion in a small bowl with the vinegar and set aside to pickle.",
+      "Put the avocado in another bowl and mash with a fork, leaving some larger chunks.",
+      "Stir in the lime juice and season well.",
+      "Mix the soured cream with the harissa and set aside until ready to serve.",
+      "Heat a griddle pan until nearly smoking.",
+      "Add the tortillas , one at a time, charring each side until hot with griddle lines.",
+      "Put everything on the table and build the fajitas : spread a little of the harissa cream over the tortilla, top with roasted chickpeas, guacamole, pickled salsa and coriander, if you like.",
+      "Serve with the lime wedges for squeezing over."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Mexican",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-53074",
+    "name": "Grilled eggplant with coconut milk",
+    "description": "A delicious Vegetarian dish from Filipino cuisine.",
+    "ingredients": [
+      {
+        "name": "Egg Plants",
+        "quantity": 6,
+        "unit": null
+      },
+      {
+        "name": "Coconut Milk",
+        "quantity": 1,
+        "unit": "can"
+      },
+      {
+        "name": "Lemon Juice",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Red Pepper Flakes",
+        "quantity": 1,
+        "unit": "To taste"
+      },
+      {
+        "name": "Onions",
+        "quantity": 4,
+        "unit": "Sticks"
+      }
+    ],
+    "instructions": [
+      ".",
+      "Prepare the eggplants for grilling by pricking them all over with a fork.",
+      "This is so it won’t burst during the grilling process as the natural water in it heats up.",
+      "2.",
+      "Grill the eggplants, turning them over frequently to ensure even cooking.",
+      "Grill until the skins are dark brown, even black and the eggplant is soft when you touch it.",
+      "3.",
+      "Soak the grilled eggplant in a bowl of water to cool it down.",
+      "Peel the skin off the eggplant.",
+      "Place the whole eggplants in a shallow dish (my mom actually cuts the eggplant into small, bite-sized pieces).",
+      "4.",
+      "In a small mixing bowl, mix together the coconut milk or cream, lemon powder, salt and hot pepper.",
+      "Mix until the lemon powder and salt dissolve.",
+      "Taste, then adjust the amount of lemon powder, salt and hot pepper to your liking.",
+      "Pour the mixture over the eggplant.",
+      "Sprinkle the green onions over the eggplant and coconut milk.",
+      "Stir gently to combine."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Filipino",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52866",
+    "name": "Squash linguine",
+    "description": "A delicious Vegetarian dish from Italian cuisine.",
+    "ingredients": [
+      {
+        "name": "Butternut Squash",
+        "quantity": 350,
+        "unit": "g"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 3,
+        "unit": "parts"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Linguine Pasta",
+        "quantity": 350,
+        "unit": "g"
+      },
+      {
+        "name": "Sage",
+        "quantity": 1,
+        "unit": "Small bunch"
+      }
+    ],
+    "instructions": [
+      "Heat oven to 200C/180C fan/gas 6.",
+      "Put the squash and garlic on a baking tray and drizzle with the olive oil.",
+      "Roast for 35-40 mins until soft.",
+      "Season.",
+      "Cook the pasta according to pack instructions.",
+      "Drain, reserving the water.",
+      "Use a stick blender to whizz the squash with 400ml cooking water.",
+      "Heat some oil in a frying pan, fry the sage until crisp, then drain on kitchen paper.",
+      "Tip the pasta and sauce into the pan and warm through.",
+      "Scatter with sage."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Italian",
+      "Pasta",
+      "Light",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52921",
+    "name": "Provençal Omelette Cake",
+    "description": "A delicious Vegetarian dish from French cuisine.",
+    "ingredients": [
+      {
+        "name": "Eggs",
+        "quantity": 10,
+        "unit": null
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Courgettes",
+        "quantity": 2,
+        "unit": "finely chopped"
+      },
+      {
+        "name": "Spring Onions",
+        "quantity": 3,
+        "unit": "finely chopped"
+      },
+      {
+        "name": "Red Pepper",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 1,
+        "unit": "clove peeled crushed"
+      },
+      {
+        "name": "Red Chilli",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Cream Cheese",
+        "quantity": 300,
+        "unit": "g"
+      },
+      {
+        "name": "Milk",
+        "quantity": 6,
+        "unit": "tblsp"
+      },
+      {
+        "name": "Chives",
+        "quantity": 4,
+        "unit": "tbs"
+      },
+      {
+        "name": "Basil",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Rocket",
+        "quantity": 1,
+        "unit": "to serve"
+      },
+      {
+        "name": "Parmesan",
+        "quantity": 1,
+        "unit": "to serve"
+      }
+    ],
+    "instructions": [
+      "Break the eggs into two bowls, five in each.",
+      "Whisk lightly and season with salt and pepper.",
+      "Heat the oil in a pan, add the courgettes and spring onions, then fry gently for about 10 mins until softened.",
+      "Cool, then stir into one bowl of eggs with a little salt and pepper.",
+      "Add the roasted peppers to the other bowl of eggs with the garlic, chilli, salt and pepper.",
+      "Heat a little oil in a 20-23cm frying pan, preferably non-stick.",
+      "Pour the eggs with courgette into a measuring jug, then pourabout one-third of the mixture into the pan, swirling it to cover the base of the pan.",
+      "Cook until the egg is set and lightly browned underneath, then cover the pan with a plate and invert the omelette onto it.",
+      "Slide it back into the pan to cook the other side.",
+      "Repeat with the remaining mix to make two more omelettes, adding a little oil to the pan each time.",
+      "Stack the omelettes onto a plate.",
+      "Make three omelettes in the same way with the red pepper mixture, then stack them on a separate plate.",
+      "Now make the filling.",
+      "Beat the cheese to soften it, then beat in the milk to make a spreadable consistency.",
+      "Stir in the herbs, salt and pepper.",
+      "Line a deep, 20-23cm round cake tin with cling film (use a tin the same size as the frying pan).",
+      "Select the best red pepper omelette and place in the tin, prettiest side down.",
+      "Spread with a thin layer of cheese filling, then cover with a courgette omelette.",
+      "Repeat, alternating the layers, until all the omelettes and filling are in the tin, finishing with an omelette.",
+      "Flip the cling film over the omelette, then chill for up to 24 hrs.",
+      "To serve, invert the omelette cake onto a serving plate and peel off the cling film.",
+      "Pile rocket on the top and scatter over the cheese, a drizzle of olive oil and a little freshly ground black pepper.",
+      "Serve cut into wedges."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "French",
+      "Egg",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-53073",
+    "name": "Eggplant Adobo",
+    "description": "A delicious Vegetarian dish from Filipino cuisine.",
+    "ingredients": [
+      {
+        "name": "Egg Plants",
+        "quantity": 1,
+        "unit": "lb"
+      },
+      {
+        "name": "Sugar",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 1,
+        "unit": "whole"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Ground Pork",
+        "quantity": 4,
+        "unit": "oz"
+      },
+      {
+        "name": "Rice Vinegar",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Soy Sauce",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Bay Leaf",
+        "quantity": 2,
+        "unit": null
+      }
+    ],
+    "instructions": [
+      "1.",
+      "Slice 1 lb.",
+      "small Japanese or Italian eggplant (about 3) into quarters lengthwise, then cut crosswise into 2\"-wide pieces.",
+      "Place in a medium bowl.",
+      "Add 1 Tbsp.",
+      "sugar, 1 tsp.",
+      "Diamond Crystal or ½ tsp.",
+      "Morton kosher salt, and ½ tsp.",
+      "freshly ground black pepper.",
+      "Toss to evenly coat eggplant and let sit at room temperature at least 20 minutes and up to 2 hours.",
+      "2.",
+      "Peel and thinly slice 8 garlic cloves.",
+      "Add 3 Tbsp.",
+      "vegetable oil and half of garlic to a medium Dutch oven or other heavy pot.",
+      "Cook over medium-high heat, stirring constantly with a wooden spoon, until light golden and crisp, about 5 minutes.",
+      "Using a slotted spoon, transfer garlic chips to a plate; season lightly with salt.",
+      "3.",
+      "Place 4 oz.",
+      "ground pork in same pot and break up into small pieces with wooden spoon.",
+      "Season with ¼ tsp.",
+      "Diamond Crystal or Morton kosher salt and cook, undisturbed, until deeply browned underneath, about 5 minutes.",
+      "Using a slotted spoon, transfer to another plate, leaving fat behind in the pot.",
+      "4.",
+      "Place eggplant on a clean kitchen towel and blot away any moisture the salt has drawn out.",
+      "5.",
+      "Working in batches and adding more oil if needed, cook eggplant in the same pot until lightly browned, about 3 minutes per side.",
+      "Transfer to a plate with pork.",
+      "6.",
+      "Pour 1½ cups of water into the pot and scrape up browned bits from the bottom with a wooden spoon.",
+      "Add remaining garlic, 3 Tbsp.",
+      "coconut vinegar or unseasoned rice vinegar, 2 Tbsp.",
+      "soy sauce, 2 bay leaves, 1 tsp.",
+      "freshly ground black pepper, and remaining 1 Tbsp.",
+      "sugar.",
+      "Bring to a simmer, then return pork and eggplant to pot.",
+      "Reduce heat to medium-low, partially cover, and simmer until eggplant is tender and silky and sauce is reduced by half, 20–25 minutes.",
+      "Taste and season with more salt and pepper and add a little more sugar if needed.",
+      "7.",
+      "Top with garlic chips and serve with cooked white rice."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Filipino",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-53067",
+    "name": "Stuffed Bell Peppers with Quinoa and Black Beans",
+    "description": "A delicious Vegetarian dish from Mexican cuisine.",
+    "ingredients": [
+      {
+        "name": "Green Pepper",
+        "quantity": 4,
+        "unit": "whole"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 1,
+        "unit": "tablespoon"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "small finely diced"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 2,
+        "unit": "cloves minced"
+      },
+      {
+        "name": "Quinoa",
+        "quantity": 1,
+        "unit": "cups"
+      },
+      {
+        "name": "Black Beans",
+        "quantity": 1,
+        "unit": "can"
+      },
+      {
+        "name": "Sweetcorn",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Diced Tomatoes",
+        "quantity": 1,
+        "unit": "can"
+      },
+      {
+        "name": "Cumin",
+        "quantity": 1,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "Chili Powder",
+        "quantity": 1,
+        "unit": "½ tsp"
+      },
+      {
+        "name": "Smoked Paprika",
+        "quantity": 1,
+        "unit": "½ tsp"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "To taste"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "To taste"
+      },
+      {
+        "name": "Shredded Mexican Cheese",
+        "quantity": 1,
+        "unit": "1/2 cup"
+      },
+      {
+        "name": "Cilantro",
+        "quantity": 1,
+        "unit": "Chopped"
+      }
+    ],
+    "instructions": [
+      "1.",
+      "Preheat your oven to 375°F (190°C).",
+      "Lightly grease a 9x13-inch baking dish or a similar-sized casserole dish.",
+      "2.",
+      "Place the bell pepper halves in the prepared baking dish, cut side up.",
+      "Bake for 15-20 minutes, or until slightly softened.",
+      "3.",
+      "While the bell peppers are baking, prepare the filling.",
+      "In a large skillet, heat the olive oil over medium heat.",
+      "Add the chopped onion, and cook for 3-4 minutes, until softened.",
+      "Add the garlic, and cook for another 1 minute, until fragrant.",
+      "4.",
+      "Stir in the cooked quinoa, black beans, corn, diced tomatoes, ground cumin, chili powder, smoked paprika, salt, and pepper.",
+      "Cook for 5-7 minutes, until heated through.",
+      "Remove the skillet from heat, and stir in 1 cup of the shredded cheese, if using.",
+      "5.",
+      "Remove the bell peppers from the oven, and carefully stuff each pepper half with the quinoa and black bean mixture.",
+      "Top the stuffed peppers with the remaining 1/2 cup of shredded cheese, if using.",
+      "6.",
+      "Return the stuffed peppers to the oven, and bake for another 15-20 minutes, until the cheese is melted and the peppers are tender.",
+      "7.",
+      "Remove from the oven, and allow the stuffed peppers to cool for 5 minutes before serving.",
+      "Garnish with fresh chopped cilantro."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Mexican",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-53078",
+    "name": "Beetroot Soup (Borscht)",
+    "description": "A delicious Vegetarian dish from Ukrainian cuisine.",
+    "ingredients": [
+      {
+        "name": "Beetroot",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 4,
+        "unit": "tbs"
+      },
+      {
+        "name": "Chicken Stock Cube",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Water",
+        "quantity": 6,
+        "unit": "cups"
+      },
+      {
+        "name": "Potatoes",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Cannellini Beans",
+        "quantity": 1,
+        "unit": "can"
+      },
+      {
+        "name": "Dill",
+        "quantity": 1,
+        "unit": "Garnish"
+      }
+    ],
+    "instructions": [
+      "Chop the beetroot, add water and stock cube and cook for 15mins.",
+      "Add the other ingredients and boil until soft.",
+      "Finally add the beans and cook for 5mins.",
+      "Serve in the soup pot."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Ukrainian",
+      "Soup",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-53012",
+    "name": "Gigantes Plaki",
+    "description": "A delicious Vegetarian dish from Greek cuisine.",
+    "ingredients": [
+      {
+        "name": "Butter Beans",
+        "quantity": 400,
+        "unit": "g"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "chopped"
+      },
+      {
+        "name": "Garlic Clove",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Tomato Puree",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Tomatoes",
+        "quantity": 800,
+        "unit": "g"
+      },
+      {
+        "name": "Sugar",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Dried Oregano",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Cinnamon",
+        "quantity": 1,
+        "unit": "Pinch"
+      },
+      {
+        "name": "Chopped Parsley",
+        "quantity": 2,
+        "unit": "tbs"
+      }
+    ],
+    "instructions": [
+      "Soak the beans overnight in plenty of water.",
+      "Drain, rinse, then place in a pan covered with water.",
+      "Bring to the boil, reduce the heat, then simmer for approx 50 mins until slightly tender but not soft.",
+      "Drain, then set aside.",
+      "Heat oven to 180C/160C fan/gas 4.",
+      "Heat the olive oil in a large frying pan, tip in the onion and garlic, then cook over a medium heat for 10 mins until softened but not browned.",
+      "Add the tomato purée, cook for a further min, add remaining ingredients, then simmer for 2-3 mins.",
+      "Season generously, then stir in the beans.",
+      "Tip into a large ovenproof dish, then bake for approximately 1 hr, uncovered and without stirring, until the beans are tender.",
+      "The beans will absorb all the fabulous flavours and the sauce will thicken.",
+      "Allow to cool, then scatter with parsley and drizzle with a little more olive oil to serve."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Greek",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-53075",
+    "name": "Tortang Talong",
+    "description": "A delicious Vegetarian dish from Filipino cuisine.",
+    "ingredients": [
+      {
+        "name": "Egg Plants",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Eggs",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 4,
+        "unit": "tsp"
+      }
+    ],
+    "instructions": [
+      "0.",
+      "Grill the eggplant until the color of skin turns almost black.",
+      "1.",
+      "Let the eggplant cool for a while then peel off the skin.",
+      "Set aside.",
+      "2.",
+      "Crack the eggs and place in a bowl.",
+      "3.",
+      "Add salt and beat.",
+      "4.",
+      "Place the eggplant on a flat surface and flatten using a fork.",
+      "5.",
+      "Dip the flattened eggplant in the beaten egg mixture.",
+      "6.",
+      "Heat the pan and pour the cooking oil.",
+      "7.",
+      "Fry the eggplant (that was dipped in the beaten mixture).",
+      "Make sure that both sides are cooked.",
+      "Frying time will take you about 3 to 4 minutes per side on medium heat."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Filipino",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52771",
+    "name": "Spicy Arrabiata Penne",
+    "description": "A delicious Vegetarian dish from Italian cuisine.",
+    "ingredients": [
+      {
+        "name": "penne rigate",
+        "quantity": 1,
+        "unit": "pound"
+      },
+      {
+        "name": "olive oil",
+        "quantity": 0.25,
+        "unit": "cup"
+      },
+      {
+        "name": "garlic",
+        "quantity": 3,
+        "unit": "cloves"
+      },
+      {
+        "name": "chopped tomatoes",
+        "quantity": 1,
+        "unit": "tin"
+      },
+      {
+        "name": "red chilli flakes",
+        "quantity": 0.5,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "italian seasoning",
+        "quantity": 0.5,
+        "unit": "teaspoon"
+      },
+      {
+        "name": "basil",
+        "quantity": 6,
+        "unit": "leaves"
+      },
+      {
+        "name": "Parmigiano-Reggiano",
+        "quantity": 1,
+        "unit": "sprinkling"
+      }
+    ],
+    "instructions": [
+      "Bring a large pot of water to a boil.",
+      "Add kosher salt to the boiling water, then add the pasta.",
+      "Cook according to the package instructions, about 9 minutes.",
+      "In a large skillet over medium-high heat, add the olive oil and heat until the oil starts to shimmer.",
+      "Add the garlic and cook, stirring, until fragrant, 1 to 2 minutes.",
+      "Add the chopped tomatoes, red chile flakes, Italian seasoning and salt and pepper to taste.",
+      "Bring to a boil and cook for 5 minutes.",
+      "Remove from the heat and add the chopped basil.",
+      "Drain the pasta and add it to the sauce.",
+      "Garnish with Parmigiano-Reggiano flakes and more basil and serve warm."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Italian",
+      "Pasta",
+      "Curry",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52865",
+    "name": "Matar Paneer",
+    "description": "A delicious Vegetarian dish from Indian cuisine.",
+    "ingredients": [
+      {
+        "name": "Sunflower Oil",
+        "quantity": 1,
+        "unit": "tbls"
+      },
+      {
+        "name": "Paneer",
+        "quantity": 225,
+        "unit": "g"
+      },
+      {
+        "name": "Ginger",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Cumin",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Turmeric",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Coriander",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Green Chilli",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Tomato",
+        "quantity": 4,
+        "unit": "large"
+      },
+      {
+        "name": "Peas",
+        "quantity": 150,
+        "unit": "g"
+      },
+      {
+        "name": "Garam Masala",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Coriander",
+        "quantity": 1,
+        "unit": "Small bunch"
+      },
+      {
+        "name": "Naan Bread",
+        "quantity": 1,
+        "unit": "to serve"
+      }
+    ],
+    "instructions": [
+      "Heat the oil in a frying pan over high heat until it’s shimmering hot.",
+      "Add the paneer, then turn the heat down a little.",
+      "Fry until it starts to brown at the edges, then turn it over and brown on each side – the paneer will brown faster than you think, so don’t walk away.",
+      "Remove the paneer from the pan and drain on kitchen paper.",
+      "Put the ginger, cumin, turmeric, ground coriander and chilli in the pan, and fry everything for 1 min.",
+      "Add the tomatoes, mashing them with the back of a spoon and simmer everything for 5 mins until the sauce smells fragrant.",
+      "Add a splash of water if it’s too thick.",
+      "Season well.",
+      "Add the peas and simmer for a further 2 mins, then stir in the paneer and sprinkle over the garam masala.",
+      "Divide between two bowls, top with coriander leaves and serve with naan bread, roti or rice."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Indian",
+      "Curry",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-53081",
+    "name": "Potato Salad (Olivier Salad)",
+    "description": "A delicious Vegetarian dish from Russian cuisine.",
+    "ingredients": [
+      {
+        "name": "Potatoes",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Carrots",
+        "quantity": 3,
+        "unit": null
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "White Wine Vinegar",
+        "quantity": 0.5,
+        "unit": "tbs"
+      },
+      {
+        "name": "Eggs",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Sausages",
+        "quantity": 7,
+        "unit": "oz"
+      },
+      {
+        "name": "Dill",
+        "quantity": 4,
+        "unit": "oz"
+      },
+      {
+        "name": "Peas",
+        "quantity": 1,
+        "unit": "can"
+      },
+      {
+        "name": "Onions",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Mayonnaise",
+        "quantity": 1,
+        "unit": "cup"
+      }
+    ],
+    "instructions": [
+      "Cut the potatoes and carrots into small uniform cubes.",
+      "Place them in a large pot and fill with water.",
+      "Add salt and vinegar.",
+      "Bring it to a boil over medium high heat, and then reduce the heat to medium and continue to cook until the potatoes are cooked through, about 15 minutes.",
+      "Drain the potatoes and let it cool to room temperature.",
+      "Meanwhile, cut the sausage and pickles into small cubes, and chop the green onions.",
+      "Cut the hard-boiled eggs into small cubes as well.",
+      "If using fresh dill, chop them as well.",
+      "In a large bowl, combine potatoes, carrots, sausage, pickles, peas and green onions.",
+      "Add mayo and dill and mix until well combined.",
+      "Salt and pepper to taste.",
+      "Cover with a plastic wrap and refrigerate for at least 1 hour before serving."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Russian",
+      "Salad",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52955",
+    "name": "Egg Drop Soup",
+    "description": "A delicious Vegetarian dish from Chinese cuisine.",
+    "ingredients": [
+      {
+        "name": "Chicken Stock",
+        "quantity": 3,
+        "unit": "cups"
+      },
+      {
+        "name": "Salt",
+        "quantity": 0.25,
+        "unit": "tsp"
+      },
+      {
+        "name": "Sugar",
+        "quantity": 0.25,
+        "unit": "tsp"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Sesame Seed Oil",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Peas",
+        "quantity": 0.3333333333333333,
+        "unit": "cup"
+      },
+      {
+        "name": "Mushrooms",
+        "quantity": 0.3333333333333333,
+        "unit": "cup"
+      },
+      {
+        "name": "Cornstarch",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Water",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Spring Onions",
+        "quantity": 0.25,
+        "unit": "cup"
+      }
+    ],
+    "instructions": [
+      "In a wok add chicken broth and wait for it to boil.",
+      "Next add salt, sugar, white pepper, sesame seed oil.",
+      "When the chicken broth is boiling add the vegetables to the wok.",
+      "To thicken the sauce, whisk together 1 Tablespoon of cornstarch and 2 Tablespoon of water in a bowl and slowly add to your soup until it's the right thickness.",
+      "Next add 1 egg slightly beaten with a knife or fork and add it to the soup slowly and stir for 8 seconds.",
+      "Serve the soup in a bowl and add the green onions on top."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Chinese",
+      "Soup",
+      "Baking",
+      "Calorific",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52785",
+    "name": "Dal fry",
+    "description": "A delicious Vegetarian dish from Indian cuisine.",
+    "ingredients": [
+      {
+        "name": "Toor dal",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Water",
+        "quantity": 2,
+        "unit": "/2 cups"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Turmeric",
+        "quantity": 0.25,
+        "unit": "tsp"
+      },
+      {
+        "name": "Ghee",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Chopped tomatoes",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Cumin seeds",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Mustard Seeds",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Bay Leaf",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Green Chilli",
+        "quantity": 1,
+        "unit": "tbs chopped"
+      },
+      {
+        "name": "Ginger",
+        "quantity": 2,
+        "unit": "tsp shredded"
+      },
+      {
+        "name": "Cilantro",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Red Pepper",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Salt",
+        "quantity": 0.5,
+        "unit": "tsp"
+      },
+      {
+        "name": "Sugar",
+        "quantity": 1,
+        "unit": "tsp"
+      },
+      {
+        "name": "Garam Masala",
+        "quantity": 0.25,
+        "unit": "tsp"
+      }
+    ],
+    "instructions": [
+      "Wash and soak toor dal in approx.",
+      "3 cups of water, for at least one hours.",
+      "Dal will be double in volume after soaking.",
+      "Drain the water.",
+      "Cook dal with 2-1/2 cups water and add salt, turmeric, on medium high heat, until soft in texture (approximately 30 mins) it should be like thick soup.",
+      "In a frying pan, heat the ghee.",
+      "Add cumin seeds, and mustard seeds.",
+      "After the seeds crack, add bay leaves, green chili, ginger and chili powder.",
+      "Stir for a few seconds.",
+      "Add tomatoes, salt and sugar stir and cook until tomatoes are tender and mushy.",
+      "Add cilantro and garam masala cook for about one minute.",
+      "Pour the seasoning over dal mix it well and cook for another minute.",
+      "Serve with Naan."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Indian",
+      "Curry",
+      "Cake",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52971",
+    "name": "Kafteji",
+    "description": "A delicious Vegetarian dish from Tunisian cuisine.",
+    "ingredients": [
+      {
+        "name": "Potatoes",
+        "quantity": 5,
+        "unit": "Large"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 2,
+        "unit": "tbs"
+      },
+      {
+        "name": "Green Pepper",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Onions",
+        "quantity": 5,
+        "unit": null
+      },
+      {
+        "name": "Ras el hanout",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Pumpkin",
+        "quantity": 500,
+        "unit": "g"
+      },
+      {
+        "name": "Eggs",
+        "quantity": 24,
+        "unit": "Skinned"
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "Pinch"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "Pinch"
+      }
+    ],
+    "instructions": [
+      "Peel potatoes and cut into 5cm cubes.",
+      "Pour 1-2 cm of olive oil into a large pan and heat up very hot.",
+      "Fry potatoes until golden brown for 20 minutes, turning from time to time.",
+      "Place on kitchen paper to drain.",
+      "Cut the peppers in half and remove seeds.",
+      "Rub a little olive oil on them and place the cut side down on a baking tray.",
+      "Place them under the grill.",
+      "Grill until the skin is dark and bubbly.",
+      "While the peppers are still hot, put them into a plastic sandwich bag and seal it.",
+      "Take them out after 15 minutes and remove skins.",
+      "In the meantime, heat more olive oil another pan.",
+      "Peel the onions and cut into thin rings.",
+      "Fry for 15 minutes until golden brown, turning them often.",
+      "Add the Ras el hanout at the end.",
+      "Cut the pumpkin into 5cm cubes and fry in the same pan you used for the potatoes for 10-15 minutes until it is soft and slightly browned.",
+      "Place on kitchen paper.",
+      "Pour the remaining olive oil out of the pan and put all the cooked vegetables into the pan and mix.",
+      "Whisk eggs and pour them over the vegetables.",
+      "Put the lid on the pan so that the eggs cook.",
+      "Put the contents of the pan onto a large chopping board, add salt and pepper and chopped and mix everything with a big knife."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Tunisian",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52872",
+    "name": "Spanish Tortilla",
+    "description": "A delicious Vegetarian dish from Spanish cuisine.",
+    "ingredients": [
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "sliced"
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 4,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Butter",
+        "quantity": 25,
+        "unit": "g"
+      },
+      {
+        "name": "Potatoes",
+        "quantity": 400,
+        "unit": "g"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 6,
+        "unit": "cloves"
+      },
+      {
+        "name": "Eggs",
+        "quantity": 8,
+        "unit": null
+      },
+      {
+        "name": "Parsley",
+        "quantity": 1,
+        "unit": "Handful"
+      },
+      {
+        "name": "Baguette",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Vine Tomatoes",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Olive Oil",
+        "quantity": 1,
+        "unit": "drizzle"
+      }
+    ],
+    "instructions": [
+      "Put a large non-stick frying pan on a low heat.",
+      "Cook the onion slowly in the oil and butter until soft but not brown – this should take about 15 mins.",
+      "Add the potatoes, cover the pan and cook for a further 15-20 mins, stirring occasionally to make sure they fry evenly.",
+      "When the potatoes are soft and the onion is shiny, crush 2 garlic cloves and stir in, followed by the beaten eggs.",
+      "Put the lid back on the pan and leave the tortilla to cook gently.",
+      "After 20 mins, the edges and base should be golden, the top set but the middle still a little wobbly.",
+      "To turn it over, slide it onto a plate and put another plate on top, turn the whole thing over and slide it back into the pan to finish cooking.",
+      "Once cooked, transfer to a plate and serve the tortilla warm or cold, scattered with the chopped parsley.",
+      "To accompany, take slices of warmed baguette, stab all over with a fork and rub with the remaining garlic, pile on grated tomatoes and season with sea salt and a drizzle of olive oil."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Spanish",
+      "Egg",
+      "Light",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-53077",
+    "name": "Cabbage Soup (Shchi)",
+    "description": "A delicious Vegetarian dish from Russian cuisine.",
+    "ingredients": [
+      {
+        "name": "Unsalted Butter",
+        "quantity": 3,
+        "unit": "tbs"
+      },
+      {
+        "name": "Onion",
+        "quantity": 1,
+        "unit": "large"
+      },
+      {
+        "name": "Cabbage",
+        "quantity": 1,
+        "unit": "medium"
+      },
+      {
+        "name": "Carrots",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Celery",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Bay Leaf",
+        "quantity": 1,
+        "unit": null
+      },
+      {
+        "name": "Vegetable Stock",
+        "quantity": 8,
+        "unit": "cups"
+      },
+      {
+        "name": "Potatoes",
+        "quantity": 2,
+        "unit": "large"
+      },
+      {
+        "name": "Tomatoes",
+        "quantity": 2,
+        "unit": "large"
+      },
+      {
+        "name": "Sour Cream",
+        "quantity": 1,
+        "unit": "Garnish"
+      },
+      {
+        "name": "Dill",
+        "quantity": 1,
+        "unit": "Garnish"
+      }
+    ],
+    "instructions": [
+      "Add the butter to a large Dutch oven or other heavy-duty pot over medium heat.",
+      "When the butter has melted, add the onion and sauté until translucent.",
+      "Add the cabbage, carrot, and celery.",
+      "Sauté until the vegetables begin to soften, stirring frequently, about 3 minutes.",
+      "Add the bay leaf and vegetable stock and bring to a boil over high heat.",
+      "Reduce the heat to low and simmer, covered, until the vegetables are crisp-tender, about 15 minutes.",
+      "Add the potatoes and bring it back to a boil over high heat.",
+      "Reduce the heat to low and simmer, covered, until the potatoes are tender, about 10 minutes.",
+      "Add the tomatoes (or undrained canned tomatoes) and bring the soup back to a boil over high heat.",
+      "Reduce the heat to low and simmer, uncovered, for 5 minutes.",
+      "Season to taste with salt and pepper.",
+      "emove and discard the bay leaf from the pot.",
+      "Serve topped with fresh sour cream and fresh dill."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Russian",
+      "Soup",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52849",
+    "name": "Spinach & Ricotta Cannelloni",
+    "description": "A delicious Vegetarian dish from Italian cuisine.",
+    "ingredients": [
+      {
+        "name": "Olive Oil",
+        "quantity": 3,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 8,
+        "unit": "cloves chopped"
+      },
+      {
+        "name": "Caster Sugar",
+        "quantity": 3,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Red Wine Vinegar",
+        "quantity": 2,
+        "unit": "tblsp"
+      },
+      {
+        "name": "Chopped Tomatoes",
+        "quantity": 3,
+        "unit": "400g Cans"
+      },
+      {
+        "name": "Basil Leaves",
+        "quantity": 1,
+        "unit": "Bunch"
+      },
+      {
+        "name": "Mascarpone",
+        "quantity": 2,
+        "unit": "tubs"
+      },
+      {
+        "name": "Milk",
+        "quantity": 3,
+        "unit": "tbsp"
+      },
+      {
+        "name": "Parmesan",
+        "quantity": 85,
+        "unit": "g"
+      },
+      {
+        "name": "Mozzarella",
+        "quantity": 2,
+        "unit": "sliced"
+      },
+      {
+        "name": "Spinach",
+        "quantity": 1,
+        "unit": "kg"
+      },
+      {
+        "name": "Parmesan",
+        "quantity": 100,
+        "unit": "g"
+      },
+      {
+        "name": "Ricotta",
+        "quantity": 3,
+        "unit": "tubs"
+      },
+      {
+        "name": "Nutmeg",
+        "quantity": 1,
+        "unit": "pinch"
+      },
+      {
+        "name": "Cannellini Beans",
+        "quantity": 400,
+        "unit": "g"
+      }
+    ],
+    "instructions": [
+      "First make the tomato sauce.",
+      "Heat the oil in a large pan and fry the garlic for 1 min.",
+      "Add the sugar, vinegar, tomatoes and some seasoning and simmer for 20 mins, stirring occasionally, until thick.",
+      "Add the basil and divide the sauce between 2 or more shallow ovenproof dishes (see Tips for freezing, below).",
+      "Set aside.",
+      "Make a sauce by beating the mascarpone with the milk until smooth, season, then set aside.",
+      "Put the spinach in a large colander and pour over a kettle of boiling water to wilt it (you may need to do this in batches).",
+      "When cool enough to handle squeeze out the excess water.",
+      "Roughly chop the spinach and mix in a large bowl with 100g Parmesan and ricotta.",
+      "Season well with salt, pepper and the nutmeg.",
+      "Heat oven to 200C/180C fan/gas 6.",
+      "Using a piping bag or plastic food bag with the corner snipped off, squeeze the filling into the cannelloni tubes.",
+      "Lay the tubes, side by side, on top of the tomato sauce and spoon over the mascarpone sauce.",
+      "Top with Parmesan and mozzarella.",
+      "You can now freeze the cannelloni, uncooked, or you can cook it first and then freeze.",
+      "Bake for 30-35 mins until golden and bubbling.",
+      "Remove from oven and let stand for 5 mins before serving."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Italian",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52963",
+    "name": "Shakshuka",
+    "description": "A delicious Vegetarian dish from Egyptian cuisine.",
+    "ingredients": [
+      {
+        "name": "Olive Oil",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Red Onions",
+        "quantity": 2,
+        "unit": "chopped"
+      },
+      {
+        "name": "Red Chilli",
+        "quantity": 1,
+        "unit": "finely chopped"
+      },
+      {
+        "name": "Garlic",
+        "quantity": 1,
+        "unit": "clove"
+      },
+      {
+        "name": "Coriander",
+        "quantity": 1,
+        "unit": "Chopped"
+      },
+      {
+        "name": "Cherry Tomatoes",
+        "quantity": 800,
+        "unit": "g"
+      },
+      {
+        "name": "Caster Sugar",
+        "quantity": 1,
+        "unit": "tbs"
+      },
+      {
+        "name": "Eggs",
+        "quantity": 4,
+        "unit": null
+      },
+      {
+        "name": "Feta",
+        "quantity": 1,
+        "unit": "Spinkling"
+      }
+    ],
+    "instructions": [
+      "Heat the oil in a frying pan that has a lid, then soften the onions, chilli, garlic and coriander stalks for 5 mins until soft.",
+      "Stir in the tomatoes and sugar, then bubble for 8-10 mins until thick.",
+      "Can be frozen for 1 month.",
+      "Using the back of a large spoon, make 4 dips in the sauce, then crack an egg into each one.",
+      "Put a lid on the pan, then cook over a low heat for 6-8 mins, until the eggs are done to your liking.",
+      "Scatter with the coriander leaves and serve with crusty bread."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Egyptian",
+      "Egg",
+      "Brunch",
+      "Breakfast",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-53072",
+    "name": "Crispy Eggplant",
+    "description": "A delicious Vegetarian dish from Filipino cuisine.",
+    "ingredients": [
+      {
+        "name": "Egg Plants",
+        "quantity": 1,
+        "unit": "large"
+      },
+      {
+        "name": "Breadcrumbs",
+        "quantity": 1,
+        "unit": "cup"
+      },
+      {
+        "name": "Sesame Seed",
+        "quantity": 50,
+        "unit": "g"
+      },
+      {
+        "name": "Eggs",
+        "quantity": 2,
+        "unit": null
+      },
+      {
+        "name": "Salt",
+        "quantity": 1,
+        "unit": "To taste"
+      },
+      {
+        "name": "Pepper",
+        "quantity": 1,
+        "unit": "To taste"
+      },
+      {
+        "name": "Vegetable Oil",
+        "quantity": 1,
+        "unit": "For frying"
+      }
+    ],
+    "instructions": [
+      "Slice eggplant into 1 cm (0.4-inch) slices.",
+      "Place them in a bowl and sprinkle them with salt.",
+      "allow them to sit for 30 minutes to render some of their liquid and bitterness.",
+      "2.",
+      "After 30 minutes wash eggplant slices from salt and pat dry with a kitchen towel.",
+      "3.",
+      "In a large bowl/plate place breadcrumbs and sesame seeds.",
+      "In another bowl beat 2 eggs with pinch salt and pepper.",
+      "4.",
+      "Heal oil in a large skillet over high heat.",
+      "5.",
+      "Dip eggplant slices in egg, then in crumbs, and place in hot oil.",
+      "Fry 2 to 3 minutes on each side, or until golden brown.",
+      "Drain on a paper towel."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "Filipino",
+      "vegetarian"
+    ]
+  },
+  {
+    "id": "rezept-api-52817",
+    "name": "Stovetop Eggplant With Harissa, Chickpeas, and Cumin Yogurt",
+    "description": "A delicious Vegetarian dish from American cuisine.",
+    "ingredients": [
+      {
+        "name": "Olive Oil",
+        "quantity": 4,
+        "unit": "tablespoons"
+      },
+      {
+        "name": "Egg Plants",
+        "quantity": 6,
+        "unit": "small"
+      },
+      {
+        "name": "Harissa Spice",
+        "quantity": 1,
+        "unit": "½ tablespoon"
+      },
+      {
+        "name": "Chickpeas",
+        "quantity": 1,
+        "unit": "can"
+      },
+      {
+        "name": "Cherry Tomatoes",
+        "quantity": 2,
+        "unit": "cups halved"
+      },
+      {
+        "name": "Greek yogurt",
+        "quantity": 1,
+        "unit": "1/2 cups"
+      },
+      {
+        "name": "Ground cumin",
+        "quantity": 1,
+        "unit": "tablespoon"
+      },
+      {
+        "name": "Parsley",
+        "quantity": 1,
+        "unit": "½ cup"
+      }
+    ],
+    "instructions": [
+      "Heat the oil in a 12-inch skillet over high heat until shimmering.",
+      "Add the eggplants and lower the heat to medium.",
+      "Season with salt and pepper as you rotate the eggplants, browning them on all sides.",
+      "Continue to cook, turning regularly, until a fork inserted into the eggplant meets no resistance (you may have to stand them up on their fat end to finish cooking the thickest parts), about 20 minutes, lowering the heat and sprinkling water into the pan as necessary if the eggplants threaten to burn or smoke excessively.",
+      "2.",
+      "Mix the harissa, chickpeas and tomatoes together, then add to the eggplants.",
+      "Cook until the tomatoes have blistered and broken down, about 5 minutes more.",
+      "Season with salt and pepper and add water as necessary to thin to a saucy consistency.",
+      "Meanwhile, combine the yogurt and cumin in a serving bowl.",
+      "Season with salt and pepper.",
+      "3.",
+      "Top the eggplant mixture with the parsley, drizzle with more extra virgin olive oil, and serve with the yogurt on the side."
+    ],
+    "isVegetarian": true,
+    "isVegan": false,
+    "tags": [
+      "Vegetarian",
+      "American",
+      "vegetarian"
     ]
   }
 ]

--- a/js/fetch_recipes.js
+++ b/js/fetch_recipes.js
@@ -1,0 +1,307 @@
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+
+const API_BASE_URL = 'https://www.themealdb.com/api/json/v1/1/';
+const FILTER_BY_INGREDIENT_URL = (ingredient) => `${API_BASE_URL}filter.php?i=${ingredient}`;
+const FILTER_BY_CATEGORY_URL = (category) => `${API_BASE_URL}filter.php?c=${category}`;
+const LOOKUP_BY_ID_URL = (id) => `${API_BASE_URL}lookup.php?i=${id}`;
+
+// Output directly to recipes.json
+const OUTPUT_PATH = path.join(__dirname, '..', 'data', 'recipes.json');
+
+const NON_VEGAN_KEYWORDS = [
+    "egg", "eggs", "cheese", "milk", "honey", "yogurt", "butter", "cream",
+    "gelatin", "casein", "whey", "lactose", "ghee", "paneer", "halloumi",
+    "sausage", "mince", "pork", "beef", "chicken", "fish", "prawns",
+    "salami", "ham", "bacon", "turkey", "duck", "salmon", "tuna",
+    "oyster sauce", "fish sauce", "anchovy", "anchovies", "rennet", "isinglass", "cochineal", "carmine",
+    "chicken stock", "beef stock", "pork stock", "fish stock" // Added stock types
+];
+
+function parseMeasure(measureStr) {
+    if (!measureStr || measureStr.trim() === "") {
+        return { quantity: null, unit: null };
+    }
+    measureStr = measureStr.trim();
+    let quantity = null;
+    let unit = '';
+
+    // Improved regex to capture various numeric formats and units
+    // Handles: "1", "1.5", "1/2", "1 1/2", "100 g", "2-3" (takes first number)
+    const measureRegex = /^((\d+\s*\/\s*\d+)|(\d+\s*-\s*\d+)|(\d*\.?\d+))\s*(.*)/;
+    const match = measureStr.match(measureRegex);
+
+    if (match) {
+        let qtyPart = match[1];
+        unit = match[5] ? match[5].trim() : null;
+
+        if (qtyPart.includes('/')) { // Fraction e.g. "1/2", "1 1/2" (though latter is not directly handled by regex, commonFractionMatch was better for "1 1/2")
+            const parts = qtyPart.split('/');
+            if (parts.length === 2 && !isNaN(parseFloat(parts[0])) && !isNaN(parseFloat(parts[1])) && parseFloat(parts[1]) !== 0) {
+                quantity = parseFloat(parts[0]) / parseFloat(parts[1]);
+            } else { // Malformed fraction
+                quantity = 1; // Default
+                if (!unit) unit = qtyPart; // Use the unparsed part as unit
+            }
+        } else if (qtyPart.includes('-')) { // Range e.g. "2-3"
+             quantity = parseFloat(qtyPart.split('-')[0]); // Take the first number in a range
+        } else if (!isNaN(parseFloat(qtyPart))) {
+            quantity = parseFloat(qtyPart);
+        }
+
+        if (unit === "") unit = null;
+
+    } else {
+        // No standard number at the start, e.g. "Pinch", "Dash" or just text
+        const lowerMeasureStr = measureStr.toLowerCase();
+        if (lowerMeasureStr.includes('pinch') || lowerMeasureStr.includes('dash')) {
+            quantity = 1;
+            unit = measureStr.replace(/^a\s+/i, '').trim();
+        } else {
+            quantity = 1;
+            unit = measureStr;
+        }
+    }
+    if (unit === "") unit = null;
+    return { quantity, unit };
+}
+
+function transformRecipe(apiRecipe) {
+    const ingredients = [];
+    for (let i = 1; i <= 20; i++) {
+        const ingredientName = apiRecipe[`strIngredient${i}`];
+        const measureStr = apiRecipe[`strMeasure${i}`];
+        if (ingredientName && ingredientName.trim() !== "") {
+            const { quantity, unit } = parseMeasure(measureStr);
+            ingredients.push({
+                name: ingredientName.trim(),
+                quantity: quantity,
+                unit: unit
+            });
+        }
+    }
+
+    let description = `A delicious ${apiRecipe.strCategory} dish.`;
+    if (apiRecipe.strArea && apiRecipe.strArea.trim() !== "") {
+        description = `A delicious ${apiRecipe.strCategory} dish from ${apiRecipe.strArea} cuisine.`;
+    }
+
+    const instructions = apiRecipe.strInstructions ? apiRecipe.strInstructions
+        .split(/\r\n|\n/) // Split by newlines first
+        .map(line => line.trim())
+        .filter(line => line.length > 0)
+        .flatMap(line => line.split(/(?<=\.)\s+/)) // Further split by period followed by space, keeping period
+        .map(step => step.trim())
+        .filter(step => step.length > 0)
+        .map(step => step.endsWith('.') || step.endsWith('!') || step.endsWith('?') ? step : step + '.')
+        : [];
+
+    let isRecipeVegetarian = apiRecipe.strCategory === 'Vegetarian';
+    if (['Beef', 'Chicken', 'Lamb', 'Pork', 'Seafood', 'Fish', 'Shellfish', 'Pasta', 'Miscellaneous'].includes(apiRecipe.strCategory)) {
+        // Check ingredients for meat if category is ambiguous like Pasta or Miscellaneous
+        let hasMeatIngredient = false;
+        for (const ing of ingredients) {
+            const ingNameLower = ing.name.toLowerCase();
+            if (NON_VEGAN_KEYWORDS.some(keyword => ingNameLower.includes(keyword) &&
+                ["beef", "chicken", "pork", "lamb", "fish", "sausage", "ham", "bacon", "mince", "prawns", "salmon", "tuna", "turkey", "duck"].includes(keyword))) {
+                hasMeatIngredient = true;
+                break;
+            }
+        }
+        if (hasMeatIngredient) isRecipeVegetarian = false;
+        else if (apiRecipe.strCategory === 'Vegetarian') isRecipeVegetarian = true;
+        // If category is not vegetarian and no meat ingredients, it *could* be vegetarian.
+        // This part is tricky; TheMealDB isn't always perfectly categorized.
+        // For now, if category IS 'Vegetarian', it's vegetarian. If it's clearly meat category, it's not.
+        // Otherwise, rely on ingredient check for meat.
+    }
+
+
+    let isRecipeVegan = false;
+    if (isRecipeVegetarian) {
+        isRecipeVegan = true; // Assume vegan unless a non-vegan keyword is found
+        const allRecipeText = [
+            apiRecipe.strMeal.toLowerCase(),
+            ...ingredients.map(ing => ing.name.toLowerCase()),
+            // Don't check instructions for keywords, could be "serve with a side of cheese (optional)"
+        ].join(' ');
+
+        if (NON_VEGAN_KEYWORDS.some(keyword => allRecipeText.includes(keyword))) {
+            isRecipeVegan = false;
+        }
+    }
+
+    // Explicitly mark beef/chicken as not vegetarian/vegan
+    if (apiRecipe.strCategory === 'Beef' || apiRecipe.strCategory === 'Chicken' ||
+        (apiRecipe.strMeal && (apiRecipe.strMeal.toLowerCase().includes('beef') || apiRecipe.strMeal.toLowerCase().includes('chicken')))
+       ) {
+        isRecipeVegetarian = false;
+        isRecipeVegan = false;
+    }
+
+
+    const tags = [];
+    if (apiRecipe.strCategory) tags.push(apiRecipe.strCategory);
+    if (apiRecipe.strArea) tags.push(apiRecipe.strArea);
+    if (apiRecipe.strTags) {
+        tags.push(...apiRecipe.strTags.split(',').map(tag => tag.trim()).filter(tag => tag));
+    }
+    if (isRecipeVegetarian) tags.push("vegetarian");
+    if (isRecipeVegan) tags.push("vegan");
+
+    return {
+        id: `rezept-api-${apiRecipe.idMeal}`,
+        name: apiRecipe.strMeal,
+        description: description,
+        ingredients: ingredients,
+        instructions: instructions,
+        isVegetarian: isRecipeVegetarian,
+        isVegan: isRecipeVegan,
+        tags: [...new Set(tags)].filter(tag => tag) // Unique and non-empty tags
+    };
+}
+
+async function fetchRecipeDetails(mealId) {
+    try {
+        // console.log(`Fetching details for ${mealId}`);
+        const response = await axios.get(LOOKUP_BY_ID_URL(mealId));
+        await new Promise(resolve => setTimeout(resolve, 100)); // Small delay to be nice to API
+        if (response.data && response.data.meals && response.data.meals.length > 0) {
+            return response.data.meals[0];
+        }
+    } catch (error) {
+        console.error(`Error fetching details for meal ID ${mealId}:`, error.message.substring(0, 200));
+    }
+    return null;
+}
+
+async function fetchMealIdsByUrl(url, limit) {
+    const mealIds = [];
+    try {
+        // console.log(`Fetching meal IDs from ${url}`);
+        const response = await axios.get(url);
+        if (response.data && response.data.meals) {
+            // Shuffle the array to get different recipes if limit is less than total
+            const shuffledMeals = response.data.meals.sort(() => 0.5 - Math.random());
+            for (const meal of shuffledMeals) {
+                if (mealIds.length < limit) {
+                    mealIds.push(meal.idMeal);
+                } else {
+                    break;
+                }
+            }
+        }
+    } catch (error) {
+        console.error(`Error fetching meal list from ${url}:`, error.message.substring(0, 200));
+    }
+    return mealIds;
+}
+
+async function fetchRecipesForCategory(categoryName, count, isIngredientFilter = false) {
+    const recipes = [];
+    const fetchedRecipeIds = new Set();
+    console.log(`Fetching ${count} recipes for category: ${categoryName}...`);
+
+    const url = isIngredientFilter ? FILTER_BY_INGREDIENT_URL(categoryName) : FILTER_BY_CATEGORY_URL(categoryName);
+    const mealIds = await fetchMealIdsByUrl(url, count * 2); // Fetch more IDs initially due to potential null details or duplicates
+
+    for (const id of mealIds) {
+        if (recipes.length >= count) break;
+        if (fetchedRecipeIds.has(id)) continue;
+
+        const detail = await fetchRecipeDetails(id);
+        if (detail) {
+            const transformedRecipe = transformRecipe(detail);
+            recipes.push(transformedRecipe);
+            fetchedRecipeIds.add(id);
+        }
+    }
+    console.log(`Successfully fetched ${recipes.length} recipes for ${categoryName}.`);
+    return recipes;
+}
+
+async function main() {
+    console.log("Starting recipe fetch process...");
+    const allRecipes = [];
+    const recipeIdMasterSet = new Set(); // To track IDs across all categories
+
+    const TARGET_COUNT_PER_CATEGORY = 80;
+    const VEGETARIAN_FETCH_TARGET = TARGET_COUNT_PER_CATEGORY * 2.5; // Fetch more vegetarian to filter for vegan
+
+    // Fetch Beef recipes
+    const beefRecipes = await fetchRecipesForCategory('beef', TARGET_COUNT_PER_CATEGORY, true);
+    beefRecipes.forEach(r => {
+        r.isVegetarian = false; r.isVegan = false; // Ensure flags
+        if (!recipeIdMasterSet.has(r.id)) { allRecipes.push(r); recipeIdMasterSet.add(r.id); }
+    });
+
+    // Fetch Chicken recipes
+    const chickenRecipes = await fetchRecipesForCategory('chicken', TARGET_COUNT_PER_CATEGORY, true);
+    chickenRecipes.forEach(r => {
+        r.isVegetarian = false; r.isVegan = false; // Ensure flags
+         if (!recipeIdMasterSet.has(r.id)) { allRecipes.push(r); recipeIdMasterSet.add(r.id); }
+    });
+
+    // Fetch all Vegetarian recipes first
+    console.log(`Fetching up to ${VEGETARIAN_FETCH_TARGET} vegetarian recipes for filtering...`);
+    const allVegetarianApiRecipes = await fetchRecipesForCategory('Vegetarian', VEGETARIAN_FETCH_TARGET, false);
+
+    const vegetarianRecipes = [];
+    const veganRecipes = [];
+
+    for (const recipe of allVegetarianApiRecipes) {
+        if (recipeIdMasterSet.has(recipe.id)) continue; // Already added (e.g. if it was miscategorized and fetched by ingredient)
+
+        // Re-evaluate vegan status based on full transformed data
+        let isActuallyVegan = true;
+        if (!recipe.isVegetarian) { // Should be vegetarian by category, but double check
+            isActuallyVegan = false;
+        } else {
+            const allRecipeText = [
+                recipe.name.toLowerCase(),
+                ...recipe.ingredients.map(ing => ing.name.toLowerCase()),
+            ].join(' ');
+            if (NON_VEGAN_KEYWORDS.some(keyword => allRecipeText.includes(keyword))) {
+                isActuallyVegan = false;
+            }
+        }
+        recipe.isVegan = isActuallyVegan; // Update based on detailed check
+        recipe.isVegetarian = true; // It came from vegetarian category
+
+        if (recipe.isVegan && veganRecipes.length < TARGET_COUNT_PER_CATEGORY) {
+            if (!recipeIdMasterSet.has(recipe.id)) {
+                 veganRecipes.push(recipe);
+                 recipeIdMasterSet.add(recipe.id);
+            }
+        } else if (!recipe.isVegan && vegetarianRecipes.length < TARGET_COUNT_PER_CATEGORY) {
+             if (!recipeIdMasterSet.has(recipe.id)) {
+                vegetarianRecipes.push(recipe);
+                recipeIdMasterSet.add(recipe.id);
+            }
+        }
+    }
+
+    allRecipes.push(...veganRecipes, ...vegetarianRecipes);
+
+    // Ensure unique recipes one last time (though recipeIdMasterSet should handle it)
+    const finalUniqueRecipes = Array.from(new Map(allRecipes.map(recipe => [recipe.id, recipe])).values());
+
+
+    console.log(`Total unique recipes fetched: ${finalUniqueRecipes.length}`);
+    console.log(` - Beef: ${beefRecipes.filter(r => finalUniqueRecipes.find(fr => fr.id === r.id)).length}`);
+    console.log(` - Chicken: ${chickenRecipes.filter(r => finalUniqueRecipes.find(fr => fr.id === r.id)).length}`);
+    console.log(` - Vegetarian (non-vegan): ${vegetarianRecipes.filter(r => finalUniqueRecipes.find(fr => fr.id === r.id)).length}`);
+    console.log(` - Vegan: ${veganRecipes.filter(r => finalUniqueRecipes.find(fr => fr.id === r.id)).length}`);
+
+    try {
+        fs.writeFileSync(OUTPUT_PATH, JSON.stringify(finalUniqueRecipes, null, 2), 'utf-8');
+        console.log(`Successfully wrote ${finalUniqueRecipes.length} recipes to ${OUTPUT_PATH}`);
+    } catch (error) {
+        console.error("Error writing recipes to file:", error.message);
+    }
+}
+
+main().catch(error => {
+    console.error("Unhandled error in main execution:", error);
+});

--- a/js/generate-recipes.js
+++ b/js/generate-recipes.js
@@ -1,51 +1,294 @@
-// Version 1500+
-// Erstellt eine große und vielfältige Rezeptdatenbank (~1500 Rezepte) mit verschiedenen Attributen und Küchenstilen.
+// Version 1600+
+// Erstellt eine große und vielfältige Rezeptdatenbank (1600 Rezepte) mit verschiedenen Attributen und Küchenstilen.
 const fs = require('fs');
 const path = require('path');
 
 const bases = [ { n: 'Nudeln', t:['mediterranean', 'defty'] }, { n: 'Reis', t:['asian', 'light'] }, { n: 'Kartoffeln', t:['defty'] }, { n: 'Quinoa', t:['light'] }, { n: 'Couscous', t:['mediterranean', 'light'] }, { n: 'Brot', t:['defty', 'mediterranean'] }, { n: 'Gnocchi', t:['mediterranean', 'defty'] }, { n: 'Polenta', t:['mediterranean'] }, { n: 'Bulgur', t:['mediterranean', 'light'] } ];
-const proteins = [ { n: 'Hähnchenbrust', v:0, vg:0, t:['light', 'asian'] }, { n: 'Rinderhack', v:0, vg:0, t:['defty'] }, { n: 'Schweinefilet', v:0, vg:0, t:['defty', 'asian'] }, { n: 'Linsen', v:1, vg:1, t:['light', 'defty', 'mediterranean'] }, { n: 'Kichererbsen', v:1, vg:1, t:['light', 'mediterranean'] }, { n: 'Schwarze Bohnen', v:1, vg:1, t:['defty'] }, { n: 'Tofu', v:1, vg:1, t:['asian', 'light'] }, { n: 'Eier', v:1, vg:0, t:['defty', 'light'] }, { n: 'Halloumi', v:1, vg:0, t:['mediterranean'] }, { n: 'Feta', v:1, vg:0, t:['mediterranean'] } ];
+const proteins = [
+    { n: 'Hähnchenbrust', v:0, vg:0, t:['light', 'asian'], type: 'chicken' },
+    { n: 'Rinderhack', v:0, vg:0, t:['defty'], type: 'beef' },
+    { n: 'Schweinefilet', v:0, vg:0, t:['defty', 'asian'], type: 'pork' }, // Pork can be filtered out if not needed
+    { n: 'Linsen', v:1, vg:1, t:['light', 'defty', 'mediterranean'], type: 'vegetarian' },
+    { n: 'Kichererbsen', v:1, vg:1, t:['light', 'mediterranean'], type: 'vegetarian' },
+    { n: 'Schwarze Bohnen', v:1, vg:1, t:['defty'], type: 'vegetarian' },
+    { n: 'Tofu', v:1, vg:1, t:['asian', 'light'], type: 'vegan' },
+    { n: 'Eier', v:1, vg:0, t:['defty', 'light'], type: 'vegetarian' },
+    { n: 'Halloumi', v:1, vg:0, t:['mediterranean'], type: 'vegetarian' },
+    { n: 'Feta', v:1, vg:0, t:['mediterranean'], type: 'vegetarian' }
+];
 const vegetables = [ { n: 'Tomaten', t:['mediterranean'] }, { n: 'Zwiebel', t:['all'] }, { n: 'Paprika', t:['mediterranean', 'defty'] }, { n: 'Brokkoli', t:['light', 'asian'] }, { n: 'Karotten', t:['all'] }, { n: 'Spinat', t:['light', 'mediterranean'] }, { n: 'Zucchini', t:['mediterranean'] }, { n: 'Knoblauch', t:['all'] }, { n: 'Pilze', t:['defty', 'asian'] }, { n: 'Aubergine', t:['mediterranean'] }, { n: 'Gurke', t:['light'] }, { n: 'Mais', t:['defty'] }, { n: 'Frühlingszwiebeln', t:['asian'] }, { n: 'Ingwer', t:['asian'] }, { n: 'Oliven', t:['mediterranean'] }, { n: 'Rotkohl', t:['defty'] } ];
-const sauces = [ { n: 'Tomatensauce', t:['mediterranean'] }, { n: 'Sahnesauce', v:1, vg:0, t:['defty'] }, { n: 'Sojasauce', t:['asian'] }, { n: 'Pesto', t:['mediterranean'] }, { n: 'Vinaigrette', t:['light'] }, { n: 'Bratensauce', t:['defty'] } ];
-const extras = [ { n: 'geriebenem Käse', v:1, vg:0 }, { n: 'frischen Kräutern', v:1, vg:1 }, { n: 'einem Klecks Joghurt', v:1, vg:0 }, { n: 'gerösteten Kernen', v:1, vg:1 }, { n: 'Röstzwiebeln', v:1, vg:1 } ];
-
-const getRandom = (arr) => arr[Math.floor(Math.random() * arr.length)];
-
-const archetypes = [
-    { name: 'Pfanne', t: ['asian', 'mediterranean'], generate: () => {
-        const p = getRandom(proteins); const b = getRandom(bases.filter(base => ['Nudeln', 'Reis', 'Quinoa', 'Gnocchi'].includes(base.n))); const v = getRandom(vegetables, 2); const s = getRandom(sauces.filter(sauce => ['Sojasauce', 'Pesto'].includes(sauce.n)));
-        return { name: `${p.n}-Pfanne mit ${b.n}`, ingredients: [p,b, ...v, s], cost: 3.5, tags: ['schnell', ...b.t, ...p.t, ...s.t], instructions: [`${b.n} kochen.`,`${p.n} mit ${v[0].n} und ${v[1].n} anbraten.`, `Gekochte ${b.n} und ${s.n} zugeben.`] };
-    }},
-    { name: 'Auflauf', t: ['defty', 'mediterranean'], generate: () => {
-        const p = getRandom(proteins); const b = getRandom(bases.filter(base => ['Kartoffeln', 'Nudeln', 'Gnocchi'].includes(base.n))); const v = getRandom(vegetables); const s = getRandom(sauces.filter(sauce => ['Tomatensauce', 'Sahnesauce'].includes(sauce.n)));
-        return { name: `${b.n}-Auflauf mit ${p.n}`, ingredients: [p, b, v, s, extras[0]], cost: 4, tags: ['für gäste', ...b.t, ...p.t, ...s.t], instructions: [`Zutaten mischen und in eine Form geben.`, `Mit ${s.n} übergießen und Käse bestreuen.`, `Bei 180°C ca. 30 Min backen.`] };
-    }},
-    { name: 'Eintopf', t: ['defty', 'light'], generate: () => {
-        const p = getRandom(proteins.filter(pr => pr.n !== 'Halloumi')); const v = getUniqueRandom(vegetables.filter(veg => veg.n !== 'Gurke'), 3); const b = getRandom([bases[2], bases[8]]); const e = extras[1];
-        return { name: `${p.n}-Eintopf mit ${v[0].n}`, ingredients: [p, ...v, b, e], cost: 3, tags: ['günstig', 'resteverwertung', ...p.t], instructions: [`${p.n} & Gemüse anbraten.`, `Mit Wasser/Brühe aufgießen und köcheln.`, `Mit ${e.n} servieren.`] };
-    }},
-    { name: 'Salat', t: ['light', 'mediterranean'], generate: () => {
-        const p = getRandom(proteins.filter(pr => ['Hähnchenbrust', 'Feta', 'Halloumi', 'Tofu', 'Kichererbsen'].includes(pr.n))); const v = getUniqueRandom(vegetables.filter(veg => veg.n !== 'Rotkohl'), 2); const e = getRandom([extras[1], extras[3]]);
-        return { name: `Großer Salat mit ${p.n}`, ingredients: [p, bases[5], ...v, e], cost: 4.5, tags: ['schnell', ...p.t], instructions: [`Zutaten vorbereiten und mischen.`, `Mit Dressing anmachen.`, `Mit ${e.n} garnieren.`] };
-    }}
+const saucesAndFats = [
+    { n: 'Tomatensauce', t:['mediterranean'], vg:1, v:1 },
+    { n: 'Sahnesauce', v:1, vg:0, t:['defty'] },
+    { n: 'Sojasauce', t:['asian'], vg:1, v:1 },
+    { n: 'Pesto', t:['mediterranean'], vg:0, v:1 }, // Traditional pesto has cheese
+    { n: 'Veganes Pesto', t:['mediterranean'], vg:1, v:1 },
+    { n: 'Vinaigrette', t:['light'], vg:1, v:1 },
+    { n: 'Bratensauce', t:['defty'], vg:0, v:0 },
+    { n: 'Olivenöl', t:['mediterranean', 'light'], vg:1, v:1 },
+    { n: 'Butter', t:['defty'], vg:0, v:1 },
+    { n: 'Kokosmilch', t:['asian', 'light'], vg:1, v:1 }
+];
+const spicesAndHerbs = [
+    { n: 'Salz', quantity: 1, unit: 'Prise', vg:1, v:1 },
+    { n: 'Pfeffer', quantity: 1, unit: 'Prise', vg:1, v:1 },
+    { n: 'Paprikapulver', quantity: 1, unit: 'TL', vg:1, v:1 },
+    { n: 'Currypulver', quantity: 1, unit: 'TL', vg:1, v:1 },
+    { n: 'Oregano', quantity: 1, unit: 'TL', vg:1, v:1 },
+    { n: 'Basilikum', quantity: 1, unit: 'TL', vg:1, v:1 },
+    { n: 'Chiliflocken', quantity: 0.5, unit: 'TL', vg:1, v:1 }
+];
+const extras = [
+    { n: 'geriebenem Käse', v:1, vg:0 },
+    { n: 'frischen Kräutern (z.B. Petersilie oder Koriander)', v:1, vg:1 },
+    { n: 'einem Klecks Joghurt', v:1, vg:0 },
+    { n: 'einem Klecks veganem Joghurt', v:1, vg:1 },
+    { n: 'gerösteten Kernen (z.B. Sonnenblumenkerne oder Pinienkerne)', v:1, vg:1 },
+    { n: 'Röstzwiebeln', v:1, vg:1 }
 ];
 
-console.log("Generiere ~1500 vielfältige Rezepte...");
+const getRandom = (arr) => arr[Math.floor(Math.random() * arr.length)];
+const getUniqueRandom = (arr, num) => {
+    const result = new Set();
+    while(result.size < num && result.size < arr.length) {
+        result.add(getRandom(arr));
+    }
+    return Array.from(result);
+};
+
+const archetypes = [
+    {
+        name: 'Pfanne',
+        t: ['asian', 'mediterranean'],
+        generate: (targetProteinType) => {
+            let p;
+            if (targetProteinType === 'beef') p = proteins.find(pr => pr.type === 'beef');
+            else if (targetProteinType === 'chicken') p = proteins.find(pr => pr.type === 'chicken');
+            else if (targetProteinType === 'vegetarian') p = getRandom(proteins.filter(pr => pr.v === 1 && pr.vg === 0 && pr.type === 'vegetarian'));
+            else if (targetProteinType === 'vegan') p = getRandom(proteins.filter(pr => pr.vg === 1 && pr.type === 'vegan'));
+            else p = getRandom(proteins);
+
+            const b = getRandom(bases.filter(base => ['Nudeln', 'Reis', 'Quinoa', 'Gnocchi', 'Couscous', 'Bulgur'].includes(base.n)));
+            const vegs = getUniqueRandom(vegetables, Math.random() < 0.5 ? 2 : 3);
+            const fat = getRandom(saucesAndFats.filter(sf => sf.n === 'Olivenöl' || sf.n === 'Butter' || (p.vg && sf.vg)));
+            const sauce = getRandom(saucesAndFats.filter(s => (p.vg ? s.vg : p.v ? s.v : s.v === 0 && s.vg === 0) && (s.n.includes('sauce') || s.n.includes('Pesto') || s.n.includes('Kokosmilch'))));
+            const spiceCount = Math.floor(Math.random() * 2) + 1; // 1 or 2 spices
+            const selectedSpices = getUniqueRandom(spicesAndHerbs, spiceCount);
+
+            return {
+                name: `${p.n}-Pfanne mit ${b.n} und ${vegs[0].n}`,
+                ingredients: [p, b, ...vegs, fat, sauce, ...selectedSpices, spicesAndHerbs[0], spicesAndHerbs[1]], // Salz & Pfeffer
+                cost: 3.5 + Math.random(),
+                tags: ['schnell', ...b.t, ...p.t, ...(sauce.t || []), ...(fat.t || [])],
+                instructions: [
+                    `${b.n} nach Packungsanweisung kochen.`,
+                    `${p.n} in ${fat.n} anbraten. ${vegs.map(v => v.n).join(', ')} hinzufügen und mitbraten, bis sie gar sind.`,
+                    `Mit ${selectedSpices.map(s => s.n).join(' und ')}, ${spicesAndHerbs[0].n} und ${spicesAndHerbs[1].n} würzen.`,
+                    `Gekochte ${b.n} und ${sauce.n} zugeben, gut vermengen und kurz erwärmen.`,
+                    `Optional: Mit ${ (getRandom(extras.filter(e => p.vg ? e.vg : p.v ? e.v : e.v===0 && e.vg === 0)) || extras.find(ex => ex.n.includes("Kräuter"))).n} servieren.`
+                ]
+            };
+        }
+    },
+    {
+        name: 'Auflauf',
+        t: ['defty', 'mediterranean'],
+        generate: (targetProteinType) => {
+            let p;
+            if (targetProteinType === 'beef') p = proteins.find(pr => pr.type === 'beef');
+            else if (targetProteinType === 'chicken') p = proteins.find(pr => pr.type === 'chicken');
+            else if (targetProteinType === 'vegetarian') p = getRandom(proteins.filter(pr => pr.v === 1 && pr.vg === 0 && pr.type === 'vegetarian'));
+            else if (targetProteinType === 'vegan') p = getRandom(proteins.filter(pr => pr.vg === 1 && pr.type === 'vegan'));
+            else p = getRandom(proteins);
+
+            const b = getRandom(bases.filter(base => ['Kartoffeln', 'Nudeln', 'Gnocchi', 'Polenta'].includes(base.n)));
+            const vegs = getUniqueRandom(vegetables, Math.random() < 0.4 ? 1 : 2);
+            let sauce = getRandom(saucesAndFats.filter(s => (p.vg ? s.vg : p.v ? s.v : s.v === 0 && s.vg === 0) && (s.n.includes('Tomatensauce') || s.n.includes('Sahnesauce') || s.n.includes('Kokosmilch'))));
+            if (!sauce) sauce = saucesAndFats.find(s => s.n === 'Tomatensauce'); // Fallback sauce
+            const topping = p.vg ? extras.find(e=> e.n.includes('veganem Käse') || e.n.includes('Röstzwiebeln')) || getRandom(extras.filter(e=>e.vg)) : extras[0]; // geriebener Käse or vegan alternative
+            const spiceCount = Math.floor(Math.random() * 2) + 1;
+            const selectedSpices = getUniqueRandom(spicesAndHerbs, spiceCount);
+
+            return {
+                name: `${b.n}-Auflauf mit ${p.n} und ${vegs[0].n}`,
+                ingredients: [p, b, ...vegs, sauce, topping, ...selectedSpices, spicesAndHerbs[0], spicesAndHerbs[1]],
+                cost: 4 + Math.random(),
+                tags: ['für gäste', 'comfort food', ...b.t, ...p.t, ...(sauce && sauce.t ? sauce.t : [])],
+                instructions: [
+                    `${b.n} vorkochen, falls nötig (z.B. Kartoffeln in Scheiben schneiden, Nudeln al dente kochen).`,
+                    `${p.n} anbraten (falls roh). Gemüse klein schneiden.`,
+                    `Alle Zutaten (außer ${topping.n}) in einer Auflaufform mischen. Mit ${selectedSpices.map(s => s.n).join(' und ')}, ${spicesAndHerbs[0].n} und ${spicesAndHerbs[1].n} würzen.`,
+                    `Mit ${sauce.n} übergießen und mit ${topping.n} bestreuen.`,
+                    `Im vorgeheizten Ofen bei 180°C (Umluft) ca. 25-35 Minuten backen, bis der Auflauf goldbraun ist.`
+                ]
+            };
+        }
+    },
+    {
+        name: 'Eintopf',
+        t: ['defty', 'light'],
+        generate: (targetProteinType) => {
+            let p;
+            if (targetProteinType === 'beef') p = proteins.find(pr => pr.type === 'beef');
+            else if (targetProteinType === 'chicken') p = proteins.find(pr => pr.type === 'chicken');
+            else if (targetProteinType === 'vegetarian') p = getRandom(proteins.filter(pr => pr.v === 1 && pr.vg === 0 && pr.type === 'vegetarian' && pr.n !== 'Halloumi' && pr.n !== 'Feta'));
+            else if (targetProteinType === 'vegan') p = getRandom(proteins.filter(pr => pr.vg === 1 && pr.type === 'vegan'));
+            else p = getRandom(proteins.filter(pr => pr.n !== 'Halloumi' && pr.n !== 'Feta'));
+
+
+            const vegs = getUniqueRandom(vegetables.filter(veg => veg.n !== 'Gurke'), Math.random() < 0.3 ? 3: 4);
+            const b = getRandom([bases.find(b=>b.n==='Kartoffeln'), bases.find(b=>b.n==='Bulgur'), bases.find(b=>b.n==='Linsen') || proteins.find(p=>p.n==='Linsen')]); // Linsen can be a base too
+            const liquid = { n: 'Gemüsebrühe', quantity: 500, unit: 'ml', vg:1, v:1 };
+            const fat = getRandom(saucesAndFats.filter(sf => sf.n === 'Olivenöl' || sf.n === 'Butter' || (p.vg && sf.vg)));
+            let ex = getRandom(extras.filter(e => (p.vg ? e.vg : p.v ? e.v : e.v === 0 && e.vg === 0) && (e.n.includes('Kräuter') || e.n.includes('Joghurt') || e.n.includes('Röstzwiebeln')) ));
+            if (!ex) ex = extras.find(e => e.n.includes('Kräuter')); // Fallback extra
+            const spiceCount = Math.floor(Math.random() * 2) + 2; // 2 or 3 spices
+            const selectedSpices = getUniqueRandom(spicesAndHerbs, spiceCount);
+
+            return {
+                name: `${p.n}-Eintopf mit ${vegs[0].n} und ${vegs[1].n}`,
+                ingredients: [p, ...vegs, b, liquid, fat, ex, ...selectedSpices, spicesAndHerbs[0], spicesAndHerbs[1]],
+                cost: 3 + Math.random(),
+                tags: ['günstig', 'resteverwertung', 'herzhaft', ...p.t, ...b.t],
+                instructions: [
+                    `Gemüse waschen und klein schneiden. ${p.n} ggf. würfeln oder vorbereiten.`,
+                    `${p.n} in ${fat.n} in einem großen Topf anbraten. Dann das härtere Gemüse (z.B. ${vegs.filter(v=>v.n==='Karotten'||v.n==='Kartoffeln').map(v=>v.n).join(' oder ') || vegs[0].n}) hinzufügen und kurz mitdünsten.`,
+                    `Restliches Gemüse (${vegs.filter(v=>v.n!=='Karotten'&&v.n!=='Kartoffeln').map(v=>v.n).join(', ') || vegs[1].n}) und ${b.n} (falls nicht vorgekocht) zugeben. Mit ${liquid.n} aufgießen.`,
+                    `Mit ${selectedSpices.map(s => s.n).join(' und ')}, ${spicesAndHerbs[0].n} und ${spicesAndHerbs[1].n} würzen. Aufkochen lassen und dann bei mittlerer Hitze 20-30 Minuten köcheln lassen, bis alle Zutaten gar sind.`,
+                    `Abschmecken und optional mit ${ex.n} servieren.`
+                ]
+            };
+        }
+    },
+    {
+        name: 'Salat',
+        t: ['light', 'mediterranean'],
+        generate: (targetProteinType) => {
+            let p;
+            if (targetProteinType === 'chicken') p = proteins.find(pr => pr.type === 'chicken');
+            // For salads, beef is less common, so we might pick another if beef is requested but not ideal for salad.
+            // Or we ensure there's a "beef salad" protein if desired. For now, let's stick to typical salad proteins.
+            else if (targetProteinType === 'vegetarian') p = getRandom(proteins.filter(pr => pr.v === 1 && pr.vg === 0 && ['Feta', 'Halloumi', 'Eier', 'Kichererbsen'].includes(pr.n)));
+            else if (targetProteinType === 'vegan') p = getRandom(proteins.filter(pr => pr.vg === 1 && ['Tofu', 'Kichererbsen', 'Schwarze Bohnen', 'Linsen'].includes(pr.n)));
+            else p = getRandom(proteins.filter(pr => ['Hähnchenbrust', 'Feta', 'Halloumi', 'Tofu', 'Kichererbsen', 'Linsen'].includes(pr.n)));
+
+
+            const vegs = getUniqueRandom(vegetables.filter(veg => veg.n !== 'Rotkohl' && veg.n !== 'Aubergine' && veg.n !== 'Ingwer'), Math.random() < 0.5 ? 3 : 4); // More veggies for salad
+            const baseSalad = getRandom([bases.find(b=>b.n==='Brot'), {n: 'Blattsalat Mix', quantity:150, unit:'g', t:['light']}]); // Brot for croutons or side
+            const dressing = getRandom(saucesAndFats.filter(s => s.n.includes('Vinaigrette') || (p.vg ? s.vg && s.n.includes('Joghurt') : p.v ? s.v && s.n.includes('Joghurt') : false) || s.n === 'Olivenöl'));
+            const ex = getRandom(extras.filter(e => (p.vg ? e.vg : p.v ? e.v : true) && (e.n.includes('Kräuter') || e.n.includes('Kerne') || e.n.includes('Röstzwiebeln'))));
+            const selectedSpices = [spicesAndHerbs[0], spicesAndHerbs[1]]; // Salt and Pepper usually enough for salad dressing
+
+            return {
+                name: `Bunter Salat mit ${p.n} und ${vegs[0].n}`,
+                ingredients: [p, baseSalad, ...vegs, dressing, ex, ...selectedSpices],
+                cost: 4.5 + Math.random(),
+                tags: ['schnell', 'frisch', 'gesund', ...p.t, ...(dressing.t || [])],
+                instructions: [
+                    `${p.n} vorbereiten (z.B. Hähnchen braten und in Streifen schneiden, Tofu würfeln und anbraten, Halloumi grillen).`,
+                    `Alle Salat Zutaten (${baseSalad.n}, ${vegs.map(v => v.n).join(', ')}) waschen und mundgerecht zerkleinern. In einer großen Schüssel vermengen.`,
+                    `${dressing.n} mit ${selectedSpices.map(s => s.n).join(' und ')} anrühren. Ggf. weitere Kräuter hinzufügen.`,
+                    `Dressing über den Salat geben und gut vermischen. ${p.n} darauf anrichten.`,
+                    `Mit ${ex.n} garnieren und sofort servieren.`
+                ]
+            };
+        }
+    }
+];
+
+console.log("Generiere 1600 vielfältige Rezepte...");
 const allRecipes = [];
-for (let i = 0; i < 1500; i++) {
-    const archetype = getRandom(archetypes);
-    const recipeData = archetype.generate();
-    const ingredients = recipeData.ingredients.map(ing => ({ name: ing.n, quantity: 100 + Math.floor(Math.random() * 150), unit: ing.u || 'g' }));
-    const isVegetarian = recipeData.ingredients.every(ing => ing.v !== 0);
-    const isVegan = recipeData.ingredients.every(ing => ing.vg !== 0);
-    const estimatedCostPerServing = parseFloat((recipeData.cost + (Math.random() - 0.5)).toFixed(2));
-    const tags = new Set(recipeData.tags);
-    recipeData.ingredients.forEach(ing => { if (ing.t) ing.t.forEach(tag => tags.add(tag)); });
-    if (estimatedCostPerServing < 3.0) tags.add('günstig');
-    if (Math.random() < 0.2) tags.add('resteverwertung');
-    if (Math.random() < 0.25) tags.add('für gäste');
-    if (Math.random() < 0.4) tags.add('schnell');
-    allRecipes.push({ id: `rezept-${i + 1}`, name: recipeData.name, description: `Ein leckeres Gericht aus der Kategorie "${archetype.name}". Perfekt für jeden Anlass.`, ingredients, instructions: recipeData.instructions, estimatedCostPerServing, isSimple: Math.random() > 0.3, isVegetarian, isVegan, tags: Array.from(tags).filter(t => t !== 'all') });
+const recipesPerType = 400;
+const proteinTypes = ['beef', 'chicken', 'vegetarian', 'vegan'];
+let recipeCounter = 0;
+
+proteinTypes.forEach(type => {
+    for (let i = 0; i < recipesPerType; i++) {
+        recipeCounter++;
+        let archetype;
+        if (type === 'beef') { // Beef is better for certain archetypes
+            archetype = getRandom(archetypes.filter(a => a.name === 'Pfanne' || a.name === 'Auflauf' || a.name === 'Eintopf'));
+        } else {
+            archetype = getRandom(archetypes);
+        }
+        const recipeData = archetype.generate(type);
+
+        const ingredients = recipeData.ingredients.map(ing => {
+            let quantity, unit;
+            if (ing.quantity && ing.unit) { // Predefined like Salz, Pfeffer, Brühe
+                quantity = ing.quantity;
+                unit = ing.unit;
+            } else if (['Salz', 'Pfeffer'].includes(ing.n)) {
+                quantity = 1; unit = 'Prise';
+            } else if (ing.n.toLowerCase().includes('öl') || ing.n.toLowerCase().includes('butter') || ing.n.toLowerCase().includes('sauce') || ing.n.toLowerCase().includes('pesto')) {
+                quantity = Math.floor(Math.random() * 30) + 20; // 20-50
+                unit = ing.n.toLowerCase().includes('öl') || ing.n.toLowerCase().includes('butter') ? 'g' : 'ml';
+            } else {
+                quantity = 100 + Math.floor(Math.random() * 150); // Default 100-250g
+                unit = 'g';
+            }
+            return { name: ing.n, quantity: quantity, unit: unit };
+        });
+
+        const isVegetarian = recipeData.ingredients.every(ing => ing.v !== 0 || proteins.find(p=>p.n===ing.n)?.v !==0 || saucesAndFats.find(s=>s.n===ing.n)?.v !==0 || spicesAndHerbs.find(s=>s.n===ing.n)?.v !==0 || extras.find(e=>e.n===ing.n)?.v !==0 );
+        const isVegan = recipeData.ingredients.every(ing => ing.vg !== 0 || proteins.find(p=>p.n===ing.n)?.vg !==0 || saucesAndFats.find(s=>s.n===ing.n)?.vg !==0 || spicesAndHerbs.find(s=>s.n===ing.n)?.vg !==0 || extras.find(e=>e.n===ing.n)?.vg !==0);
+
+        // Correct isVegetarian/isVegan based on target type if generation logic had a mismatch (should be rare)
+        let finalIsVegetarian = isVegetarian;
+        let finalIsVegan = isVegan;
+
+        if (type === 'vegan') {
+            finalIsVegan = true;
+            finalIsVegetarian = true;
+        } else if (type === 'vegetarian') {
+            finalIsVegan = false; // Could be vegan, but we are targeting vegetarian specifically
+            finalIsVegetarian = true;
+        } else if (type === 'chicken' || type === 'beef') {
+            finalIsVegan = false;
+            finalIsVegetarian = false;
+        }
+
+
+        const estimatedCostPerServing = parseFloat((recipeData.cost + (Math.random() - 0.5)).toFixed(2));
+        const tags = new Set(recipeData.tags);
+        recipeData.ingredients.forEach(ing => {
+            const item = proteins.find(p=>p.n===ing.n) || bases.find(b=>b.n===ing.n) || vegetables.find(v=>v.n===ing.n) || saucesAndFats.find(s=>s.n===ing.n) || extras.find(e=>e.n===ing.n);
+            if (item && item.t) item.t.forEach(tag => tags.add(tag));
+        });
+
+        if (estimatedCostPerServing < 3.0) tags.add('günstig');
+        if (Math.random() < 0.2) tags.add('resteverwertung');
+        if (archetype.name !== 'Salat' && Math.random() < 0.25) tags.add('für kinder');
+        if (Math.random() < 0.4) tags.add('schnell');
+        if (Math.random() < 0.3) tags.add('einfach');
+
+
+        allRecipes.push({
+            id: `rezept-${recipeCounter}`,
+            name: recipeData.name,
+            description: `Ein ${recipeData.tags.includes('schnell') ? 'schnelles und ' : ''}leckeres ${archetype.name}-Gericht mit ${recipeData.ingredients[0].n}. ${recipeData.tags.includes('für gäste') ? 'Ideal für Gäste oder einen besonderen Anlass.' : 'Perfekt für ein zufriedenstellendes Mittag- oder Abendessen.'}`,
+            ingredients,
+            instructions: recipeData.instructions,
+            estimatedCostPerServing: Math.max(1.5, estimatedCostPerServing), // Ensure cost is not too low
+            isSimple: Math.random() > 0.3,
+            isVegetarian: finalIsVegetarian,
+            isVegan: finalIsVegan,
+            tags: Array.from(tags).filter(t => t !== 'all' && t)
+        });
+    }
+});
+
+// Shuffle recipes for more randomness in the final list if desired
+for (let i = allRecipes.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [allRecipes[i], allRecipes[j]] = [allRecipes[j], allRecipes[i]];
 }
-fs.writeFileSync(path.join(__dirname, 'data', 'recipes.json'), JSON.stringify(allRecipes, null, 2));
+
+
+fs.writeFileSync(path.join(__dirname, '..', 'data', 'recipes.json'), JSON.stringify(allRecipes, null, 2));
 console.log(`Erfolgreich ${allRecipes.length} Rezepte generiert.`);
+console.log(`Verteilung:`);
+console.log(`Rind: ${allRecipes.filter(r => !r.isVegetarian && r.ingredients.some(i => i.name === 'Rinderhack')).length}`);
+console.log(`Huhn: ${allRecipes.filter(r => !r.isVegetarian && r.ingredients.some(i => i.name === 'Hähnchenbrust')).length}`);
+console.log(`Vegetarisch (nicht vegan): ${allRecipes.filter(r => r.isVegetarian && !r.isVegan).length}`);
+console.log(`Vegan: ${allRecipes.filter(r => r.isVegan).length}`);


### PR DESCRIPTION
Modifies the `js/fetch_recipes.js` script to:
- Fetch approximately 80 recipes each for beef, chicken, vegetarian (non-vegan), and vegan categories in English from TheMealDB API.
- Save these recipes directly into `data/recipes.json`, overwriting previous content.

Populates `data/recipes.json` with 72 English recipes based on current API availability for the queries made. This file is intended for further processing (e.g., translation) by the user.

Includes .gitignore to exclude Node.js generated files.