### PR TITLE
Fix: Make ingredient parsing robust to non-string inputs

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -49,6 +49,18 @@ function generateWeeklyPlan(allRecipes, prefs) {
 
 // Helper function to parse ingredient strings
 function parseIngredientString(ingString) {
+    const originalInputString = ingString; // Preserve the original input for originalString
+
+    if (typeof ingString !== 'string') {
+        // Handle non-string inputs gracefully
+        return {
+            originalString: "Fehlerhafter Eintrag", // Placeholder for display
+            quantity: 0,
+            unit: "",
+            name: "Unbekannt" // Parsed name for logic
+        };
+    }
+
     ingString = ingString.trim();
     let quantity = 1;
     let unit = 'Stk.'; // Default unit, especially for items like "1 Apfel"
@@ -156,7 +168,7 @@ function parseIngredientString(ingString) {
     // if (!normalizedName) normalizedName = name; // if stripping parentheses removes everything
 
     return {
-        originalString: ingString,
+        originalString: originalInputString, // Return the original, unmodified input string
         quantity: quantity,
         unit: unit,
         name: name // Use the potentially more complex name for matching logic for now


### PR DESCRIPTION
Previously, if a non-string value was encountered in a recipe's ingredient list, it could lead to 'undefined' being displayed for the ingredient name in the shopping list.

This commit modifies the `parseIngredientString` function in `js/logic.js` to check for non-string inputs. If such an input is detected, it now returns a default ingredient object with placeholder values (e.g., 'Fehlerhafter Eintrag' for the name). This prevents potential TypeErrors during parsing and ensures a more user-friendly display in case of corrupted or unexpected ingredient data.

The function also now ensures that for valid string inputs, the `originalString` property in the returned object is the exact string passed to the function, preserving any original formatting or details for display purposes.