### PR TITLE
Fix: Enable plan confirmation for <7 days and update Vorrat threshold

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -50,7 +50,7 @@ function generateShoppingList(plan, inventory, persons = 1) {
     return shoppingList.sort((a, b) => a.haveAtHome - b.haveAtHome);
 }
 
-function findAlmostCompleteRecipes(allRecipes, inventory, threshold = 0.8) {
+function findAlmostCompleteRecipes(allRecipes, inventory, threshold = 0.55) {
     if (!inventory || inventory.length === 0) return [];
     const inventorySet = new Set(inventory.map(i => i.toLowerCase().trim()));
     const matchedRecipes = allRecipes.map(recipe => {

--- a/js/ui.js
+++ b/js/ui.js
@@ -152,7 +152,7 @@ const ui = (() => {
 
             const resultsDiv = document.createElement('div');
             if (recipes.length === 0) {
-                resultsDiv.innerHTML = '<p>Keine Rezepte gefunden, für die du mindestens 80% der Zutaten hast.</p>';
+                resultsDiv.innerHTML = '<p>Keine Rezepte gefunden, für die du mindestens 55% der Zutaten hast.</p>';
                 if (deleteInventoryRecipesBtn) deleteInventoryRecipesBtn.classList.add('hidden');
             } else {
                 recipes.forEach(recipe => resultsDiv.appendChild(createRecipeCardElement(recipe, onInfoClick)));
@@ -176,7 +176,7 @@ const ui = (() => {
         switchView: (viewId) => { document.querySelectorAll('.view').forEach(v => v.classList.add('hidden')); document.getElementById(viewId).classList.remove('hidden'); },
         updateConfirmButtonState: (plan) => {
             const btn = document.getElementById('confirm-plan-btn');
-            if (!plan || plan.length < 7) { btn.disabled = true; return; }
+            if (!plan || plan.length === 0) { btn.disabled = true; return; }
             btn.disabled = !plan.every(day => day.selected !== null);
         },
         showApp: () => {


### PR DESCRIPTION
- Modifies `js/ui.js` to allow plan confirmation as long as plan.length > 0.
- Modifies `js/logic.js` to change inventory recipe threshold to 55%.
- Modifies `js/ui.js` to update inventory results message to reflect 55%.