### PR TITLE
Fix: Correctly display ingredient names in shopping list

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -192,7 +192,7 @@ const ui = (() => {
                             const displayQuantity = Number.isInteger(item.quantity) ? item.quantity : parseFloat(item.quantity).toFixed(2);
 
                             htmlContent += `<li class="${haveAtHomeClass}">
-                                                <span>${item.originalString}${combinedIcon}</span>
+                                                <span>${item.name}${combinedIcon}</span>
                                                 <div>
                                                     <span class="unit">${displayQuantity} ${item.unit}</span>
                                                     ${atHomeStatus}


### PR DESCRIPTION
The shopping list was attempting to display item.originalString, but the correct property holding the ingredient's display name is item.name. This change updates the renderShoppingList function in js/ui.js to use the correct property, resolving an issue where ingredient names would appear as 'undefined'.