### PR TITLE
Add script to scale recipe portions and generate JSON files

### DIFF
--- a/data/recipes_2.json
+++ b/data/recipes_2.json
@@ -1,0 +1,3466 @@
+[
+  {
+    "title": "Reispfanne mit Pilzen und Frühlingszwiebeln",
+    "tags": [
+      "Vegetarisch",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "639 kcal",
+      "Kohlenhydrate": "104,7 g",
+      "Fett": "17 g",
+      "Eiweiß": "19,3 g"
+    },
+    "ingredients": [
+      "250 g Naturreis",
+      "Salz",
+      "1 Knoblauchzehen",
+      "250 g Champignons (braun)",
+      "0,5 Bd . Frühlingszwiebeln",
+      "2 EL Olivenöl",
+      "25 g Parmesan",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Reis in Salzwasser 25 bis 30 Minuten gar kochen.",
+      "Knoblauch schälen und in dünne Scheiben schneiden. Champignons putzen, säubern und längs vierteln.",
+      "Frühlingszwiebeln waschen, putzen und schräg in ca. 1 cm lange Stücke schneiden - das Weiße vom Grünen getrennt.",
+      "3 EL Olivenöl in der Pfanne erhitzen, Knoblauch 2 Minuten darin anbraten und herausnehmen.",
+      "Champignons in die Pfanne geben und ca. 5 Minuten scharf anbraten. Die weißen Frühlingszwiebel-Ringe dazugeben und weitere 5 Minuten anbraten.",
+      "Reis zu den Champignons geben. Das Grüne von den Frühlingszwiebeln und den Knoblauch dazugeben. Umrühren und 1 EL Olivenöl darüber träufeln. Parmesan darüber reiben und mit Pfeffer würzen."
+    ],
+    "id": "rec_1"
+  },
+  {
+    "title": "One Pot Gnocchi mit Buttergemüse",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "701 kcal",
+      "Kohlenhydrate": "99,9 g",
+      "Fett": "28,6 g",
+      "Eiweiß": "14,8 g"
+    },
+    "ingredients": [
+      "2 Zwiebeln",
+      "1 EL Rapsöl",
+      "400 g Gnocchi (Kühlregal)",
+      "1 Pck . ja! Buttergemüse (TK, à 300 g)",
+      "200 ml Gemüsebrühe",
+      "100 g Crème fraîche",
+      "5 g Schnittlauch"
+    ],
+    "instructions": [
+      "Zwiebeln schälen und hacken. Öl in einem Topf erhitzen und die Zwiebeln anschwitzen.",
+      "Gnocchi und TK-Gemüse zufügen. Kurz anschwitzen, dann Gemüsebrühe sowie Crème fraîche zufügen und 5-7 Minuten köcheln, bis das Gemüse weich ist.",
+      "Schnittlauch waschen, trocken schütteln und in Röllchen schneiden. Über die Gnocchi streuen und servieren."
+    ],
+    "id": "rec_2"
+  },
+  {
+    "title": "Rösti-Auflauf mit versunkenen Spiegeleiern",
+    "tags": [
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "513 kcal",
+      "Kohlenhydrate": "39,6 g",
+      "Fett": "25,7 g",
+      "Eiweiß": "30,5 g"
+    },
+    "ingredients": [
+      "400 g Kartoffeln (festkochend)",
+      "0,5 rote Zwiebel",
+      "50 g Schinkenwürfel",
+      "0,5 TL Butter",
+      "90 g Reibekäse",
+      "0,5 EL Senf",
+      "115 g Joghurt",
+      "Salz",
+      "Pfeffer",
+      "Paprikapulver",
+      "2 Eier",
+      "0,5 Bd . Schnittlauch"
+    ],
+    "instructions": [
+      "Die Kartoffeln schälen und auf einer groben Reibe raspeln. Kartoffelraspel portionsweise in die Hand nehmen und ausdrücken, sodass die Flüssigkeit abtropfen kann. Auf Küchenpapier ausbreiten.",
+      "Eine Kasserolle bereitstellen, den Backofen auf 200 Grad Ober-/Unterhitze vorheizen.",
+      "Die Zwiebel schälen und fein würfeln, mit den Schinkenwürfeln vermischen. Butter in einer Pfanne schmelzen, Zwiebel-Schinken-Mix darin kurz anbraten.",
+      "Aus Käse, Senf und Joghurt eine Soße anrühren und mit den Zwiebeln, den Kartoffeln und dem Schinken vermengen. Alles mit Salz, Pfeffer und Paprikapulver würzen und in die Kasserolle geben.",
+      "Kasserolle auf mittlerer Schiene auf einem Rost in den Ofen schieben und in ca. 45 Minuten ohne Deckel backen. Auflauf aus dem Ofen nehmen und mit Hilfe eines Esslöffels vier Mulden hineindrücken. In jede Mulde ein Ei schlagen, Auflauf zurück in den Ofen schieben und bis zum gewünschten Gargrad der Eier zu Ende backen.",
+      "Mit Schnittlauch bestreuen und in der Kasserolle servieren."
+    ],
+    "id": "rec_3"
+  },
+  {
+    "title": "Schneller Paprika-Tofu-Reis",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Fettarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "496 kcal",
+      "Kohlenhydrate": "80,1 g",
+      "Fett": "12,5 g",
+      "Eiweiß": "19,7 g"
+    },
+    "ingredients": [
+      "1 Zwiebeln",
+      "1 Knoblauchzehen",
+      "1 rote Paprikaschoten",
+      "1 gelbe Paprikaschoten",
+      "125 g Basilikum-Tofu",
+      "1,5 EL Öl",
+      "1,5 TL Rosenpaprika scharf",
+      "Salz",
+      "Zucker",
+      "125 g 10-Minuten-Reis",
+      "1 Dose(n) stückige Tomaten (à 425 g)",
+      "200 ml Gemüsebrühe",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Zwiebeln und Knoblauch schälen und fein würfeln. Paprikaschoten vierteln, entkernen und waschen. Paprikaschoten in ca. 2 cm große Stücke schneiden. Tofu in ca. 3 cm große Stücke schneiden.",
+      "Öl in einer großen Pfanne erhitzen, Tofu darin bei starker Hitze rundherum anbraten. Zwiebeln, Knoblauch und Paprikastücke zugeben und ca. 2 Minuten mitbraten. Mit Paprikapulver, Salz und 1 Prise Zucker würzen.",
+      "Reis, stückige Tomaten und Brühe zugeben. Alles aufkochen und zugedeckt 10 Min. garen. Mit Salz und Pfeffer abschmecken."
+    ],
+    "id": "rec_4"
+  },
+  {
+    "title": "Hack-Reis-Pfanne",
+    "tags": [
+      "Laktosefrei",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "508 kcal",
+      "Kohlenhydrate": "33,4 g",
+      "Fett": "30,1 g",
+      "Eiweiß": "27,4 g"
+    },
+    "ingredients": [
+      "62,5 g ja! Langkorn-Spitzenreis",
+      "ja! Jodsalz",
+      "1 rote Paprikaschoten",
+      "0,5 Salatgurke",
+      "1 Lauchzwiebeln",
+      "1,5 EL ja! Sonnenblumenöl",
+      "0,5 EL Weißweinessig",
+      "Pfeffer",
+      "0,5 TL Zucker",
+      "250 g ja! gemischtes Hackfleisch"
+    ],
+    "instructions": [
+      "Reis in kochendem Salzwasser nach Packungsanweisung zubereiten. Paprika putzen, waschen, entkernen und in Streifen schneiden. Gurke putzen, waschen und fein würfeln. Lauchzwiebeln putzen, waschen und in feine Ringe schneiden. Gurke, Lauchzwiebeln, 1 EL ÖL und Essig mischen. Mit Salz, Pfeffer und Zucker würzen.",
+      "2 EL Öl in einer Pfanne erhitzen. Hack darin krümelig braten. Mit Salz und Pfeffer würzen. Paprikastreifen zugeben, andünsten. Reis abgießen und zur Hackpfanne geben. Mit Salz und Pfeffer würzen. Hack-Reis-Pfanne anrichten. 2 EL Gurken- Lauchzwiebel-Mischung darüber streuen. Übrige Gurken-Lauchzwiebel-Mischung in einem Schälchen dazu reichen."
+    ],
+    "id": "rec_5"
+  },
+  {
+    "title": "Spaghetti mit Linsenbolognese",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "499 kcal",
+      "Kohlenhydrate": "86,6 g",
+      "Fett": "9,6 g",
+      "Eiweiß": "22,1 g"
+    },
+    "ingredients": [
+      "0,5 Zwiebel",
+      "100 g Möhren",
+      "50 g Staudensellerie",
+      "0,5 Zehe(n) Knoblauch",
+      "1 EL Olivenöl",
+      "75 g Rote Linsen",
+      "0,5 EL Tomatenmark",
+      "100 ml Gemüsebrühe",
+      "125 g Pizza-Tomaten",
+      "Salz",
+      "Pfeffer",
+      "160 g Vollkornspaghetti",
+      "7,5 g Basilikum"
+    ],
+    "instructions": [
+      "Zwiebel schälen und fein würfeln. Möhren schälen, Sellerie waschen und putzen und beides in kleine Würfel schneiden. Knoblauch schälen und fein hacken. Öl in einem Topf leicht erhitzen und Zwiebelwürfel darin andünsten. Möhren, Sellerie und Knoblauch zugeben und ca. 2 Minuten mit anschwitzen.",
+      "Linsen zugeben, Tomatenmark einrühren und kurz anrösten. Mit Brühe und Tomaten ablöschen und ca. 10 Minuten köcheln lassen. Mit Salz und Pfeffer abschmecken.",
+      "Vollkornspaghetti nach Packungsanweisung in Salzwasser kochen. Basilikum waschen, trocken schütteln. Spaghetti mit Linsenbolognese und Basilikumblättern servieren."
+    ],
+    "id": "rec_6"
+  },
+  {
+    "title": "Yum Yum Salat",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "561 kcal",
+      "Kohlenhydrate": "47,7 g",
+      "Fett": "35,3 g",
+      "Eiweiß": "18,2 g"
+    },
+    "ingredients": [
+      "40 ml Öl",
+      "2 EL Essig (hell)",
+      "1 EL Honig",
+      "0,5 TL Salz",
+      "0,5 TL Pfeffer",
+      "1 Pck . asiatische Instant Nudeln (Yum Yum, mit Gewürzmischung)",
+      "30 g Sonnenblumenkerne",
+      "50 g Erdnüsse",
+      "0,5 Chinakohl"
+    ],
+    "instructions": [
+      "In einer großen Schüssel Öl, Essig, Honig, Salz und Pfeffer miteinander verrühren. Die Gewürzmischung aus den Nudelpackungen ebenfalls unterrühren.",
+      "Die Nudeln zerbröseln und in das Dressing geben. Vorsichtig vermengen und 10 Minuten ziehen lassen.",
+      "Währenddessen die Sonnenblumenkerne und Erdnüsse in einer Pfanne ohne Fett bei mittlerer Temperatur anrösten. Die Pfanne dabei mehrmals rütteln, damit die Kerne von allen Seiten bräunen. Den Chinakohl in feine Streifen schneiden.",
+      "Chinakohl und geröstete Kerne in die Schüssel zu Nudeln und Dressing geben, den Salat gut durchmischen und servieren."
+    ],
+    "id": "rec_7"
+  },
+  {
+    "title": "Schnelle Gemüsesuppe mit weißen Bohnen",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "335 kcal",
+      "Kohlenhydrate": "53,4 g",
+      "Fett": "9 g",
+      "Eiweiß": "17,3 g"
+    },
+    "ingredients": [
+      "0,5 kleine Zwiebel",
+      "1 Karotten",
+      "1 Stange(n) Sellerie",
+      "0,5 Stange(n) Lauch",
+      "1 Zehe(n) Knoblauch",
+      "0,5 TL Olivenöl",
+      "1,5 EL Tomatenmark",
+      "225 g weiße Bohnen (Dose)",
+      "0,5 Dose(n) stückige Tomaten (400 g)",
+      "0,7 l Gemüsebrühe (glutenfrei)",
+      "0,5 Zweig(e) Thymian",
+      "Salz",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Zwiebeln und Karotten schälen und fein würfeln, Sellerie und Lauch putzen und in feine Stücke bzw. Ringe schneiden, Knoblauch schälen und fein hacken.",
+      "Das Olivenöl in einem großen Suppentopf erhitzen, die Zwiebel anbraten, die Karotten dazu geben, dann Sellerie, Lauch und Knoblauch. Kurz weiterbraten, dann das Tomatenmark einrühren.",
+      "Die Bohnen zusammen mit den Tomatenstücken dazu geben, mit der Brühe aufgießen, den Thymian dazu geben, dann 15 Minuten köcheln lassen. Thymianzweig rausnehmen. Mit Salz und Pfeffer abschmecken und in Schälchen servieren."
+    ],
+    "id": "rec_8"
+  },
+  {
+    "title": "Schales mit Rettich: saarländischer Kartoffelkuchen",
+    "tags": [
+      "Laktosefrei",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "483 kcal",
+      "Kohlenhydrate": "58,1 g",
+      "Fett": "17,4 g",
+      "Eiweiß": "24,9 g"
+    },
+    "ingredients": [
+      "0,5 kg Kartoffeln, vorwiegend festkochend",
+      "Salz",
+      "0,5 Stange(n) Lauch",
+      "125 g Speckwürfel",
+      "1 Eier",
+      "Pfeffer",
+      "0,5 Msp . Muskatnuss",
+      "neutrales Öl",
+      "0,5 Rettich",
+      "0,5 Bd . Petersilie",
+      "0,5 EL Zitronensaft",
+      "0,5 EL Honig"
+    ],
+    "instructions": [
+      "Kartoffeln waschen, schälen und fein reiben. Geriebene Kartoffeln salzen und kurz ziehen lassen. Lauch halbieren, waschen und in feine Streifen schneiden.",
+      "Eine mittelgroße Pfanne erhitzen und zunächst die Speckwürfel darin für etwa 5 Minuten braten. Dann Lauch dazugeben und 2 bis 3 Min. mitbraten.",
+      "Kartoffeln gut ausdrücken und das Wasser abschütten. Lauch und Speckwürfel mit den Eiern unter die geriebenen Kartoffeln mischen. Mit Salz, Pfeffer und Muskatnuss abschmecken.",
+      "Backofen vorheizen (180 °C, Ober- und Unterhitze). Eine Springform mit neutralem Öl fetten. Den rohen Kartoffelteig darin verteilen und leicht andrücken. Für 1,5 bis 2 Stunden goldbraun backen.",
+      "In der Zwischenzeit den Rettich schälen. Dann mit dem Spiralschneider oder Sparschäler in feine Streifen schneiden. Petersilie waschen, trocken schütteln und grob hacken. Mit Zitronensaft, Honig und Rettich mischen. Mit Salz und Pfeffer würzen.",
+      "Schales nach dem Backen etwa 15 Minuten abkühlen lassen, aus der Springform lösen und auf einer Platte anrichten. Dazu den Rettich servieren."
+    ],
+    "id": "rec_9"
+  },
+  {
+    "title": "Flammkuchen mit Kartoffeln und Rosmarin",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "912 kcal",
+      "Kohlenhydrate": "165,7 g",
+      "Fett": "15,7 g",
+      "Eiweiß": "34,2 g"
+    },
+    "ingredients": [
+      "350 g Dinkel-Vollkornmehl",
+      "30 g Hefewürfel",
+      "250 ml fettarme H-Milch",
+      "1 TL Olivenöl",
+      "Salz",
+      "200 g Speisekartoffeln Drillinge (z. B. von )",
+      "3 EL Schmand",
+      "3 Zweig(e) Rosmarin",
+      "Tellicherry-Pfeffer Mühle (z. B. von Feine Welt)",
+      "2 EL Honig"
+    ],
+    "instructions": [
+      "Dinkelvollkornmehl in eine Schüssel sieben. In die Mitte eine Mulde drücken. Backhefe hineinbröseln. H-Milch in einem Topf oder in der Mikrowelle kurz erwärmen. Lauwarme H-Milch, Olivenöl und etwas Salz in die Mulde geben. Teig so lange kneten, bis er sich vom Schüsselrand löst und elastisch auseinanderziehen lässt. Ist der Teig noch zu klebrig, noch etwas Dinkelmehl zufügen. Mit einem feucht-warmen Handtuch abdecken und an einem warmen Ort für 30 Minuten gehen lassen. Teig erneut kneten. Auf einem Stück Backpapier ausrollen.",
+      "Speisekartoffeln waschen und 20 Minuten in Salzwasser kochen. Backofen auf 220°C Ober-/Unterhitze vorheizen.",
+      "Grundteig auf ein Backpapier ausrollen. Mit Schmand bestreichen. Rosmarinnadeln abzupfen und grob hacken. Speisekartoffeln nach Belieben geschält oder ungeschält in Scheiben schneiden und auf dem Teig verteilen. Mit den gehackten Rosmarinnadeln bestreuen. Mit Pfeffer und Salz würzen.",
+      "Den fertig belegten Flammkuchen im Backofen auf der untersten Schiene 12 bis 15 Minuten goldbraun backen. Honig über den Kartoffeln verteilen und servieren."
+    ],
+    "id": "rec_10"
+  },
+  {
+    "title": "Mediterrane Reis-Gemüse-Pfanne mit Hackfleisch",
+    "tags": [
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "752 kcal",
+      "Kohlenhydrate": "50 g",
+      "Fett": "45,1 g",
+      "Eiweiß": "38 g"
+    },
+    "ingredients": [
+      "100 g Reis",
+      "Salz",
+      "1,5 Paprikaschoten",
+      "0,5 Zucchini",
+      "1 Knoblauchzehen",
+      "100 g Schafskäse",
+      "1 EL Olivenöl",
+      "250 g gemischtes Hackfleisch",
+      "0,5 EL Tomatenmark",
+      "100 ml Gemüsebrühe",
+      "62,5 g grüne Oliven",
+      "Pfeffer",
+      "Paprikapulver rosenscharf"
+    ],
+    "instructions": [
+      "Reis nach Packungsanweisung in Salzwasser garen.",
+      "Paprika waschen, Kerne entfernen und in Würfel schneiden. Zucchini waschen und würfeln. Knoblauch schälen und fein hacken. Schafskäse abtropfen lassen und zerbröseln.",
+      "Öl in einer Pfanne erhitzen, Hackfleisch anschwítzen. Tomatenmark, Knoblauch, Paprika und Zucchini zugeben und anbraten. Mit Brühe ablöschen und einige Minuten köcheln lassen, bis Hackfleisch und Gemüse gar sind.",
+      "Reis abtropfen lassen und unter das Hackfleisch mengen. Oliven abtropfen lassen und zusammen mit dem Schafskäse unterheben. Mit Salz, Pfeffer und Paprikapulver abschmecken."
+    ],
+    "id": "rec_11"
+  },
+  {
+    "title": "Rote Linsensuppe mit Feta-Topping",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "303 kcal",
+      "Kohlenhydrate": "38,9 g",
+      "Fett": "10,1 g",
+      "Eiweiß": "17,7 g"
+    },
+    "ingredients": [
+      "1 Zwiebeln",
+      "0,5 EL Bratöl",
+      "0,5 EL Kreuzkümmel",
+      "0,5 EL Currypulver",
+      "100 g Rote Linsen",
+      "200 ml Gemüsebrühe",
+      "0,5 Dose(n) Tomaten in Stücken (280 g)",
+      "Salz",
+      "Pfeffer",
+      "0,5 Zitrone",
+      "50 g Feta"
+    ],
+    "instructions": [
+      "Zwiebeln schälen und klein schneiden.",
+      "Öl erhitzen und die Zwiebeln anschwitzen. Kreuzkümmel, Curry und Linsen zugeben und kurz mit anschwitzen. Mit angerührter Brühe und Tomaten ablöschen. Zugedeckt bei schwacher bis mittlerer Hitze ca. 15 Minuten köcheln, bis die Linsen weich sind.",
+      "Linsensuppe pürieren, mit Salz, Pfeffer und Zitronensaft abschmecken.",
+      "Feta zerbröseln und die Suppe mit Fetabröseln servieren."
+    ],
+    "id": "rec_12"
+  },
+  {
+    "title": "Überbackene Pfannkuchenrollen",
+    "tags": [],
+    "difficulty": "Mittel",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "634 kcal",
+      "Kohlenhydrate": "82,5 g",
+      "Fett": "22,7 g",
+      "Eiweiß": "24,7 g"
+    },
+    "ingredients": [
+      "150 g ja! Weizenmehl",
+      "250 ml ja! fettarme H-Milch",
+      "1,5 Eier (Größe M)",
+      "ja! Jodsalz",
+      "2 EL ja! Markenbutter",
+      "1 kleine Zucchini",
+      "100 g ja! Delikatess Kochschinken",
+      "0,5 Dose(n) gehackte Tomaten",
+      "Pfeffer",
+      "50 g ja! geriebener Gratin- und Pizzakäse"
+    ],
+    "instructions": [
+      "Mehl, Milch und Eier zu einem glatten Pfannkuchenteig verrühren. Mit Salz würzen. Butter portionsweise in einer Pfanne erhitzen. Nacheinander ca. 8-10 dünne Pfannkuchen aus dem Teig backen.",
+      "Backofen auf 150°C Umluft vorheizen. Zucchini waschen, putzen und mit einem Sparschäler in dünne Streifen schneiden. Pfannkuchen mit Zucchinischeiben und Schinken belegen, aufrollen und in jeweils 3-4 Rollen schneiden.",
+      "Dosentomaten mit Salz und Pfeffer würzen, in einer Auflaufform verteilen. Pfannkuchenröllchen in die Tomatensoße setzen, mit Käse bestreuen und im vorgeheizten Backofen ca. 20 Minuten gratinieren."
+    ],
+    "id": "rec_13"
+  },
+  {
+    "title": "Kartoffel-Möhren-Stampf mit Fischstäbchen",
+    "tags": [
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "319 kcal",
+      "Kohlenhydrate": "39,2 g",
+      "Fett": "13,7 g",
+      "Eiweiß": "11,5 g"
+    },
+    "ingredients": [
+      "300 g Kartoffeln",
+      "200 g Möhren",
+      "150 ml Gemüsebrühe",
+      "50 ml Milch",
+      "Salz",
+      "Pfeffer",
+      "Muskatnuss",
+      "Petersilie",
+      "4 Fischstäbchen",
+      "0,5 EL Rapsöl"
+    ],
+    "instructions": [
+      "Kartoffeln waschen, schälen und in kleine Stücke schneiden. Möhren schälen und in Scheiben schneiden.",
+      "Kartoffeln und Möhren in einem Topf mit Gemüsebrühe gar kochen. Abgießen und zusammen mit der Milch stampfen. Mit Salz, Pfeffer und Muskat abschmecken.",
+      "Petersilie waschen, trocken schütteln, fein hacken und über den Kartoffel-Möhren-Stampf streuen.",
+      "Fischstäbchen in etwas Öl goldbraun braten und zusammen mit dem Kartoffel-Möhren-Stampf anrichten."
+    ],
+    "id": "rec_14"
+  },
+  {
+    "title": "One Pot Pasta mit Spinat",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "628 kcal",
+      "Kohlenhydrate": "81,7 g",
+      "Fett": "25,3 g",
+      "Eiweiß": "21,5 g"
+    },
+    "ingredients": [
+      "1 Zwiebeln",
+      "0,5 Pck . ja! Rahmspinat (450 g)",
+      "200 g ja! Spaghetti",
+      "400 ml ja! Gemüsebrühe",
+      "100 ml ja! Schlagsahne",
+      "25 g Parmesan"
+    ],
+    "instructions": [
+      "Zwiebeln schälen und hacken. Zusammen mit dem gefrorenen Spinat und den Spaghetti in einen großen Topf geben.",
+      "Gemüsebrühe und Sahne zugießen und mit geschlossenem Deckel aufkochen. Nach dem Aufkochen Deckel entfernen und die Nudeln bei schwacher bis mäßiger Hitze ca. 10 Minuten köcheln, bis sie gar sind. Zwischendurch umrühren, ggf. noch etwas Wasser zufügen.",
+      "Mit Parmesan bestreuen und servieren."
+    ],
+    "id": "rec_15"
+  },
+  {
+    "title": "Penne mit Erbsen-Schinken-Sahne-Sauce",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "726 kcal",
+      "Kohlenhydrate": "107 g",
+      "Fett": "20,6 g",
+      "Eiweiß": "31,7 g"
+    },
+    "ingredients": [
+      "100 g ja! TK-Erbsen",
+      "250 g Penne",
+      "Salz",
+      "0,5 Zwiebel",
+      "0,5 Zehe(n) Knoblauch",
+      "100 g gekochter Schinken",
+      "1 EL Rapsöl",
+      "50 ml Gemüsebrühe",
+      "75 ml Sahne",
+      "Pfeffer",
+      "0,25 Zitrone"
+    ],
+    "instructions": [
+      "Erbsen auftauen lassen. Penne nach Packungsanweisung in Salzwasser gar kochen und abtropfen lassen.",
+      "In der Zwischenzeit Zwiebel und Knoblauch schälen und fein hacken. Schinken in kleine Stücke schneiden.",
+      "Öl in einer großen Pfanne erhitzen und Zwiebel und Knoblauch darin andünsten. Nun Schinken dazugeben und mitbraten. Salzen und Pfeffern. Gemüsebrühe und Sahne angießen und Erbsen ebenfalls untermischen. Etwas einköcheln lassen. Falls die Sauce zu dünn ist, ggf. mit 1 TL Mehl abbinden. Dafür das Mehl mit einem Schneebesen einrühren.",
+      "Zitronenhälfte auspressen und mit 1 TL Zitronensaft und Salz und Pfeffer abschmecken. Penne unterheben und servieren."
+    ],
+    "id": "rec_16"
+  },
+  {
+    "title": "Kartoffel-Gemüse-Pfanne",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "395 kcal",
+      "Kohlenhydrate": "55,4 g",
+      "Fett": "15,9 g",
+      "Eiweiß": "11,9 g"
+    },
+    "ingredients": [
+      "400 g Drillings Kartoffeln",
+      "2 Zehe(n) Knoblauch",
+      "3 rote Zwiebeln",
+      "250 g braune Champignons",
+      "1 grüne Paprika",
+      "3 Möhren",
+      "2 Zweig(e) Rosmarin",
+      "2 Zweig(e) Thymian",
+      "15 g Petersilie",
+      "Salz",
+      "3 EL Olivenöl",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Kartoffeln waschen und halbieren. Knoblauch und Zwiebeln abziehen. Knoblauch fein hacken, Zwiebeln vierteln. Champignons putzen und vierteln. Paprika entkernen und in Streifen schneiden.",
+      "Möhren waschen, schälen und schräg in dünne Scheiben schneiden. Kräuter waschen und trocken schütteln. Rosmarin und Thymianblättchen von den Stielen streifen und grob hacken.",
+      "Salzwasser in einem Topf zum Kochen bringen und Kartoffeln etwa 10 Minuten vorgaren. Wasser abgießen.",
+      "Olivenöl in einer Pfanne erhitzen. Erst Knoblauch und Zwiebeln glasig andünsten. Restliches Gemüse und Kartoffeln zufügen und etwa 5 anbraten. Kräuter hinzufügen und ca. 3 Minuten mitbraten. Mit Salz und Pfeffer abschmecken."
+    ],
+    "id": "rec_17"
+  },
+  {
+    "title": "Blumenkohlauflauf Mac ‘n‘ Cheese",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "721 kcal",
+      "Kohlenhydrate": "82,9 g",
+      "Fett": "31,5 g",
+      "Eiweiß": "29,5 g"
+    },
+    "ingredients": [
+      "200 g ja! Penne",
+      "150 g ja! Blumenkohl (TK)",
+      "0,5 Zehe(n) Knoblauch",
+      "1 EL ja! Butter",
+      "0,5 EL ja! Weizenmehl (Type 405)",
+      "100 ml ja! Vollmilch",
+      "50 g ja! Schlagsahne",
+      "ja! Salz",
+      "ja! Pfeffer",
+      "0,5 TL ja! Paprikapulver edelsüß",
+      "100 g ja! Cheddar"
+    ],
+    "instructions": [
+      "Penne laut Packungsanleitung zubereiten und ca. 3 Minuten vor Ende der Garzeit den gefrorenen Blumenkohl dazugeben.",
+      "Knoblauch schälen. In einem großen Topf die Butter bei kleiner Temperatur schmelzen und den Knoblauch, durch eine Knoblauchpresse gedrückt, dazugeben. Wenige Minuten andünsten. Das Mehl einrühren. Dann unter ständigem Rühren Milch und Sahne unterrühren. Einmal kurz aufkochen lassen und dann mit Salz, Pfeffer und Paprikapulver abschmecken. Die Soße bei niedriger Hitze köcheln lassen, bis sie leicht eindickt.",
+      "Backofen auf 180 °C Ober- und Unterhitze vorheizen. Eine Auflaufform (38 x 26 cm) mit etwas Butter einreiben.",
+      "Den Cheddar in kleine Würfel schneiden und die Hälfte vom Cheddar (100 g) in die Soße rühren.",
+      "Pasta und Blumenkohl in einem Sieb über der Spüle abtropfen lassen und in die Auflaufform geben. Die Soße gleichmäßig darauf verteilen und alles einmal gut durchmischen. Den restlichen Cheddar auf dem Auflauf verteilen.",
+      "Den Blumenkohlauflauf Mac ‘n‘ Cheese im Backofen ca. 20 Minuten backen, bis der Käse goldbraun ist."
+    ],
+    "id": "rec_18"
+  },
+  {
+    "title": "Schnelle Tomaten-One-Pot-Pasta",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "782 kcal",
+      "Kohlenhydrate": "108 g",
+      "Fett": "27,4 g",
+      "Eiweiß": "29,3 g"
+    },
+    "ingredients": [
+      "400 ml ja! Tomatencremesuppe",
+      "250 g Penne Mezzane Rigate",
+      "50 g Getrocknete Tomaten in Öl",
+      "0,5 TL Knoblauchpulver",
+      "Pfeffer",
+      "Salz",
+      "1 ja ! Mozzarella"
+    ],
+    "instructions": [
+      "Tomatencremesuppe, 750 ml Wasser und Penne in einen Topf geben, erhitzen und für 15 Minuten köcheln lassen, bis die Penne al dente sind.",
+      "3 Minuten vor Ende der Garzeit die getrockneten Tomaten würfeln und mit 1 TL Öl zur Pasta geben. Mit Knoblauchpulver, Pfeffer und Salz abschmecken.",
+      "Mozzarella in Stücke zupfen und unter die Pasta heben."
+    ],
+    "id": "rec_19"
+  },
+  {
+    "title": "Einfaches Risi Bisi",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "600 kcal",
+      "Kohlenhydrate": "111,8 g",
+      "Fett": "11,3 g",
+      "Eiweiß": "15,1 g"
+    },
+    "ingredients": [
+      "150 g Ja! TK-Erbsen",
+      "240 g Ja! Langkorn-Reis",
+      "0,5 mittlere Zwiebel",
+      "0,5 Zehe(n) Knoblauch",
+      "0,25 Bd . frische Petersilie",
+      "0,5 Kopfsalat",
+      "2 EL Rapsöl",
+      "1 EL Essig",
+      "0,5 TL Senf",
+      "Salz",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Erbsen auftauen lassen. Reis mit der doppelten Menge Salzwasser aufkochen lassen. Bei schwacher Hitze so lange quellen lassen, bis die Flüssigkeit aufgesogen und der Reis gar ist.",
+      "In der Zwischenzeit Zwiebel und Knoblauch schälen und beides fein hacken. Petersilie waschen und ebenfalls hacken.",
+      "Salat waschen, trocknen und in Stücke zupfen. Aus 3 EL Öl, Essig, Senf, Salz und Pfeffer das Dressing zubereiten und unter die Salatblätter mischen.",
+      "Restliches Öl in einer Pfanne erhitzen und die Zwiebel andünsten, dann Knoblauch hinzufügen und kurz mitbraten. Erbsen und kurze Zeit später Reis und Petersilie unterrühren und gut mischen. Mit Salz und Pfeffer würzen.",
+      "Risi Bisi auf Teller verteilen und mit dem Salat servieren."
+    ],
+    "id": "rec_20"
+  },
+  {
+    "title": "Vollkorn-Spaghetti mit Cherrytomaten aus dem Ofen",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "654 kcal",
+      "Kohlenhydrate": "104 g",
+      "Fett": "21,3 g",
+      "Eiweiß": "19,3 g"
+    },
+    "ingredients": [
+      "0,5 kg Cherry-Rispentomaten",
+      "0,13 Knolle(n) Knoblauch",
+      "7,5 g Rosmarin",
+      "37,5 ml Olivenöl",
+      "Salz",
+      "0,25 TL Pfeffer",
+      "1 EL Aceto Balsamico",
+      "Zucker",
+      "250 g Vollkorn-Spaghetti"
+    ],
+    "instructions": [
+      "Backofen auf 200 °C Umluft vorheizen.",
+      "Cherrytomaten waschen und trocknen. 4 schöne Rispen intakt lassen und die restlichen Tomaten abzupfen.",
+      "Knoblauch schälen. Rosmarin waschen.",
+      "Olivenöl mit Salz, Pfeffer, Aceto Balsamico und Zucker verrühren. Tomaten, Knoblauch und Rosmarin hinzufügen und gut mischen.",
+      "Tomaten, Knoblauch und Kräuter in einer einzelnen Lage in eine große Auflaufform geben und im Ofen 25 Minuten backen.",
+      "Spaghetti in Salzwasser nach Packungsanweisung garen.",
+      "Spaghetti sofort mit den gebackenen Cherrytomaten sowie dem Sud vermischen. Mit den Rispen garnieren und servieren."
+    ],
+    "id": "rec_21"
+  },
+  {
+    "title": "Bandnudeln mit Butternut-Kürbis",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "609 kcal",
+      "Kohlenhydrate": "104 g",
+      "Fett": "15,6 g",
+      "Eiweiß": "19,1 g"
+    },
+    "ingredients": [
+      "0,5 Kürbis (600 g, Butternut oder Hokkaido)",
+      "0,5 Zwiebel",
+      "0,5 Zehe(n) Knoblauch",
+      "1 Zweig(e) Thymian",
+      "1 EL Olivenöl",
+      "150 ml Gemüsebrühe",
+      "Salz",
+      "Pfeffer",
+      "Cayennepfeffer",
+      "200 g Bandnudeln",
+      "25 g Walnüsse"
+    ],
+    "instructions": [
+      "Kürbis halbieren, Kerne entfernen und schälen, dann klein würfeln. Zwiebel und Knoblauch schälen und fein hacken. Thymianblättchen ebenfalls fein hacken.",
+      "Öl erhitzen und die Zwiebel anschwitzen. Kürbis und Knoblauch zufügen und kurz mitbraten, dann mit der Gemüsebrühe ablöschen und ca. 15 Minuten bei schwacher Hitze köcheln, bis der Kürbis gar ist. Mit Salz, Pfeffer und Cayennepfeffer würzen.",
+      "Bandnudeln nach Packungsanweisung kochen.",
+      "Walnüsse hacken.",
+      "Die Bandnudeln mit dem Kürbis anrichten und mit gehackten Walnüssen sowie Thymian bestreuen."
+    ],
+    "id": "rec_22"
+  },
+  {
+    "title": "Asia-Suppe mit Huhn & Gemüse",
+    "tags": [
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "295 kcal",
+      "Kohlenhydrate": "32 g",
+      "Fett": "7,1 g",
+      "Eiweiß": "26,6 g"
+    },
+    "ingredients": [
+      "1,5 Frühlingszwiebeln",
+      "1 Zehe(n) Knoblauch",
+      "0,5 kleine rote Zwiebel",
+      "0,5 Karotte",
+      "175 g Hähnchenbrustfilet",
+      "1 EL Rapsöl",
+      "0,5 Stück Ingwer",
+      "1 EL Sojasauce",
+      "75 g Wok Nudeln (chinesische Eiernudeln)",
+      "1 Zweig(e) Koriander"
+    ],
+    "instructions": [
+      "Frühlingszwiebeln waschen und in feine Ringe schneiden, Knoblauch und Zwiebel schälen, Knoblauch fein hacken, Zwiebeln in halbe Ringe schneiden. Karotte schälen und in Stifte schneiden.",
+      "Hähnchenbrust in 1 l Wasser ca. 20 Minuten kochen, aus der Brühe nehmen und mit einer Gabel grob zerrupfen. Brühe abgießen und auffangen.",
+      "In dem Topf Rapsöl erhitzen, Zwiebeln, Knoblauch und Karotten kurz anbraten, mit der Brühe aufgießen, das Gemüse wenige Minuten garen. Mit geriebenem Ingwer und Sojasauce abschmecken.",
+      "Die Nudeln in die Suppe geben und al dente kochen, das Fleisch zurück in die Suppe geben und mit frisch gezupften Korianderblättern servieren."
+    ],
+    "id": "rec_23"
+  },
+  {
+    "title": "Rigatoni mit Tomatensoße",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "692 kcal",
+      "Kohlenhydrate": "110,2 g",
+      "Fett": "17,3 g",
+      "Eiweiß": "26,2 g"
+    },
+    "ingredients": [
+      "1,5 Knoblauchzehen",
+      "1,5 EL Öl",
+      "1,5 EL Tomatenmark",
+      "1 Dose(n) Tomaten",
+      "Salz",
+      "Pfeffer",
+      "Chiliflocken",
+      "1 EL Balsamico",
+      "1 TL Zucker",
+      "250 g Rigatoni",
+      "0,25 Bd . Basilikum",
+      "50 g Parmesan"
+    ],
+    "instructions": [
+      "Knoblauch schälen und in dünne Scheiben schneiden. Öl erhitzen, Knoblauch darin kurz anschwitzen. Tomatenmark zugeben und anrösten. Tomaten zugeben und etwas zerdrücken. Mit Salz, Pfeffer, Chili, Balsamico und Zucker würzen. Soße ca. 15 Minuten köcheln lassen.",
+      "Nudeln nach Packungsanweisung in kochendem Salzwasser bissfest garen. In der Zwischenzeit Basilikum waschen, trocken schütteln und hacken. Parmesan hobeln.",
+      "Nudeln mit Tomatensoße anrichten und mit Basilikum und Parmesan bestreut servieren."
+    ],
+    "id": "rec_24"
+  },
+  {
+    "title": "Schnüsch-Gratin",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "560 kcal",
+      "Kohlenhydrate": "47 g",
+      "Fett": "34,7 g",
+      "Eiweiß": "18,5 g"
+    },
+    "ingredients": [
+      "250 g Kartoffeln (vorwiegend festkochend)",
+      "150 g Möhren",
+      "0,5 Kohlrabi",
+      "1 Stange(n) Lauch",
+      "0,25 Bd . Kerbel",
+      "0,25 Bd . Petersilie",
+      "1 EL Rapsöl",
+      "75 ml Gemüsebrühe",
+      "Salz",
+      "Pfeffer",
+      "Muskat",
+      "0,5 EL Butter",
+      "0,5 EL Weizenmehl Type 405",
+      "200 ml Milch",
+      "100 g Sahne",
+      "50 g geriebener Käse"
+    ],
+    "instructions": [
+      "Kartoffeln, Möhren und Kohlrabi schälen. Kartoffeln und Möhren in Scheiben, Kohlrabi in dünne Spalten schneiden. Lauch putzen, waschen und das Weiße in feine Ringe schneiden. Kräuter waschen und Blättchen hacken. Einen kleinen Teil der Kräuter für die Deko beiseitestellen.",
+      "Öl erhitzen und die Möhren sowie den Kohlrabi anschwitzen. Lauch und Kartoffeln zufügen und kurz mitgaren. 150 ml Gemüsebrühe zufügen und bei schwacher Hitze gut 15 Minuten garen, bis Gemüse und Kartoffeln fast gar sind. Mit Salz, Pfeffer und Muskat würzen.",
+      "Butter schmelzen, Mehl zufügen und unter Rühren aufschäumen lassen. Milch und Sahne zufügen, aufkochen und bei schwacher Hitze gut 15 Minuten köcheln lassen. Mit Salz, Pfeffer und Muskat würzen.",
+      "Gemüse, Kartoffeln und Kräuter in eine Auflaufform geben und vermengen. Soße darüber gießen, mit Käse bestreuen und im auf 240 °C Oberhitze (oder Grillfunktion) vorgeheizten Backofen 5-7 Minuten goldbraun überbacken. Mit den beiseitegelegten Kräutern anrichten."
+    ],
+    "id": "rec_25"
+  },
+  {
+    "title": "Pasta mit Linsenbällchen",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "770 kcal",
+      "Kohlenhydrate": "136,6 g",
+      "Fett": "13,2 g",
+      "Eiweiß": "31,6 g"
+    },
+    "ingredients": [
+      "100 g rote Linsen",
+      "Salz",
+      "2 Knoblauchzehen",
+      "2 EL Öl",
+      "3 EL Tomatenmark",
+      "2,5 Stiel(e) Petersilie",
+      "0,5 EL Sojasoße",
+      "2,5 EL zarte Haferflocken",
+      "Paprikapulver",
+      "0,5 große Zwiebel",
+      "0,5 Dose(n) gehackte Tomaten",
+      "50 ml Rotwein",
+      "0,5 TL Zucker",
+      "Chilipulver",
+      "200 g Spaghetti",
+      "1,5 Stiel(e) Basilikum"
+    ],
+    "instructions": [
+      "Für die Linsenbällchen Linsen in 400 ml kochendem Salzwasser ca. 15 Minuten kochen, abgießen und sehr gut abtropfen lassen. Backofen auf 180°C Umluft vorheizen.",
+      "Knoblauch schälen und fein hacken. Hälfte Knoblauch in 2 EL Öl anrösten, 1 EL Tomatenmark zugeben und mitrösten. Mischung zu den Linsen geben. Petersilie waschen, trocken schütteln und fein hacken. Petersilie, Sojasoße und Haferflocken ebenfalls zu den Linsen geben und alles zu einer homogenen Masse verkneten. Mit Paprikapulver und evtl. etwas Salz würzen.",
+      "Aus der Masse kleine Bällchen formen, diese auf ein mit Backpapier belegtes Backblech legen und im vorgeheizten Backofen ca. 30 Minuten backen.",
+      "Für die Tomatensoße Zwiebel schälen und in kleine Würfel schneiden. 2 EL Öl in einem Topf erhitzen, Zwiebel darin andünsten und übrigen Knoblauch hinzufügen. 5 EL Tomatenmark und gehackte Tomaten zugeben. Mit Rotwein ablöschen, 100 ml Wasser zugeben, mit Salz, Zucker und Chili würzen. Soße ca. 20 Minuten köcheln lassen.",
+      "Spaghetti nach Packungsanweisung in Salzwasser kochen. Basilikum waschen, trocken schütteln.",
+      "Linsenbällchen vorsichtig unter die Tomatensoße heben und mit Nudeln anrichten. Mit dem Basilikum garnieren."
+    ],
+    "id": "rec_26"
+  },
+  {
+    "title": "Penne all’arrabbiata",
+    "tags": [
+      "Vegetarisch",
+      "Zuckerfrei",
+      "Kalorienarm",
+      "Fettarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "421 kcal",
+      "Kohlenhydrate": "65,2 g",
+      "Fett": "12,7 g",
+      "Eiweiß": "13,5 g"
+    },
+    "ingredients": [
+      "200 g reife Tomaten",
+      "1 Knoblauchzehen",
+      "1 Chilischoten",
+      "20 ml Olivenöl",
+      "Salz",
+      "Pfeffer",
+      "0,5 Handvoll glatte Petersilie",
+      "0,5 Stück Pecorino",
+      "160 g Penne Rigate"
+    ],
+    "instructions": [
+      "Tomaten mit Wasser überbrühen und die Schale abziehen, dann in kleine Würfel schneiden. Knoblauch schälen und halbieren, Chilischoten in feine Ringe schneiden.",
+      "Olivenöl in einer Pfanne erhitzen, Knoblauch und Chiliringe darin anbraten, die Tomatenwürfel dazugeben, mitbraten und mit Salz und Pfeffer würzen.",
+      "Petersilie fein hacken, Pecorino reiben. Nudeln in reichlich Salzwasser nach Packungsanleitung al dente garen.",
+      "Knoblauch aus der Pfanne nehmen, Nudeln abgießen und sofort in die Pfanne geben. Alles miteinander vermengen, erneut mit Salz und Pfeffer abschmecken, Petersilie und Pecorino unterrühren und sofort servieren."
+    ],
+    "id": "rec_27"
+  },
+  {
+    "title": "Vegetarisches Kartoffelgulasch",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "336 kcal",
+      "Kohlenhydrate": "63,7 g",
+      "Fett": "5,8 g",
+      "Eiweiß": "8,7 g"
+    },
+    "ingredients": [
+      "2 Zwiebeln",
+      "1 Zehe(n) Knoblauch",
+      "0,6 g Kartoffeln, festkochend",
+      "1 rote Paprika",
+      "1 EL Natives Olivenöl extra",
+      "2 EL Tomatenmark",
+      "0,5 l Gemüsebrühe",
+      "Pfeffer",
+      "Salz",
+      "2 TL Paprika edelsüß gemahlen",
+      "0,5 Bd . Petersilie"
+    ],
+    "instructions": [
+      "Zwiebeln und Knoblauch schälen und fein würfeln. Kartoffeln schälen, waschen und in mundgerechte Stücke schneiden (ca. 1 x 1,5 cm). Paprika waschen, entkernen und ebenfalls in gleicher Größe würfeln.",
+      "Öl in einem großen Topf erhitzen. Zwiebeln und Knoblauch darin glasig dünsten. Kartoffel zufügen und kurz anbraten. Tomatenmark zufügen und ebenfalls mit anbraten.",
+      "Alles mit Gemüsebrühe ablöschen und die Gewürze zufügen. Für circa 15 Minuten köcheln lassen, dann die Paprika zufügen. Für weitere 5 Minuten köcheln lassen.",
+      "Petersilie waschen, trocken schütteln, zupfen und grob hacken.",
+      "Gulasch mit frischer Petersilie bestreut servieren."
+    ],
+    "id": "rec_28"
+  },
+  {
+    "title": "Schneller Couscous-Salat",
+    "tags": [
+      "Vegetarisch",
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "286 kcal",
+      "Kohlenhydrate": "58,7 g",
+      "Fett": "2,1 g",
+      "Eiweiß": "9,3 g"
+    },
+    "ingredients": [
+      "125 g Instant-Couscous",
+      "0,5 Salatgurke",
+      "125 g Cherrytomaten",
+      "0,5 Bd . glatte Petersilie",
+      "0,5 Bd . Minze",
+      "1 Limette",
+      "0,5 TL flüssiger Honig",
+      "2,5 EL Ajvar pikant",
+      "Salz",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Couscous nach Packungsanweisung zubereiten. Gurke waschen, längs vierteln und entkernen. In grobe Würfel schneiden. Cherrytomaten waschen und halbieren.",
+      "Kräuter waschen, trocken schütteln und Blätter hacken. Saft der Limette auspressen und mit Honig verrühren.",
+      "Ajvar unter den Couscous rühren und nach Belieben mit Salz und Pfeffer würzen. Gurken und Tomaten hinzugeben und vermengen. Kräuter und Limetten-Honig-Saft unter die Mischung heben."
+    ],
+    "id": "rec_29"
+  },
+  {
+    "title": "Vegane Kohlrabi-Schnitzel mit Gurkensalat",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "306 kcal",
+      "Kohlenhydrate": "39,8 g",
+      "Fett": "14 g",
+      "Eiweiß": "7,5 g"
+    },
+    "ingredients": [
+      "1 Kohlrabi",
+      "3 EL Cornflakes, ungezuckert",
+      "3 EL Paniermehl",
+      "Salz",
+      "Pfeffer",
+      "Paprikapulver",
+      "1,5 EL Weizenmehl Type 405",
+      "1,5 EL Soja-Kochcreme",
+      "1 Salatgurken",
+      "2 EL Sonnenblumenöl",
+      "1 EL Limettensaft",
+      "0,5 TL Ahornsirup",
+      "0,5 TL Senf",
+      "0,5 Bd . Dill",
+      "0,5 rote Zwiebel"
+    ],
+    "instructions": [
+      "Die Kohlrabi schälen und in 5 mm dicke Scheiben schneiden. Blanchiert diese ca. 5 Minuten, bis sie weich sind. Gut trocken tupfen. Die Cornflakes grob mit den Fingern zerbröseln und mit dem Paniermehl mischen. Salz, Pfeffer, Paprikapulver untermischen. Auf einem großen Teller Mehl und Sojacreme zu einer glatten Creme verrühren. Die Kohlrabischeiben erst in der Creme, dann in der Cornflakes-Panade wälzen. Die Panade ca. 10 Minuten anziehen lassen.",
+      "Die Salatgurken gut waschen, die Enden abschneiden und die Gurken der Länge nach halbieren. Mit einem Teelöffel das kernige Innere auskratzen und anschließend in dünne Scheiben schneiden. Für die Salatsoße Öl, Limettensaft, Ahornsirup und Senf miteinander glatt rühren. Mit Salz und Pfeffer abschmecken und unter die Gurkenscheiben rühren. Dill waschen und fein hacken. Die rote Zwiebel abziehen und in sehr feine Ringe schneiden. Beides unter den Salat mischen und ziehen lassen.",
+      "In einer großen, beschichteten Pfanne Öl erhitzen und die Schnitzel von beiden Seiten ca. 3 Minuten knusprig anbraten. Anschließend kurz auf einem Küchenpapier abtropfen lassen und mit dem Gurkensalat servieren."
+    ],
+    "id": "rec_30"
+  },
+  {
+    "title": "Khao Phad - Thailändischer Bratreis",
+    "tags": [
+      "Vegetarisch",
+      "Laktosefrei",
+      "Glutenfrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "415 kcal",
+      "Kohlenhydrate": "56 g",
+      "Fett": "15,1 g",
+      "Eiweiß": "14,7 g"
+    },
+    "ingredients": [
+      "2 Zehe(n) Knoblauch",
+      "2 Lauchzwiebeln",
+      "125 g Möhren",
+      "1,5 EL Öl",
+      "2,5 Eier",
+      "0,5 kg gekochter Reis (z. B. vom Vortag)",
+      "Salz",
+      "Zucker",
+      "weißer Pfeffer",
+      "1 -Limetten"
+    ],
+    "instructions": [
+      "Knoblauch schälen und hacken. Lauchzwiebeln waschen und in Ringe schneiden. Möhren schälen und in feine Stifte schneiden.",
+      "Öl in einem Wok erhitzen. Knoblauch darin kurz anbraten, dann die Eier zugeben, verrühren und stocken lassen. Reis untermischen, Möhren und Lauchzwiebeln ebenfalls zugeben und alles ca. 5 Minuten anbraten. Mit Salz, Zucker, Pfeffer und Saft von einer Limette abschmecken.",
+      "Andere Limette waschen und in Spalten schneiden. Fertigen Reis mit Limetten garniert anrichten."
+    ],
+    "id": "rec_31"
+  },
+  {
+    "title": "Süßkartoffel Curry",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "758 kcal",
+      "Kohlenhydrate": "126,4 g",
+      "Fett": "25 g",
+      "Eiweiß": "13,8 g"
+    },
+    "ingredients": [
+      "2 Süßkartoffeln (ca. 800 g)",
+      "1 Zwiebel",
+      "1 daumengroßes Stück Ingwer (3 g)",
+      "3 EL Rapsöl",
+      "2 EL Garam Masala",
+      "1 TL Kurkuma",
+      "0,5 TL Kreuzkümmel (gemahlen)",
+      "700 g passierte Tomaten (400 g)",
+      "1 EL Erdnussmus",
+      "Salz",
+      "15 g Koriander"
+    ],
+    "instructions": [
+      "Süßkartoffel schälen und in ca. 2 cm große Würfel schneiden. Zwiebel schälen und in Streifen schneiden. Ingwer schälen und fein würfeln.",
+      "Öl in einem Topf erhitzen und Süßkartoffeln und Zwiebeln darin anrösten. Ingwer, Garam Masala, Kurkuma und Kreuzkümmel zugeben, kurz anrösten und die passierten Tomaten zugeben. 15 Minuten köcheln lassen.",
+      "Erdnussmus unterrühren und mit Salz abschmecken. Koriander waschen, trocken schütteln und grob hacken. Curry mit Koriander garniert servieren."
+    ],
+    "id": "rec_32"
+  },
+  {
+    "title": "Schupfnudeln mit Kohl",
+    "tags": [
+      "Laktosefrei"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "582 kcal",
+      "Kohlenhydrate": "38,7 g",
+      "Fett": "38,8 g",
+      "Eiweiß": "23,5 g"
+    },
+    "ingredients": [
+      "0,5 Spitzkohl",
+      "1 Zwiebeln",
+      "1 EL Butterschmalz",
+      "200 g Schupfnudeln",
+      "0,5 Prise(n) Kümmel",
+      "0,5 Prise(n) Pfeffer",
+      "Salz",
+      "2 geräucherte Mettenden"
+    ],
+    "instructions": [
+      "Spitzkohl putzen, halbieren, den Strunk entfernen und in ca. 1 cm breite Streifen schneiden. Zwiebeln schälen und würfeln.",
+      "Butterschmalz in einer großen Pfanne erhitzen und die Schupfnudeln bei mittlerer Hitze rundherum goldbraun braten. Zwiebeln und Kohl dazugeben. Mit Kümmel, Pfeffer und Salz würzen und alles 5 Minuten braten.",
+      "Mettenden in Scheiben schneiden und in die Pfanne geben. Alles gut durchmischen und nochmals 5-6 Minuten bei mittlerer Hitze braten. Nochmals abschmecken und servieren."
+    ],
+    "id": "rec_33"
+  },
+  {
+    "title": "Beamtenstippe zu Kartoffeln",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "673 kcal",
+      "Kohlenhydrate": "34,2 g",
+      "Fett": "41 g",
+      "Eiweiß": "42,7 g"
+    },
+    "ingredients": [
+      "300 g Kartoffeln (festkochend)",
+      "1 Zwiebeln",
+      "1 EL Butter",
+      "400 g Hackfleisch (gemischt)",
+      "Salz",
+      "Pfeffer",
+      "1 EL Weizenmehl Type 405",
+      "1,5 EL Tomatenmark",
+      "150 ml Brühe",
+      "1,5 Gewürzgurken",
+      "1 EL Petersilie"
+    ],
+    "instructions": [
+      "Kartoffeln schälen und in heißem Wasser ca. 20 Minuten kochen, abgießen und warm stellen.",
+      "In der Zwischenzeit die Zwiebeln schälen und würfeln. Butter in einer Pfanne zerlassen. Die Zwiebelwürfel in die Pfanne geben und 5 Minuten glasig dünsten.",
+      "Hackfleisch dazugeben und goldbraun anbraten. Dabei das Fleisch mit einem Löffel zerkleinern, bis es krümelig ist. Mit Salz und Pfeffer würzen und mit Mehl bestäuben.",
+      "Tomatenmark unterrühren und mit Brühe ablöschen. Die Hitze reduzieren und ca. 10 Minuten köcheln lassen.",
+      "Gurken in Würfel schneiden und zum Hackfleisch geben. 200 ml vom Gurkenwasser dazugeben und das Ganze noch einmal aufkochen lassen.",
+      "Die Petersilie waschen, trocken tupfen und fein hacken.",
+      "Die Beamtenstippe mit den Salzkartoffeln servieren und mit Petersilie bestreuen."
+    ],
+    "id": "rec_34"
+  },
+  {
+    "title": "Schnelle Pasta mit Wirsing und Cranberries",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "566 kcal",
+      "Kohlenhydrate": "80,3 g",
+      "Fett": "19,8 g",
+      "Eiweiß": "24,1 g"
+    },
+    "ingredients": [
+      "150 g Vollkorn-Fusilli",
+      "400 g Wirsing",
+      "Salz",
+      "1 Schalotte",
+      "1 EL Öl",
+      "30 g Pinienkerne",
+      "30 g getrocknete Cranberries",
+      "Pfeffer",
+      "30 g Parmesan"
+    ],
+    "instructions": [
+      "Nudeln nach Packungsanweisung zubereiten. Wirsing putzen, in Streifen schneiden und in kochendem Salzwasser ca. 5 Minuten bissfest kochen. Schalotte schälen und fein würfeln. Wirsing abgießen, etwas Kochwasser zurückbehalten.",
+      "Öl in einer Pfanne erhitzen und Schalotte darin glasig dünsten. Pinienkerne zugeben und kurz anrösten. Wirsing und Cranberries zugeben und mit 100-200 ml Kochwasser ablöschen. Nudeln abgießen und in die Pfanne geben. Mit Salz und Pfeffer abschmecken. Auf Tellern verteilen und Parmesan darüber hobeln."
+    ],
+    "id": "rec_35"
+  },
+  {
+    "title": "Spaghetti Amatriciana",
+    "tags": [
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "856 kcal",
+      "Kohlenhydrate": "111,4 g",
+      "Fett": "30,4 g",
+      "Eiweiß": "38,5 g"
+    },
+    "ingredients": [
+      "1 kleine Zwiebel",
+      "1 Zehe(n) Knoblauch",
+      "200 g Spaghetti",
+      "Salz",
+      "1 TL Olivenöl",
+      "150 g Speckwürfel",
+      "Chiliflocken",
+      "1 Dose(n) stückige Tomaten (400 ml)",
+      "2 EL Pecorino (gerieben)",
+      "Zucker",
+      "Pfeffer",
+      "1 Zweig(e) frisches Basilikum"
+    ],
+    "instructions": [
+      "Zwiebel und Knoblauch schälen und fein hacken. Nudeln in Salzwasser nach Packungsanweisung al dente kochen.",
+      "Olivenöl in einer Pfanne erhitzen, den Speck darin anbraten, dann Zwiebeln, Knoblauch und Chiliflocken dazugeben und mitbraten.",
+      "Tomaten sowie eine Kelle vom Nudelwasser dazugeben und alles ca. 10 Minuten einköcheln lassen. Die Hälfte des Pecorino einrühren, mit etwas Zucker, Pfeffer und Salz abschmecken.",
+      "Spaghetti und Sauce vermischen, auf Tellern anrichten und mit dem übrigen Pecorino sowie frischem Basilikum servieren."
+    ],
+    "id": "rec_36"
+  },
+  {
+    "title": "Schinken-Käse-Nudelauflauf",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "655 kcal",
+      "Kohlenhydrate": "60,3 g",
+      "Fett": "30,7 g",
+      "Eiweiß": "35,7 g"
+    },
+    "ingredients": [
+      "150 g kurze Nudeln (z.B. Penne)",
+      "0,5 TL Butter",
+      "100 g Kochschinken",
+      "75 g Bergkäse",
+      "75 ml Milch",
+      "75 g Crème Fraîche",
+      "1 Eier",
+      "Pfeffer",
+      "Salz",
+      "0,5 Prise(n) Muskat"
+    ],
+    "instructions": [
+      "Die Nudeln nach Packungsanleitung al dente kochen und danach mit kaltem Wasser abschrecken.",
+      "Den Backofen auf 200 °C Ober-/ Unterhitze vorheizen. Eine Auflaufform mit Butter fetten. Den Schinken in Streifen schneiden. Den Käse fein hobeln.",
+      "Milch, Crème Fraîche und Eier miteinander verquirlen und mit Pfeffer, Salz und Muskat würzen.",
+      "Nudeln und Schinken in die Auflaufform geben und vermischen. Die Eiermilch gleichmäßig darüber verteilen. Mit Käse bestreuen und in ca. 25 Minuten goldbraun backen."
+    ],
+    "id": "rec_37"
+  },
+  {
+    "title": "Nudelauflauf mit Gemüse vom Blech",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "768 kcal",
+      "Kohlenhydrate": "77,4 g",
+      "Fett": "37,3 g",
+      "Eiweiß": "33,8 g"
+    },
+    "ingredients": [
+      "80 g TK-Erbsen",
+      "160 g Spiralnudeln",
+      "Salz",
+      "1,6 Eier (Größe M)",
+      "80 ml Schlagsahne",
+      "80 ml Milch",
+      "Pfeffer",
+      "Muskatnuss",
+      "60 g Kochschinken (in Scheiben)",
+      "60 g mittelalter Gouda",
+      "1,2 EL Semmelbrösel",
+      "1,2 EL Sonnenblumenöl"
+    ],
+    "instructions": [
+      "Erbsen auftauen lassen. Nudeln in reichlich kochendem Salzwasser nach Packungsanweisung bissfest garen, abgießen und abtropfen lassen. Eier mit Sahne und Milch verquirlen und mit Salz, Pfeffer und Muskat würzen.",
+      "Schinken würfeln. Käse raspeln und mit den Semmelbröseln mischen. Ein tiefes Blech mit 2 EL Sonnenblumenöl fetten. Nudeln mit Erbsen und Schinken mischen und auf dem Blech verteilen. Eier-Sahne-Mischung darübergießen. Käse-Brösel-Mischung gleichmäßig darüberstreuen. Alles mit 1 EL Sonnenblumenöl beträufeln.",
+      "Nudelauflauf im vorgeheizten Ofen bei 220 Grad Ober- und Unterhitze (Umluft 200 Grad) auf der mittleren Schiene 20 Min. goldbraun backen."
+    ],
+    "id": "rec_38"
+  },
+  {
+    "title": "Bandnudeln mit Spinatsoße",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "585 kcal",
+      "Kohlenhydrate": "80,7 g",
+      "Fett": "20,9 g",
+      "Eiweiß": "21,2 g"
+    },
+    "ingredients": [
+      "200 g tiefgefrorener Blattspinat",
+      "1 EL Rapsöl",
+      "15 g Pinienkerne",
+      "1 Schalotten",
+      "0,5 Knoblauchzehe",
+      "100 ml Gemüsebrühe",
+      "Salz",
+      "weißer Pfeffer",
+      "Muskatnuss (frisch gerieben)",
+      "50 g Schmand",
+      "200 g Bandnudeln",
+      "20 g Parmesan (oder veg. Alternative)"
+    ],
+    "instructions": [
+      "Spinat auftauen. 1 EL Öl in einer Pfanne erhitzen. Pinienkerne darin unter Wenden ca. 3 Minuten rösten.",
+      "Schalotten und Knoblauch schälen und würfeln. 1 EL Öl in einem Topf erhitzen und Schalottenwürfel darin ca. 10 Minuten glasig dünsten. Knoblauch zufügen und kurz mitdünsten. Spinat leicht ausdrücken und nach ca. 5 Minuten zu den Schalottenwürfeln geben. Mit Brühe ablöschen und aufkochen. Mit Salz, Pfeffer und Muskat abschmecken. Schmand einrühren.",
+      "Inzwischen Nudeln in kochendem Salzwasser nach Packungsanweisung zubereiten. Käse fein reiben. Nudeln abgießen. Mit Spinat mischen und auf Tellern anrichten. Mit Käse und gerösteten Pinienkerne bestreuen."
+    ],
+    "id": "rec_39"
+  },
+  {
+    "title": "Vegetarischer Bohneneintopf",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "346 kcal",
+      "Kohlenhydrate": "58,9 g",
+      "Fett": "7,1 g",
+      "Eiweiß": "20,2 g"
+    },
+    "ingredients": [
+      "0,5 grüne Paprika",
+      "150 g weiße Bohnen (Dose)",
+      "0,5 Dose(n) Kidneybohnen (255 g)",
+      "0,25 Dose(n) Kichererbsen",
+      "1 EL Rapsöl nativ",
+      "1 Zehe(n) Knoblauch",
+      "0,5 Zwiebel",
+      "250 ml Gemüsebrühe (glutenfrei)",
+      "0,5 Dose(n) stückige Tomaten (400 g)",
+      "Salz",
+      "Pfeffer",
+      "0,5 TL Chili Gewürzmischung gemahlen",
+      "0,5 TL Paprikapulver",
+      "0,13 Bd . frische Petersilie",
+      "1 EL Essig"
+    ],
+    "instructions": [
+      "Paprika waschen, entkernen und würfeln. Bohnen und Kichererbsen in ein Sieb abgießen, waschen und abtropfen lassen.",
+      "Öl in einem großen Topf erhitzen. Knoblauch und Zwiebeln schälen, fein hacken und in Öl anschwitzen. Paprika, Kichererbsen und Bohnen in den Topf geben. Mit Gemüsebrühe und stückigen Tomaten ablöschen.",
+      "Gewürze hinzufügen und Eintopf circa 20 Minuten köcheln lassen.",
+      "Petersilie waschen, trocken schütteln und zupfen. Essig zum Eintopf geben und den Eintopf abschmecken.",
+      "Eintopf in vier Schüsseln verteilen und mit Petersilie garnieren."
+    ],
+    "id": "rec_40"
+  },
+  {
+    "title": "Grüner Kartoffelsalat",
+    "tags": [
+      "Vegan",
+      "Laktosefrei",
+      "Glutenfrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "415 kcal",
+      "Kohlenhydrate": "62,8 g",
+      "Fett": "13,4 g",
+      "Eiweiß": "11,2 g"
+    },
+    "ingredients": [
+      "0,5 kg festkochende Kartoffeln",
+      "0,5 große rote Zwiebel",
+      "90 ml Gemüsebrühe (glutenfrei)",
+      "0,75 TL Senf (glutenfrei)",
+      "0,5 Prise(n) Zucker",
+      "1,5 EL Apfelessig",
+      "1,5 EL Walnussöl",
+      "Salz",
+      "Pfeffer",
+      "35 g Sonnenblumenkerne geschält",
+      "100 g Feldsalat",
+      "125 g grüne, kernlose Trauben"
+    ],
+    "instructions": [
+      "Kartoffeln in kochendem Salzwasser ca. 20 Minuten gar kochen. Abschrecken, 15 Minuten stehen lassen, pellen und in dünne Scheiben schneiden.",
+      "Zwiebel schälen und fein würfeln. Mit den Kartoffelscheiben mischen. Brühe erhitzen, Senf und Zucker einrühren. Essig und Brühe über die Kartoffeln gießen und mischen. Öl unterheben und mit Salz und Pfeffer würzen. Abkühlen lassen. Sonnenblumenkerne in einer Pfanne ohne Fett rösten.",
+      "Feldsalat waschen, trocken schleudern. Trauben halbieren. Feldsalat, Trauben und Sonnenblumenkerne unter den Salat heben."
+    ],
+    "id": "rec_41"
+  },
+  {
+    "title": "Schnelle Spaghetti Bolognese",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "823 kcal",
+      "Kohlenhydrate": "82,7 g",
+      "Fett": "36 g",
+      "Eiweiß": "44,2 g"
+    },
+    "ingredients": [
+      "1 Zwiebeln",
+      "0,5 Zehe(n) Knoblauch",
+      "50 g Möhren",
+      "1 EL Rapsöl nativ",
+      "250 g Hackfleisch gemischt",
+      "1 EL ja! Tomatenmark 3-fach konzentriert",
+      "1 Dose(n) Tomaten geschält à 400g",
+      "ja! Jodsalz",
+      "ja! Pfeffer schwarz gemahlen",
+      "ja! Raffinade Zucker",
+      "1 TL Oregano gerebelt",
+      "200 g ja! Spaghetti",
+      "25 g ja! geriebener Mozzarella"
+    ],
+    "instructions": [
+      "Zwiebeln und Knoblauch schälen und fein hacken. Möhren schälen und fein würfeln.",
+      "Öl erhitzen und Zwiebeln, Knoblauch und Hackfleisch anbraten. Möhren und Tomatenmark zufügen, kurz mitbraten, Tomaten zugeben und diese mit einer Gabel zerdrücken. Bei schwacher Hitze gut 20 Minuten köcheln lassen, ggf. etwas Wasser zufügen. Mit Salz, Pfeffer, Zucker und Oregano abschmecken.",
+      "Spaghetti in Salzwasser nach Packungsanweisung zubereiten.",
+      "Spaghetti mit der Bolognese anrichten und nach Belieben mit etwas geriebenem Mozzarella bestreut servieren."
+    ],
+    "id": "rec_42"
+  },
+  {
+    "title": "Schnelle Tomaten-Schnitten",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "476 kcal",
+      "Kohlenhydrate": "29,1 g",
+      "Fett": "37,8 g",
+      "Eiweiß": "6,39 g"
+    },
+    "ingredients": [
+      "0,5 Pck . Blätterteig",
+      "75 g Schmand",
+      "Salz",
+      "Pfeffer",
+      "300 g Tomaten",
+      "0,25 Topf Basilikum",
+      "50 g Naturjoghurt",
+      "0,5 EL Olivenöl"
+    ],
+    "instructions": [
+      "Blätterteig auf einem mit Backpapier belegten Backblech entrollen. Schmand mit Salz und Pfeffer verrühren, Teig damit gleichmäßig bestreichen.",
+      "Tomaten putzen, waschen und in Scheiben schneiden. Tomaten auf dem Blätterteig verteilen und im vorgeheizten Backofen bei 180 °C ca. 20 Minuten backen.",
+      "In der Zwischenzeit Basilikumblättchen waschen und zusammen mit Joghurt und Öl pürieren. Mit Salz und Pfeffer abschmecken.",
+      "Fertige Tomatentarte aus dem Ofen nehmen, mit dem Basilikum-Joghurt beträufeln und in längliche Streifen schneiden."
+    ],
+    "id": "rec_43"
+  },
+  {
+    "title": "Omelett mit Kartoffeln",
+    "tags": [
+      "Vegetarisch",
+      "Laktosefrei",
+      "Glutenfrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "350 kcal",
+      "Kohlenhydrate": "36,9 g",
+      "Fett": "16 g",
+      "Eiweiß": "14,9 g"
+    },
+    "ingredients": [
+      "400 g Kartoffeln (überwiegend festkochend)",
+      "0,5 TL Salz",
+      "1 Zwiebeln",
+      "1,5 EL Öl",
+      "3 Eier (Größe M)",
+      "0,5 EL gemischte Kräuter (frisch gehackt)",
+      "0,5 Msp . Pfeffer"
+    ],
+    "instructions": [
+      "Die Kartoffeln waschen und in Salzwasser 20–30 Minuten, je nach Größe, garen. Darauf achten, dass die Kartoffeln ungefähr gleich groß sind, damit sie eine ähnlich lange Garzeit haben. Große Kartoffeln ggfs. halbieren oder vierteln. Nach der Kochzeit abgießen und abkühlen lassen.",
+      "Die abgekühlten Kartoffeln pellen und in Scheiben schneiden. Die Zwiebeln schälen und fein würfeln.",
+      "Das Öl in einer großen Pfanne erhitzen und die Zwiebelwürfel darin anschwitzen. Nach einigen Minuten die Kartoffelscheiben dazugeben und mitbraten, bis sie leicht knusprig werden.",
+      "Die Eier gründlich mit den Kräutern, 1 TL Salz und Pfeffer verquirlen und über die Kartoffeln in der Pfanne gießen. Bei mittlerer Temperatur 5–6 Minuten stocken lassen und braten, bis die Unterseite goldbraun ist.",
+      "Einen großen Teller verkehrt herum auf die Pfanne legen und die Pfanne mit Schwung umdrehen, sodass das Omelett auf dem Teller liegt. Dann das Omelett wieder in die Pfanne gleiten lassen, mit der hellen Seite nach unten. Noch einmal ca. 5 Minuten backen. Dann kurz abkühlen lassen und servieren. Dazu passt ein grüner Salat."
+    ],
+    "id": "rec_44"
+  },
+  {
+    "title": "Linsen-Curry-Topf mit Koriander-Joghurt",
+    "tags": [
+      "Vegetarisch",
+      "Glutenfrei",
+      "Zuckerfrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "290 kcal",
+      "Kohlenhydrate": "42,1 g",
+      "Fett": "8,9 g",
+      "Eiweiß": "14 g"
+    },
+    "ingredients": [
+      "1 Zwiebeln",
+      "0,5 Knoblauchzehe",
+      "1,5 Möhren",
+      "0,5 Zucchini",
+      "0,5 Bd . Frühlingszwiebeln",
+      "1 EL Rapsöl",
+      "60 g rote Linsen",
+      "1 EL Currypulver",
+      "200 g gehackte Tomaten",
+      "0,5 EL Tomatenmark",
+      "Salz",
+      "Pfeffer",
+      "0,5 Bd . Koriander",
+      "150 g Naturjoghurt"
+    ],
+    "instructions": [
+      "Zwiebeln, Knoblauch und Möhren schälen und fein würfeln. Zucchini waschen und klein schneiden. Frühlingszwiebeln waschen und in Röllchen schneiden.",
+      "Öl in einem großen Topf erhitzen. Zwiebeln und Knoblauch anschwitzen. Linsen, Zucchini und Möhren sowie Currypulver, gehackte Tomaten und Tomatenmark zufügen. Kurz anschwitzen und mit gut 600 ml Wasser ablöschen. Frühlingszwiebeln zufügen und gut 10-15 Minuten köcheln lassen, bis die Linsen gar sind. Bei Bedarf noch etwas Wasser zufügen. Mit Salz, Pfeffer und Curry abschmecken.",
+      "Koriander waschen, trocken schütteln und fein hacken. Unter den Joghurt rühren und mit Salz und Pfeffer würzen. Zum Linsen-Curry-Topf servieren."
+    ],
+    "id": "rec_45"
+  },
+  {
+    "title": "Spinat mit Spiegelei und Salzkartoffeln",
+    "tags": [
+      "Laktosefrei",
+      "Glutenfrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "389 kcal",
+      "Kohlenhydrate": "34 g",
+      "Fett": "19,4 g",
+      "Eiweiß": "21,2 g"
+    },
+    "ingredients": [
+      "400 g frischer Spinat",
+      "0,5 Zwiebel",
+      "1 EL Butter",
+      "62,5 g Speckwürfel",
+      "400 g Kartoffeln (z. B. Sorte Linda)",
+      "2 Eier",
+      "Salz",
+      "Pfeffer",
+      "0,13 Bd . Petersilie"
+    ],
+    "instructions": [
+      "Spinat waschen. Zwiebel schälen und in kleine Würfel schneiden.",
+      "1 EL Butter in einem Topf schmelzen, Zwiebel und Speck darin andünsten. Spinat zugeben und zusammenfallen lassen. Kartoffeln schälen und in Salzwasser ca. 20 Minuten kochen.",
+      "Übrige Butter in einer beschichteten Pfanne erhitzen. Eier darin nacheinander zu Spiegeleiern braten (je nach Belieben mit gestocktem oder flüssigem Eigelb). Mit Salz und Pfeffer würzen.",
+      "Petersilie hacken und auf Kartoffeln und Spiegeleier streuen."
+    ],
+    "id": "rec_46"
+  },
+  {
+    "title": "Spaghetti in Paprikasoße mit Hähnchen",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "643 kcal",
+      "Kohlenhydrate": "97,7 g",
+      "Fett": "15 g",
+      "Eiweiß": "32,4 g"
+    },
+    "ingredients": [
+      "200 g Spaghetti",
+      "Salz",
+      "62,5 g tiefgefrorene Erbsen",
+      "125 g Hähnchenbrustfilet",
+      "0,5 Glas Tomatenpaprika (à 650 g)",
+      "0,5 EL Öl",
+      "Pfeffer",
+      "50 ml Gemüsebrühe (Instant)",
+      "62,5 ml Schlagsahne",
+      "1 EL Soßenbinder, hell",
+      "getrocknete Kräuter",
+      "Rosmarin zum Garnieren"
+    ],
+    "instructions": [
+      "Nudeln nach Packungsanweisung in kochendem Salzwasser zubereiten. Inzwischen Erbsen auftauen lassen. Hähnchenfilet waschen, trocken tupfen, in Würfel schneiden. Paprika abtropfen lassen. 2 Paprikastücke in Würfel schneiden, übrige Paprika pürieren.",
+      "Öl erhitzen. Hähnchenwürfel darin unter Wenden braun anbraten. Mit Salz und Pfeffer würzen. Pürierte Paprika, Brühe und Sahne zufügen, aufkochen. Soßenbinder einstreuen. Unter Rühren nochmals aufkochen. Erbsen und Paprikawürfel darin erwärmen.",
+      "Mit Salz, Pfeffer und getrockneten Kräutern abschmecken. Nudeln und Soße portionsweise mit Rosmarin garniert anrichten."
+    ],
+    "id": "rec_47"
+  },
+  {
+    "title": "Gemüse-Kartoffel-Wedges-Pfanne",
+    "tags": [
+      "Vegetarisch",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "406 kcal",
+      "Kohlenhydrate": "48,1 g",
+      "Fett": "19,3 g",
+      "Eiweiß": "11,8 g"
+    },
+    "ingredients": [
+      "400 g Kartoffeln (festkochend)",
+      "25 g Palmin Kokosfett",
+      "Salz",
+      "Pfeffer",
+      "1 Zucchini",
+      "0,5 rote Paprika",
+      "0,5 gelbe Paprika",
+      "125 g Cherrytomaten",
+      "1 Zwiebeln",
+      "75 ml Gemüsebrühe",
+      "Paprikapulver edelsüß",
+      "50 g Feta"
+    ],
+    "instructions": [
+      "Kartoffeln waschen und in Wedges/Spalten schneiden. 30 g Palmin Kokosfett erhitzen und die Kartoffeln unter regelmäßigem Wenden ca. 20 Minuten knusprig braten. Mit Salz und Pfeffer würzen.",
+      "In der Zwischenzeit Zucchini waschen, halbieren und in Scheiben schneiden. Paprika waschen, Kerne entfernen und das Fruchtfleisch in Würfel schneiden. Tomaten waschen und halbieren. Zwiebeln schälen und hacken.",
+      "Fertige Kartoffeln aus der Pfanne nehmen und warm halten. 20 g Palmin in die Pfanne geben, schmelzen und die Zwiebeln anschwitzen. Paprika und Zucchini zugeben und mitbraten. Mit Brühe ablöschen und 5-10 Minuten bei schwacher Hitze garen, bis das Gemüse gar ist. Nach 5 Minuten die Tomaten zugeben.",
+      "Kartoffel-Wedges in die Pfanne geben und mit Paprikapulver, Salz und Pfeffer abschmecken. Feta darüber bröseln und sofort servieren."
+    ],
+    "id": "rec_48"
+  },
+  {
+    "title": "Tortelloni-Gratin",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "830 kcal",
+      "Kohlenhydrate": "40,6 g",
+      "Fett": "56,8 g",
+      "Eiweiß": "43,4 g"
+    },
+    "ingredients": [
+      "0,5 Pck . Spinat-Ricotta-Tortelloni",
+      "200 g Tomaten",
+      "50 g Parmesankäse",
+      "200 g Schlagsahne",
+      "Fett für die Form",
+      "75 g Pizzakäse (gerieben)",
+      "1 Zweig(e) Oregano"
+    ],
+    "instructions": [
+      "Backofen auf 200 °C Ober-/Unterhitze vorheizen. Tortelloni in kochendem Salzwasser nach Packungsanweisung zubereiten. Tomaten waschen, putzen, vierteln und entkernen. Fruchtfleisch in kleine Würfel schneiden. Tortelloni abgießen, abtropfen lassen und in kaltem Wasser abschrecken. Parmesan fein reiben.",
+      "Sahne in einem Topf aufkochen, vom Herd nehmen und Parmesan darin schmelzen. 4 Auflaufformen (à ca. 250 ml Inhalt) fetten. Tomatenwürfel mit den Tortelloni mischen und in die Formen geben. Mit Käse-Sahne-Mischung übergießen und mit Pizzakäse bestreuen. Im vorgeheizten Backofen 10–15 Minuten goldbraun backen. Oregano waschen, trocken schütteln und Blättchen von den Stielen zupfen. Aufläufe nach dem Backen mit Oregano bestreuen."
+    ],
+    "id": "rec_49"
+  },
+  {
+    "title": "Spinat-Reis-Tortilla",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "468 kcal",
+      "Kohlenhydrate": "51 g",
+      "Fett": "21,2 g",
+      "Eiweiß": "18,7 g"
+    },
+    "ingredients": [
+      "125 g Basmatireis",
+      "100 g TK-Rahmspinat",
+      "1 Zehe(n) Knoblauch",
+      "75 g Feta",
+      "1 EL Bratöl",
+      "Salz",
+      "Pfeffer",
+      "Muskatnuss",
+      "2 Spitz & Bube Eier (M)"
+    ],
+    "instructions": [
+      "Reis nach Packungsanweisung zubereiten. In der Zwischenzeit Spinat in einem Topf auftauen. Knoblauch schälen und fein hacken. Feta zerbröseln. Ofen auf 180 °C Umluft (200 °C Ober-/Unterhitze) vorheizen.",
+      "Öl in einer großen, ofenfesten Pfanne erhitzen und den Knoblauch anschwitzen. Reis und Spinat zufügen und mit Salz, Pfeffer sowie Muskat würzen.",
+      "Eier verquirlen und unter den Reis mischen. Mit Feta bestreuen und ca. 20 Minuten backen."
+    ],
+    "id": "rec_50"
+  },
+  {
+    "title": "Bergischer Pillekuchen - Kartoffelpuffer mit Speck",
+    "tags": [
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "380 kcal",
+      "Kohlenhydrate": "48 g",
+      "Fett": "13,8 g",
+      "Eiweiß": "16,2 g"
+    },
+    "ingredients": [
+      "0,5 kg mehlig kochende Kartoffeln",
+      "1 Schalotten",
+      "65 g geräucherter Speck",
+      "1,5 Eier",
+      "1 EL Weizenmehl Type 405",
+      "Salz",
+      "Pfeffer",
+      "0,5 Prise(n) Muskatnuss",
+      "2,5 Stiel(e) Petersilie"
+    ],
+    "instructions": [
+      "Kartoffeln schälen und reiben. Schalotten schälen und in feine Würfel schneiden.",
+      "Speck würfeln und in einer Pfanne ohne Fett knusprig auslassen. Schalotten zugeben und anschwitzen. Geraspelte Kartoffeln zugeben und weitere 5 Minuten braten.",
+      "Eier in einer Schüssel verquirlen. Mehl unterrühren und die Mischung mit Salz, Pfeffer und Muskat würzen. Mischung über die Kartoffeln gießen und bei schwacher Hitze ca. 15 Minuten mit geschlossenem Deckel stocken lassen.",
+      "Petersilie waschen, trocken schütteln und hacken. Fertige Pillekuchen mit Petersilie bestreut servieren."
+    ],
+    "id": "rec_51"
+  },
+  {
+    "title": "Ofenkürbis mit Kartoffeln und Schmand Dip",
+    "tags": [
+      "Vegetarisch",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "510 kcal",
+      "Kohlenhydrate": "44,8 g",
+      "Fett": "34 g",
+      "Eiweiß": "8,9 g"
+    },
+    "ingredients": [
+      "300 g Kartoffeln",
+      "2,5 EL Olivenöl",
+      "Salz",
+      "Pfeffer",
+      "0,5 Hokkaido Kürbis (ca. 850 g)",
+      "1 rote Zwiebeln",
+      "10 g Kürbiskerne",
+      "3 Zweig(e) Majoran",
+      "125 g Schmand",
+      "1 TL Agavendicksaft"
+    ],
+    "instructions": [
+      "Kartoffeln schälen, waschen und in Spalten schneiden. Mit 3 EL Öl, Salz und Pfeffer mischen. Auf ein Backblech geben. Im vorgeheizten Backofen (E-Herd: 200 °C/ Umluft: 175 °C/ Gas: s. Hersteller) ca. 40 Minuten garen.",
+      "Kürbis waschen, halbieren und entkernen. Zwiebeln schälen. Kürbis und Zwiebeln in Spalten schneiden. Majoran waschen und trocken schütteln. Kürbis und Zwiebeln mit 2 EL Öl, Salz und Pfeffer mischen. Mit Kürbiskernen und Majoran nach ca. 20 Minuten mit auf das Backblech geben und weitergaren. Gemüse und Kartoffeln zwischendurch wenden.",
+      "Schmand und Agavendicksaft verrühren. Mit Salz und Pfeffer abschmecken. Gemüse aus dem Ofen nehmen. Schmand dazureichen."
+    ],
+    "id": "rec_52"
+  },
+  {
+    "title": "Ofenkartoffeln mit Radieschen-Kräuterquark",
+    "tags": [
+      "Vegetarisch",
+      "Glutenfrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "440 kcal",
+      "Kohlenhydrate": "58 g",
+      "Fett": "15,3 g",
+      "Eiweiß": "17,5 g"
+    },
+    "ingredients": [
+      "4 Backkartoffeln (à ca. 150 g)",
+      "100 g Radieschen",
+      "25 g Radieschensprossen",
+      "0,5 Bd . Petersilie",
+      "1 Becher Speisequark Halbfettstufe",
+      "0,5 Becher Schmand",
+      "Salz",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Kartoffeln gründlich waschen und in kochendem Wasser ca. 25 Minuten garen. Kartoffeln abgießen, auf einem mit Backpapier ausgelegten Backblech verteilen und im vorgeheizten Backofen (E-Herd: 200 °C/ Umluft: 175 °C/ Gas: Stufe 3) ca. 20 Minuten backen.",
+      "Inzwischen Radieschen putzen, waschen, trocken tupfen und in Stifte schneiden. Sprossen mit kaltem Wasser gründlich abspülen und gut abtropfen lassen. Petersilie waschen, trocken schütteln. Bis auf etwas zum Garnieren, Blättchen von den Stielen zupfen und in feine Streifen schneiden.",
+      "Quark und Schmand verrühren. Mit Salz und Pfeffer würzen. Sprossen, Radieschen und Petersilie mischen. Hälfte unter den Quark mengen. Kartoffeln aus dem Ofen nehmen, aufbrechen. Je 2 Kartoffeln mit einem Klecks Quark und restlicher Sprossenmischung auf 4 Tellern anrichten, mit Petersilie garnieren. Restlichen Quark dazureichen."
+    ],
+    "id": "rec_53"
+  },
+  {
+    "title": "Knoblauchnudeln",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "542 kcal",
+      "Kohlenhydrate": "97,9 g",
+      "Fett": "10,7 g",
+      "Eiweiß": "16,4 g"
+    },
+    "ingredients": [
+      "250 g Spaghetti",
+      "Salz",
+      "2,5 Zehe(n) Knoblauch",
+      "125 g Kirschtomaten",
+      "5 g Basilikum",
+      "2 EL Olivenöl",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Spaghetti nach Packungsanweisung in Salzwasser kochen.",
+      "Knoblauch schälen und nach Belieben in feine Scheiben schneiden oder fein hacken. Tomaten waschen und halbieren. Basilikum waschen, trocken schütteln, Blätter abzupfen und hacken.",
+      "4-5 Minuten, bevor die Nudeln al dente sind, Öl erhitzen und den Knoblauch vorsichtig anbraten, er sollte nicht verbrennen. Tomaten zugeben und kurz andünsten.",
+      "Nudeln abgießen, dabei etwas Nudelwasser auffangen. Spaghetti zum Knoblauch in die Pfanne geben und vorsichtig unterheben. 3-4 EL Nudelwasser zugeben. Mit Salz und Pfeffer würzen. Basilikum darüber streuen und sofort servieren."
+    ],
+    "id": "rec_54"
+  },
+  {
+    "title": "Schnitzel mit Gurkensalat und Bratkartoffeln",
+    "tags": [],
+    "difficulty": "Mittel",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "647 kcal",
+      "Kohlenhydrate": "80,6 g",
+      "Fett": "14,9 g",
+      "Eiweiß": "47,1 g"
+    },
+    "ingredients": [
+      "0,5 Salatgurke",
+      "1,5 Stiel(e) Dill",
+      "1 EL ja! Schmand",
+      "1,5 EL ja! Condimento bianco",
+      "0,5 TL ja! Senf mittelscharf",
+      "ja! Jodsalz",
+      "ja! Pfeffer schwarz gemahlen",
+      "400 g Kartoffeln",
+      "1 Zwiebeln",
+      "1,5 EL ja! Natives Rapsöl",
+      "300 g Schweine-Schinkenschnitzel",
+      "1 Eier",
+      "2 EL ja! Weizenmehl Type 405",
+      "75 g ja! Paniermehl",
+      "0,5 Zitrone"
+    ],
+    "instructions": [
+      "Gurke waschen, nach Belieben schälen und in feine Scheiben hobeln. Dill waschen, trocken schütteln und fein hacken, einen Teil beiseitelegen. Schmand, Essig und Senf verrühren. Mit den Gurkenscheiben und dem Dill mischen und mit Salz und Pfeffer würzen. Mit dem restlichen Dill bestreuen.",
+      "Kartoffeln schälen und in dünne Scheiben schneiden. Zwiebeln schälen und würfeln. 1 EL Öl in einer Pfanne erhitzen und die Kartoffelscheiben anbraten. Unter gelegentlichem Wenden gut 10 Minuten mit Deckel braten, dann Zwiebeln zugeben und weitere 10 Minuten ohne Deckel braten, bis Kartoffelscheiben gar und knusprig sind. Mit Salz und Pfeffer würzen.",
+      "Schnitzel waschen und trocken tupfen, flach klopfen. Mit Salz und Pfeffer würzen.",
+      "Eier in einem tiefen Teller verquirlen. Mehl auf einen flachen Teller geben, Paniermehl auf einen weiteren Teller.",
+      "Schnitzel erst von beiden Seiten im Mehl wenden, dann durch das verquirlte Ei ziehen und zum Schluss im Paniermehl wälzen.",
+      "2 EL Öl erhitzen und die Schnitzel bei mittlerer Hitze von beiden Seiten knusprig braten. Auf Küchenpapier abtropfen lassen.",
+      "Zitrone waschen, in Spalten schneiden und zusammen mit Schnitzel und dem Gurkensalat anrichten."
+    ],
+    "id": "rec_55"
+  },
+  {
+    "title": "Tagliatelle mit Fenchel",
+    "tags": [
+      "Vegan",
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "441 kcal",
+      "Kohlenhydrate": "83,3 g",
+      "Fett": "6,5 g",
+      "Eiweiß": "14,6 g"
+    },
+    "ingredients": [
+      "200 g Tagliatelle",
+      "Salz",
+      "1 Knolle(n) Fenchel",
+      "0,5 Zitrone",
+      "0,5 Bd . Petersilie",
+      "1 EL Öl",
+      "1 Zehe(n) Knoblauch",
+      "Pfeffer, frisch gemahlen"
+    ],
+    "instructions": [
+      "Nudeln nach Packungsanweisung in kochendem Salzwasser garen. Fenchel putzen, waschen, Strunk entfernen und Fenchel in dünne Streifen schneiden. Zitrone heiß waschen, Schale abreiben und Saft auspressen. Petersilie waschen, trocken schütteln, zupfen und grob hacken.",
+      "Öl in einer Pfanne erhitzen. Knoblauch schälen, fein hacken und in Öl anbraten. Fenchel hinzufügen und in der Pfanne anrösten.",
+      "Nudeln abgießen, dabei ein kleines Glas des Nudelwassers auffangen.",
+      "Nudelwasser und Zitronensaft zum Fenchel geben, kurz köcheln lassen und mit Salz und Pfeffer würzen. Nudeln, Petersilie und etwas Zitronenabrieb hinzugeben und alles vermengen.",
+      "Nudeln auf vier tiefen Tellern anrichten und servieren."
+    ],
+    "id": "rec_56"
+  },
+  {
+    "title": "Spaghetti mit köstlichem Tomatenpesto",
+    "tags": [
+      "Vegetarisch",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "605 kcal",
+      "Kohlenhydrate": "103 g",
+      "Fett": "12,8 g",
+      "Eiweiß": "21,3 g"
+    },
+    "ingredients": [
+      "250 g Spaghetti",
+      "Salz",
+      "0,5 Knoblauch Zehe(n)",
+      "140 ml getrocknete Tomaten in Öl mit Oregano",
+      "0,5 Dose(n) stückige Tomaten",
+      "2 Stiel(e) Basilikum",
+      "1 TL ja! Tomatenmark",
+      "Bunter Pfeffer aus der Mühle",
+      "Fleur de Sel",
+      "Zucker",
+      "evtl. Aceto Balsamico",
+      "15 g Parmesan"
+    ],
+    "instructions": [
+      "Nudeln in kochendem Salzwasser nach Packungsanweisung zubereiten.",
+      "Knoblauch schälen und mit den getrockneten Tomaten in ein hohes Rührgefäß geben. Die Hälfte der stückigen Tomaten und etwas Tomatenöl (aus dem Glas) zufügen und mit dem Pürierstab fein pürieren.",
+      "Basilikum waschen, trocken schütteln. Blättchen von 2 Stielen fein hacken, mit dem Schneebesen unter das Pesto rühren. Die restlichen stückigen Tomaten unterheben und mit Tomatenmark, buntem Pfeffer aus der Mühle, etwas Fleur de Sel, Zucker und evtl. Balsamico-Essig abschmecken. Nudeln abgießen und sofort mit dem Pesto locker vermengen. Nudeln anrichten und mit Basilikum garnieren. Parmesan darüberhobeln."
+    ],
+    "id": "rec_57"
+  },
+  {
+    "title": "Vegetarische Partysuppe mit Bohnen",
+    "tags": [
+      "Vegetarisch",
+      "Low Carb",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "263 kcal",
+      "Kohlenhydrate": "28,6 g",
+      "Fett": "12,2 g",
+      "Eiweiß": "9,1 g"
+    },
+    "ingredients": [
+      "0,25 Zwiebel",
+      "1 Zehe(n) Knoblauch",
+      "0,5 rote Paprika",
+      "0,5 gelbe Paprika",
+      "125 g weiße Riesenbohnen",
+      "1 EL Olivenöl",
+      "0,5 TL Zucker",
+      "1,5 EL Tomatenmark",
+      "0,25 Dose(n) stückige Tomaten (400 g)",
+      "62,5 ml Rotwein (trocken)",
+      "0,3 l Gemüsebrühe",
+      "0,13 Bd . Petersilie",
+      "Pfeffer",
+      "Salz",
+      "Chiliflocken",
+      "75 g saure Sahne"
+    ],
+    "instructions": [
+      "Zwiebel und Knoblauch schälen und in Würfel schneiden. Paprika waschen, entkernen und in Würfel schneiden. Bohnen abtropfen lassen.",
+      "Olivenöl in einem Topf erhitzen, Zwiebeln und Knoblauch darin anbraten. Mit Zucker kurz karamellisieren lassen. Tomatenmark, stückige Tomaten und Paprika hinzufügen und mit Rotwein ablöschen. Dann Gemüsebrühe zugeben und alles ca. 20 Minuten köcheln lassen. Ca. 2 Minuten vor Ende der Garzeit die Bohnen zugeben.",
+      "Währenddessen Petersilie waschen, trocken schütteln und hacken.",
+      "Suppe mit Pfeffer, Salz und Chiliflocken abschmecken und die saure Sahne unterziehen.",
+      "Mit Petersilie garniert servieren."
+    ],
+    "id": "rec_58"
+  },
+  {
+    "title": "Haferflockenschnitzel mit Gurkensalat",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "454 kcal",
+      "Kohlenhydrate": "61,9 g",
+      "Fett": "19,5 g",
+      "Eiweiß": "11,3 g"
+    },
+    "ingredients": [
+      "110 g zarte Haferflocken",
+      "0,75 TL Senf",
+      "Salz",
+      "1,5 TL Paprikapulver edelsüß",
+      "0,5 TL Knoblauchpulver",
+      "Pfeffer",
+      "1 Salatgurken",
+      "0,5 Schalotte",
+      "0,25 Beet(e) Kresse",
+      "0,5 EL Weißweinessig",
+      "1 EL Rapsöl",
+      "40 g Paniermehl",
+      "Öl zum Braten",
+      "0,5 Zitrone"
+    ],
+    "instructions": [
+      "Haferflocken mit 250 ml kochendem Wasser übergießen. Senf, Salz, Paprikapulver, Knoblauchpulver und Pfeffer zugeben, alles verrühren und 10 Minuten quellen lassen.",
+      "Währenddessen die Gurke waschen und in dünne Scheiben hobeln. Schalotte schälen und fein würfeln. Gurken, Schalotten und Kresse in eine Salatschüssel geben. Essig und Öl verrühren und mit Pfeffer und Salz würzen. Paniermehl auf einen Teller geben. 4 Kugeln aus der Hafermasse formen und im Paniermehl zu Schnitzeln drücken und wenden.",
+      "Öl in einer Pfanne erhitzen und die Schnitzel nacheinander ausbraten. Zitrone in Spalten schneiden. Dressing an den Salat geben und Schnitzel mit Salat und Zitronenspalten servieren."
+    ],
+    "id": "rec_59"
+  },
+  {
+    "title": "Nudelauflauf mit Schmand und Hack",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "1136 kcal",
+      "Kohlenhydrate": "91,8 g",
+      "Fett": "64,5 g",
+      "Eiweiß": "52 g"
+    },
+    "ingredients": [
+      "150 g ja! Buttergemüse (TK)",
+      "160 g ja! Penne Rigate",
+      "Salz",
+      "0,5 große Zwiebel",
+      "1 Zehe(n) Knoblauch",
+      "1 EL ja! Rapsöl",
+      "200 g ja! Hackfleisch gemischt",
+      "250 g ja! Tomaten passiert",
+      "Pfeffer",
+      "0,5 Prise(n) Zucker",
+      "0,25 TL Oregano getrocknet",
+      "0,13 TL Thymian getrocknet",
+      "100 g ja! Schmand",
+      "125 g ja! geriebener Gratin- und Pizzakäse"
+    ],
+    "instructions": [
+      "Buttergemüse antauen lassen. Nudeln in Salzwasser bissfest kochen. Zwiebel und Knoblauch schälen, würfeln. Backofen auf 180 °C Ober-/Unterhitze vorheizen.",
+      "Öl in einer Pfanne erhitzen, Hackfleisch scharf anbraten. Zwiebeln, Buttergemüse und Knoblauch dazugeben und kurz mitdünsten. Tomaten zufügen, aufkochen. Mit Salz, Pfeffer, Zucker, Oregano und Thymian abschmecken. Schmand unterrühren.",
+      "Nudeln und Soße in eine Auflaufform geben. Gut vermengen und mit Käse bestreuen. Im Ofen 15-20 Minuten backen."
+    ],
+    "id": "rec_60"
+  },
+  {
+    "title": "Einfacher Wrap",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "828 kcal",
+      "Kohlenhydrate": "73,7 g",
+      "Fett": "46 g",
+      "Eiweiß": "32,2 g"
+    },
+    "ingredients": [
+      "2 ja ! Hähnchen Mini Schnitzel",
+      "2 Tortilla -Wraps",
+      "2 EL Frischkäse",
+      "25 g Nachos",
+      "0,5 Avocado",
+      "0,25 Limette",
+      "Chilisalz",
+      "Kreuzkümmel (gemahlen)",
+      "1 Salatherzen",
+      "1 EL Rapsöl",
+      "50 g Cheddar, gerieben"
+    ],
+    "instructions": [
+      "Mini Hähnchenschnitzel auftauen lassen (ggf. in der Mikrowelle).",
+      "Tortillawraps zu ¼ einschneiden und ¼ mit 1 EL Frischkäse bestreichen. Darüber je eine Handvoll Nachos zerbröseln.",
+      "Avocado schälen, den Kern entfernen und das Fruchtfleisch in Scheiben schneiden. Sofort mit Limettensaft beträufeln und mit Chilisalz und Kreuzkümmel würzen. Auf dem nächsten Viertel verteilen.",
+      "Salatherzen waschen, trocken schleudern und in Streifen schneiden. ¼ des Wraps mit Salat belegen.",
+      "Hähnchenschnitzel in 2 EL Öl anbraten, in Streifen schneiden und das nächste Viertel damit belegen. Cheddar auf die Hähnchenstreifen streuen.",
+      "Wrap von Viertel zu Viertel aufeinander falten (mit dem Frischkäse-Tortilla-Chips-Viertel beginnen) und kurz in der Pfanne oder einem Kontaktgrill grillen."
+    ],
+    "id": "rec_61"
+  },
+  {
+    "title": "Pizzataschen mit Schinken",
+    "tags": [
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "435 kcal",
+      "Kohlenhydrate": "36,9 g",
+      "Fett": "26,3 g",
+      "Eiweiß": "13,9 g"
+    },
+    "ingredients": [
+      "0,17 Zwiebel",
+      "0,17 rote Zwiebel",
+      "0,5 EL ja! Sonnenblumenöl",
+      "20,8 g ja! Schinkenwürfel",
+      "33,3 g ja! Frischkäse Natur Doppelrahmstufe",
+      "16,7 g ja! Schmand",
+      "0,5 Zweig(e) Basilikum",
+      "0,83 Tomaten",
+      "Salz",
+      "Pfeffer",
+      "0,33 Pck . Pizzateig (Kühlregal)",
+      "1 TL Paniermehl",
+      "0,17 Eigelb",
+      "0,33 EL ja! Milch",
+      "33,3 g ja! Geriebener Gouda",
+      "33,3 g Cocktailtomaten",
+      "0,5 Stück Romana-Salatherzen",
+      "0,67 EL Weißwein-Essig",
+      "0,08 TL ja! mittelscharfer Senf",
+      "Zucker"
+    ],
+    "instructions": [
+      "Zwiebeln schälen. Die weiße Zwiebel fein würfeln, die rote Zwiebel in Ringe schneiden und für den Salat beiseitelegen. 1 EL Öl in einer Pfanne erhitzen. Zwiebel- und Schinkenwürfel zugeben, 2–3 Minuten dünsten. Zwiebel-Schinkenmischung herausnehmen und in eine Schüssel geben. Frischkäse und Schmand zugeben, glatt rühren.",
+      "Basilikum waschen und trocken schütteln. Blättchen abzupfen und hacken. Tomaten waschen und putzen, dann vierteln und entkernen. Fruchtfleisch in kleine Würfel schneiden. Tomatenwürfel und Basilikum unter die Frischkäsecreme heben. Käsecreme mit Salz und Pfeffer würzen.",
+      "Teig entrollen. Teig vom Papier lösen und auf eine bemehlte Arbeitsfläche legen. Teig je in 6 Vierecke schneiden und mittig je mit 1/2 TL Paniermehl bestreuen. Käsecreme in die Teigmitte geben. Eigelb und Milch verrühren. Teigränder damit einpinseln. Vierecke diagonal zusammenklappen, die Ränder zusammendrücken. Pizzataschen auf ein mit Backpapier ausgelegtes Backblech legen. Mit der Eigelbmischung bestreichen und Käse darüberstreuen. Im vorgeheizten Backofen (E-Herd: 200 °C/ Umluft: 175 °C/ Gas: Stufe 3) 20 Minuten backen.",
+      "Für den Salat die Cocktailtomaten waschen und halbieren. Salat waschen, trocken schütteln und die Blätter klein zupfen. Essig und Senf verrühren. Mit Salz, Pfeffer und Zucker würzen. 2 EL Öl darunterschlagen und nochmals abschmecken. Vinaigrette, Zwiebelringe und Tomaten vermengen. Pizzataschen aus dem Backofen nehmen. Mit Salat auf Tellern anrichten."
+    ],
+    "id": "rec_62"
+  },
+  {
+    "title": "Blumenkohl-Hack-Nudelauflauf",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "1082 kcal",
+      "Kohlenhydrate": "106 g",
+      "Fett": "52,9 g",
+      "Eiweiß": "50,9 g"
+    },
+    "ingredients": [
+      "250 g Fusilli",
+      "Salz",
+      "0,5 Blumenkohl",
+      "0,5 große Zwiebel",
+      "0,5 Zehe(n) Knoblauch",
+      "1,5 EL Rapsöl",
+      "250 g gemischtes Hackfleisch",
+      "1 EL Tomatenmark",
+      "Pfeffer",
+      "50 ml Gemüsebrühe",
+      "2 Eier",
+      "100 ml Sahne"
+    ],
+    "instructions": [
+      "Nudeln nach Packungsanleitung in Salzwasser gar kochen und abtropfen lassen.",
+      "Währenddessen Blumenkohl waschen und in Röschen schneiden. In Salzwasser etwa 3-4 Minuten blanchieren, mit kaltem Wasser abschrecken und gut abtropfen lassen. Backofen auf 180 °C Ober-/Unterhitze vorheizen.",
+      "Zwiebel und Knoblauch schälen und fein hacken. Öl in einer Pfanne erhitzen, beides darin anschwitzen und das Hackfleisch zufügen. Tomatenmark unterrühren, salzen, pfeffern und mit 100 ml Gemüsebrühe ablöschen. Vom Herd nehmen.",
+      "Eier kräftig verquirlen, Sahne unterrühren und mit Salz und Pfeffer würzen.",
+      "In eine Auflaufform zuerst die Nudeln, dann das Hackfleisch, dann die Blumenkohlröschen schichten und zum Schluß mit der Eiersahne übergießen. 45 Minuten goldgelb backen."
+    ],
+    "id": "rec_63"
+  },
+  {
+    "title": "Herzhafter Brotauflauf",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "527 kcal",
+      "Kohlenhydrate": "46,6 g",
+      "Fett": "32,6 g",
+      "Eiweiß": "14,3 g"
+    },
+    "ingredients": [
+      "1,5 Fleischtomaten",
+      "125 g Brot (z. B. Ciabatta oder Graubrot)",
+      "Fett für die Form",
+      "1 Becher Crème fraîche",
+      "2,5 EL Milch",
+      "1,5 Eier (Größe M)",
+      "Salz",
+      "Pfeffer",
+      "0,13 Bd . Basilikum"
+    ],
+    "instructions": [
+      "Tomaten putzen, waschen und in Scheiben schneiden. Brot ebenfalls in Scheiben schneiden. Eine Auflaufform fetten und Tomaten und Brot abwechselnd einschichten. Backofen auf 200°C Ober-/ Unterhitze vorheizen.",
+      "Crème fraîche, Milch und Eier verquirlen. Mit Salz und Pfeffer abschmecken und über den Auflauf gießen. Auflauf im vorgeheizten Backofen ca. 20 Minuten backen, bis das Ei gestockt ist. Basilikum waschen, trocken schütteln und hacken. Basilikum über den fertigen Auflauf streuen."
+    ],
+    "id": "rec_64"
+  },
+  {
+    "title": "Kartoffelsalat mit Mayonnaise",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "525 kcal",
+      "Kohlenhydrate": "47,5 g",
+      "Fett": "32,2 g",
+      "Eiweiß": "11,7 g"
+    },
+    "ingredients": [
+      "0,5 kg festkochende Kartoffeln",
+      "Salz",
+      "0,5 TL Kümmel",
+      "1 Zwiebeln",
+      "100 ml Gemüsebrühe",
+      "1,5 EL Obstessig",
+      "1,5 EL mittelscharfer Senf",
+      "0,5 EL ja! Zucker",
+      "Pfeffer",
+      "1,5 EL Pflanzenöl",
+      "50 g ja! Delikatess-Mayonnaise",
+      "2 Gewürzgurken",
+      "1,5 Eier"
+    ],
+    "instructions": [
+      "Kartoffeln waschen und mit Schale in Salzwasser gar kochen. Kümmel dazugeben. Zwiebel schälen und in feine Würfel schneiden. Kartoffeln pellen und etwas auskühlen lassen, dann in Scheiben schneiden und in eine Schüssel geben. Gewürzgurken in Würfel schneiden. Eier hart kochen, abkühlen lassen und vierteln.",
+      "Gemüsebrühe in einem Topf aufkochen, Zwiebelwürfel hinzugeben und die Brühe kräftig mit Essig, Senf, Zucker, Salz und Pfeffer würzen. Öl zur Brühe geben und Topf vom Herd nehmen.",
+      "Die heiße Brühe über die warmen Kartoffelscheiben gießen und vorsichtig unterheben. Kartoffelsalat 20-30 Minuten durchziehen lassen. Mayonnaise vorsichtig unterheben, Gurken und Eier dazu geben und mit Salz und Pfeffer abschmecken."
+    ],
+    "id": "rec_65"
+  },
+  {
+    "title": "Kartoffelsuppe mit Würstchen",
+    "tags": [
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "495 kcal",
+      "Kohlenhydrate": "69,4 g",
+      "Fett": "17,7 g",
+      "Eiweiß": "15,5 g"
+    },
+    "ingredients": [
+      "0,5 Zwiebel",
+      "1 Karotten",
+      "0,75 kg mehlige Kartoffeln",
+      "1 EL Sonnenblumenöl",
+      "0,6 l Gemüsebrühe",
+      "Salz",
+      "Pfeffer",
+      "1 TL getrockneter Majoran",
+      "1 Bockwürste",
+      "0,25 Bd . Petersilie"
+    ],
+    "instructions": [
+      "Zwiebel schälen und würfeln. Karotten schälen und in Scheiben schneiden. Kartoffeln schälen und grob würfeln.",
+      "Zwiebel in Öl goldgelb anbraten. Dann Karotten-und Kartoffelwürfel dazugeben und mitdünsten.",
+      "Mit Gemüsebrühe angießen. Mit Salz, Pfeffer und Majoran würzen und etwa 20 Minuten köcheln lassen.",
+      "Würste in Scheiben schneiden. Suppe entweder mit dem Kartoffelstampfer zerdrücken oder, wer es feiner mag, mit dem Pürierstab pürieren. Petersilie waschen, trocken schütteln und fein hacken. Suppe mit Würstchen und Petersilie garnieren und servieren."
+    ],
+    "id": "rec_66"
+  },
+  {
+    "title": "Kichererbsen-Pfanne mit Spinat",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Low Carb",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "232 kcal",
+      "Kohlenhydrate": "32,5 g",
+      "Fett": "8,4 g",
+      "Eiweiß": "10,7 g"
+    },
+    "ingredients": [
+      "1 Gläser Kichererbsen 220g",
+      "150 g Blattspinat",
+      "200 g Tomaten",
+      "1 große Zwiebeln",
+      "1 EL Olivenöl",
+      "Salz",
+      "0,5 TL Curry"
+    ],
+    "instructions": [
+      "Kichererbsen abtropfen lassen. Spinat und Tomaten waschen. Tomaten in grobe Würfel schneiden. Zwiebel schälen und in feine Würfel schneiden.",
+      "Öl in einer Pfanne erhitzen und Zwiebeln darin anbraten. Kichererbsen, Tomaten und Spinat dazugeben und kurz andünsten. Mit Salz und Curry würzen."
+    ],
+    "id": "rec_67"
+  },
+  {
+    "title": "Risi Bisi mit Erbsen und Champignons",
+    "tags": [
+      "Vegetarisch",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "394 kcal",
+      "Kohlenhydrate": "67 g",
+      "Fett": "7,82 g",
+      "Eiweiß": "16,6 g"
+    },
+    "ingredients": [
+      "125 g ja! Langkorn-Reis",
+      "300 ml ja! Gemüsebrühe",
+      "150 g ja! TK-Erbsen",
+      "125 g Champignons",
+      "1 Zwiebeln",
+      "0,5 EL ja! Rapsöl",
+      "50 g ja! Hirtenkäse"
+    ],
+    "instructions": [
+      "Reis mit der Gemüsebrühe aufkochen und bei schwacher Hitze ca. 10 Minuten quellen, bis der Reis gar und die Flüssigkeit aufgesogen ist. Nach 5 Minuten die gefrorenen Erbsen zugeben.",
+      "In der Zwischenzeit Champignons putzen und in Scheiben schneiden. Zwiebeln schälen und hacken.",
+      "Öl erhitzen, die Zwiebeln und Champignons braten. Unter das fertige Risi Bisi heben.",
+      "Hirtenkäse zerbröseln und über das Risi Bisi streuen."
+    ],
+    "id": "rec_68"
+  },
+  {
+    "title": "Spaghetti Carbonara vegan",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "797 kcal",
+      "Kohlenhydrate": "103 g",
+      "Fett": "32,3 g",
+      "Eiweiß": "27,7 g"
+    },
+    "ingredients": [
+      "100 g Räuchertofu",
+      "250 g Spaghetti",
+      "Salz",
+      "0,5 Schalotte",
+      "0,5 Zehe(n) Knoblauch",
+      "7,5 g Petersilie",
+      "1 EL Olivenöl",
+      "200 ml Sojacreme Cuisine",
+      "1 EL Margarine (ggf. vegan)",
+      "Pfeffer",
+      "Kala Namak (Schwefelsalz)",
+      "1 EL Sonnenblumenkerne"
+    ],
+    "instructions": [
+      "Tofu klein würfeln. Nudeln nach Packungsanweisung in Salzwasser al dente kochen. 1 Tasse Nudelwasser aufbewahren.",
+      "Schalotte und Knoblauch schälen, fein würfeln. Petersilie waschen, trocken schütteln, hacken.",
+      "1 EL Öl in einer Pfanne erhitzen. Räuchertofu darin ca. 5 Minuten kross anbraten, herausnehmen.",
+      "1 EL Öl in der Pfanne erhitzen, Schalotte und Knoblauch darin anschwitzen, mit Sojacreme ablöschen, Margarine einrühren. Mit Salz, Pfeffer und etwas Kala Namak (für den Ei-Geschmack) abschmecken.",
+      "Nudeln abgießen, abtropfen lassen und mit dem Tofu in die Pfanne geben. Sonnenblumenkerne in einer Pfanne ohne Fett rösten. Alles gut durchschwenken, nochmals erhitzen, ggf. etwas Nudelwasser zufügen und mit Petersilie und Kernen bestreut servieren."
+    ],
+    "id": "rec_69"
+  },
+  {
+    "title": "Rinderrouladen mit Kartoffeln und Rotkohl",
+    "tags": [
+      "Laktosefrei"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "476 kcal",
+      "Kohlenhydrate": "50,9 g",
+      "Fett": "20,6 g",
+      "Eiweiß": "23,3 g"
+    },
+    "ingredients": [
+      "2 ja ! Cornichons",
+      "160 g ja! Rinder Minutensteaks",
+      "1 TL ja! Senf mittelscharf",
+      "0,5 Zwiebel",
+      "1 EL ja! Natives Rapsöl",
+      "0,5 EL ja! Tomatenmark 3-fach konzentriert",
+      "100 ml Traubensaft",
+      "100 ml ja! Klare Gemüsebrühe (Pulver)",
+      "1 Lorbeerblätter",
+      "400 g Kartoffeln",
+      "ja! Jodsalz",
+      "360 g ja! Rotkohl mit Apfelstücken",
+      "ja! Pfeffer schwarz gemahlen",
+      "0,5 TL Küchenmeister Speisestärke"
+    ],
+    "instructions": [
+      "Gurken in feine Streifen schneiden. Minutensteaks flach klopfen, mit Senf bestreichen und mit Gurkenscheiben belegen. Das Fleisch eng aufrollen und mit Zahnstochern oder Rouladennadeln feststecken.",
+      "Zwiebel schälen und in feine Würfel schneiden. Öl in einem Topf mit dickem Boden erhitzen und Rouladen kräftig anbraten. Zwiebeln zugeben und kurz mitbraten. Tomatenmark zugeben, kurz mitbraten, dann mit Traubensaft und Brühe ablöschen. Lorbeerblätter zugeben. Deckel auflegen und bei mittlerer Hitze gut 70 Minuten schmoren.",
+      "Kartoffeln schälen und in Salzwasser garen.",
+      "Rotkohl erwärmen.",
+      "Das fertig gegarte Fleisch aus der Soße nehmen. Speisestärke mit etwas Wasser anrühren, in die Soße geben und andicken. Mit Salz und Pfeffer abschmecken. Rouladen wieder zugeben.",
+      "Rouladen mit Kartoffeln und Rotkohl anrichten."
+    ],
+    "id": "rec_70"
+  },
+  {
+    "title": "Hackbällchen in Tomatensauce",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "488,2 kcal",
+      "Kohlenhydrate": "14,8 g",
+      "Fett": "33,6 g",
+      "Eiweiß": "34,3 g"
+    },
+    "ingredients": [
+      "300 g Wilhelm Brandenburg Hackfleisch (gemischt)",
+      "0,5 Ei (Zimmertemperatur)",
+      "1 EL Paniermehl",
+      "0,5 EL Senf",
+      "Salz",
+      "Pfeffer",
+      "0,5 TL Italienische Kräuter",
+      "1 EL Sonnenblumenöl nativ",
+      "200 g Porree",
+      "0,5 Dose(n) stückige Tomaten (500 g)",
+      "1 EL ja! Tomatenmark",
+      "75 ml Gemüsebrühe"
+    ],
+    "instructions": [
+      "Hackfleisch, Ei, Paniermehl und Senf verkneten. Mit Salz, Pfeffer und 0,5 TL getrockneten Kräutern würzen. Aus der Hackmasse kleine Bällchen formen.",
+      "Öl in einer Pfanne erhitzen. Bällchen darin bei mittlerer Hitze 10 Minuten lang braten. Porree putzen, waschen und in Ringe schneiden. Hackklößchen herausnehmen.",
+      "Porree im Bratöl kurz andünsten. Tomaten und Tomatenmark zugeben. Brühe angießen und aufkochen. Alles ca. 5 Minuten kochen lassen. Mit Salz, Pfeffer und 0,5 TL getrockneten Kräutern abschmecken. Hackbällchen zugeben und kurz mit erwärmen. Mit Baguette servieren."
+    ],
+    "id": "rec_71"
+  },
+  {
+    "title": "Schnelles Chili con Carne",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "652 kcal",
+      "Kohlenhydrate": "49,8 g",
+      "Fett": "36,3 g",
+      "Eiweiß": "38,1 g"
+    },
+    "ingredients": [
+      "1 Zwiebeln (à ca. 60 g)",
+      "1 Knoblauchzehen",
+      "0,5 Dose(n) ja! Kidney-Bohnen (255 g)",
+      "0,5 Dose(n) ja! Super Sweet Mais (425 ml)",
+      "1 EL ja! Natives Rapsöl",
+      "250 g ja! Hackfleisch gemischt",
+      "0,5 EL ja! Tomatenmark 3-fach konzentriert",
+      "0,5 Dose(n) ja! Fein gehackte Tomaten (400 g)",
+      "100 ml ja! Gemüsebrühe",
+      "1,5 Stiel(e) Petersilie",
+      "Salz",
+      "Pfeffer",
+      "0,25 TL Kreuzkümmel (gemahlen)",
+      "Zucker",
+      "2 Spritzer Tabasco",
+      "75 g ja! Saure Sahne"
+    ],
+    "instructions": [
+      "Zwiebeln schälen, halbieren und fein würfeln. Knoblauch schälen und fein hacken. Bohnen in ein Sieb gießen, mit kaltem Wasser abspülen und gut abtropfen lassen. Mais zu den Bohnen geben und ebenfalls abtropfen lassen.",
+      "Öl in einem großen Topf erhitzen. Hack darin 6–8 Minuten krümelig anbraten. Tomatenmark darin anschwitzen. Zwiebeln und Knoblauch darin andünsten. Mit Tomaten und Brühe ablöschen, aufkochen lassen. Bohnen und Mais zugeben. Ca. 10 bis 15 Minuten bei niedriger Hitze köcheln lassen.",
+      "Inzwischen Petersilie waschen trocken schütteln, Blättchen von den Stielen zupfen und fein hacken. 2/3 der Petersilie unter das Chili rühren. Mit Salz, Pfeffer, Kreuzkümmel, Zucker und Tabasco abschmecken. Chili in Schälchen anrichten. Je einen Klecks saure Sahne darauf geben und mit restlicher Petersilie bestreuen. Dazu schmecken Tortillachips."
+    ],
+    "id": "rec_72"
+  },
+  {
+    "title": "Mac'n'Cheese (Käse-Makkaroni)",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "700 kcal",
+      "Kohlenhydrate": "59,8 g",
+      "Fett": "39,4 g",
+      "Eiweiß": "28,6 g"
+    },
+    "ingredients": [
+      "125 g Makkaroni",
+      "Salz",
+      "22,5 g Butter",
+      "10 g Weizenmehl Type 405",
+      "100 ml Milch",
+      "50 g Sahne",
+      "Pfeffer",
+      "0,25 TL Senf",
+      "0,25 TL Paprikapulver",
+      "50 g Cheddar",
+      "50 g Emmentaler",
+      "25 g Parmesan",
+      "0,25 Knoblauchzehe",
+      "12,5 g Paniermehl"
+    ],
+    "instructions": [
+      "Makkaroni nach Packungsanweisung in kochendem Salzwasser bissfest kochen.",
+      "60 g Butter in einem Topf schmelzen und Mehl darübersieben. Unter Rühren kurz anschwitzen lassen und Milch und Sahne langsam unter Rühren zugießen. Aufkochen und mit Salz und Pfeffer würzen und Senf und Paprikapulver unterrühren. Ca. 10 Minuten bei schwacher Hitze köcheln lassen. Cheddar, Emmentaler und Parmesan reiben.",
+      "Makkaroni abgießen und mit der Béchamelsoße und den 3 Käsesorten in einer Schüssel mischen, der Käse sollte dabei schmelzen. Knoblauchzehe schälen, halbieren und eine Auflaufform mit der halbierten Zehe ausstreichen. Käse-Nudel-Masse in die Auflaufform füllen.",
+      "30 g Butter in einer Pfanne schmelzen und Paniermehl darin kurz anrösten. Geröstetes Paniermehl über den Makkaroni verteilen und den Auflauf im vorgeheizten Backofen (Ober-/ Unterhitze: 175 °C) ca. 35 Minuten goldbraun backen."
+    ],
+    "id": "rec_73"
+  },
+  {
+    "title": "Orientalischer Instant-Couscous im Topf",
+    "tags": [
+      "Vegetarisch",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "604 kcal",
+      "Kohlenhydrate": "121 g",
+      "Fett": "7,7 g",
+      "Eiweiß": "18,2 g"
+    },
+    "ingredients": [
+      "8 Aprikosen , getrocknet",
+      "1 Tasse(n) Couscous",
+      "2 EL gesalzene Pistazien",
+      "3 TL Gemüsebrühe",
+      "0,5 TL Knoblauch granuliert",
+      "1 TL Zwiebeln granuliert",
+      "1 TL Kurkuma",
+      "0,5 TL Chiliflocken",
+      "0,5 TL Ras el Hanout",
+      "1 Msp . Pfeffer"
+    ],
+    "instructions": [
+      "Aprikosen in Streifen oder Würfel schneiden.",
+      "Zusammen mit Couscous, Pistazien, Gemüsebrühe, Knoblauchgranulat, Zwiebelgranulat und Gewürzen in einen verschließbaren Plastikbeutel geben. Gut durchschütteln.",
+      "Für die Zubereitung 2 Tassen Wasser auf dem Gaskocher in einem Topf erhitzen, den Beutel öffnen und den Beutelinhalt in das kochende Wasser einrühren. Kurz ziehen lassen und servieren."
+    ],
+    "id": "rec_74"
+  },
+  {
+    "title": "Gemüse-Pasta mit Speck",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "758 kcal",
+      "Kohlenhydrate": "104,9 g",
+      "Fett": "33 g",
+      "Eiweiß": "21,8 g"
+    },
+    "ingredients": [
+      "25 g ja! Delicatess Bacon",
+      "400 g ja! Kaisergemüse TK",
+      "0,5 Zwiebel",
+      "0,5 EL ja! Sonnenblumenöl",
+      "100 g ja! Schlagsahne",
+      "ja! Jodsalz",
+      "Pfeffer",
+      "200 g ja! Fusilli",
+      "0,5 Knoblauchzehe",
+      "1 Scheibe(n) ja! American Sandwich",
+      "1 EL ja! Markenbutter"
+    ],
+    "instructions": [
+      "Gemüse auftauen lassen. Zwiebel schälen und fein würfeln. Öl in einer Pfanne erhitzen, Zwiebel darin andünsten. Gemüse zugeben und mitbraten. Mit Sahne ablöschen, mit Salz und Pfeffer würzen und ca. 5 Minuten köcheln lassen.",
+      "Nudeln nach Packungsanweisung in Salzwasser kochen. Speck in einer Pfanne ohne Fett knusprig auslassen. Knoblauch schälen und fein hacken. Toast würfeln. Speck aus der Pfanne nehmen. Butter im Speckfett schmelzen. Knoblauch und Toastwürfel kurz darin braten.",
+      "Nudeln abgießen, mit der Soße mischen. Mit Speck und Croutons anrichten."
+    ],
+    "id": "rec_75"
+  },
+  {
+    "title": "Vegetarisches Chili (Chili sin carne)",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "489 kcal",
+      "Kohlenhydrate": "69,5 g",
+      "Fett": "15,8 g",
+      "Eiweiß": "25,9 g"
+    },
+    "ingredients": [
+      "50 g Soja-Schnetzel",
+      "225 ml Gemüsebrühe",
+      "1 große Zwiebeln",
+      "1,5 Knoblauchzehen",
+      "1 rote Chilischoten",
+      "0,5 rote Paprika",
+      "1 gelbe Paprika",
+      "0,5 Zucchini",
+      "1,5 EL Öl",
+      "0,5 TL Kreuzkümmel (gemahlen)",
+      "250 ml passierte Tomaten (400 g)",
+      "Salz",
+      "0,5 Dose(n) Kidneybohnen (255 g)",
+      "0,5 Dose(n) Mais (285 g)",
+      "75 g Crème fraîche"
+    ],
+    "instructions": [
+      "Soja-Schnetzel ca. 15 Minuten in heißer Gemüsebrühe einweichen. Zwiebeln und Knoblauch schälen und würfeln. Chilis waschen, entkernen und hacken. Paprikaschoten putzen, waschen und würfeln. Zucchini waschen und in Scheiben schneiden.",
+      "Öl in einem großen Topf erhitzen. Zwiebeln, Knoblauch, Chilis und Kreuzkümmel darin anschwitzen. Soja-Schnetzel abgießen, ausdrücken und zugeben. Paprika und Zucchini zugeben und mit andünsten. Mit passierten Tomaten ablöschen und mit Salz würzen. Ca. 15 Minuten köcheln lassen.",
+      "Kidneybohnen und Mais abgießen und zum Chili hinzufügen. Nochmals aufkochen und abschmecken. Mit einem Klecks Crème fraîche servieren. Dazu passt Reis."
+    ],
+    "id": "rec_76"
+  },
+  {
+    "title": "Blumenkohl-Kartoffel-Auflauf",
+    "tags": [
+      "Vegetarisch",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "447 kcal",
+      "Kohlenhydrate": "36,5 g",
+      "Fett": "27,9 g",
+      "Eiweiß": "16,2 g"
+    },
+    "ingredients": [
+      "0,5 kleiner Blumenkohl",
+      "250 g Kartoffeln (vorwiegend festkochend)",
+      "0,5 Zwiebel",
+      "Salz",
+      "0,5 EL Rapsöl",
+      "150 ml Gemüsebrühe",
+      "100 g Sahne",
+      "0,5 TL Speisestärke",
+      "Pfeffer",
+      "Muskat",
+      "50 g Gratinkäse"
+    ],
+    "instructions": [
+      "Blumenkohl putzen und in Röschen teilen. Kartoffeln schälen und in Scheiben schneiden. Zwiebel schälen und fein hacken.",
+      "Blumenkohl und Kartoffeln getrennt voneinander in kochendem Salzwasser ca. 5 Minuten blanchieren.",
+      "Öl erhitzen und Zwiebeln darin anschwitzen. Gemüsebrühe sowie Sahne zugießen und etwas einköcheln lassen. Stärke mit einem EL Wasser verrühren, unterrühren und kurz aufkochen lassen. Mit Salz, Pfeffer und Muskat würzen.",
+      "Kartoffeln und Blumenkohl in eine Auflaufform schichten. Sahnesoße darübergießen und mit Käse bestreuen. Im auf 175 °C Ober-/Unterhitze vorgeheizten Backofen 35-40 Minuten backen."
+    ],
+    "id": "rec_77"
+  },
+  {
+    "title": "Kartoffelgratin mit Käse",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "499 kcal",
+      "Kohlenhydrate": "43,5 g",
+      "Fett": "27,6 g",
+      "Eiweiß": "19,5 g"
+    },
+    "ingredients": [
+      "225 ml Milch",
+      "1 Lorbeerblätter",
+      "1 Zehe(n) Knoblauch",
+      "1 EL Butter",
+      "1 EL Weizenmehl Type 405",
+      "25 ml Sahne",
+      "Pfeffer",
+      "Salz",
+      "0,5 Prise(n) Muskat",
+      "0,5 kg Kartoffeln",
+      "100 g Gratinkäse"
+    ],
+    "instructions": [
+      "Milch mit Lorbeerblättern und geschälten Knoblauchzehen kurz aufkochen und anschließend 15 Minuten ziehen lassen. Danach Knoblauch und Lorbeerblätter herausnehmen. Butter in einem Topf zerlassen, Mehl darübersieben und kurz anschwitzen. Milch unter ständigem Rühren dazugeben. Soße kurz aufkochen lassen und anschließend 10 Minuten köcheln lassen. Sahne dazugeben. Mit Pfeffer, Salz und Muskat würzen.",
+      "Kartoffeln schälen und in dünne Scheiben hobeln. Auflaufform einfetten und die Kartoffelscheiben und die Soße abwechselnd in die Form schichten. Mit Gratinkäse bedecken.",
+      "Kartoffelgratin im vorgeheizten Backofen bei 180 °C Ober-/Unterhitze 40-45 Minuten backen."
+    ],
+    "id": "rec_78"
+  },
+  {
+    "title": "Kartoffel-Lauch-Suppe",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Zuckerfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "198 kcal",
+      "Kohlenhydrate": "25,4 g",
+      "Fett": "9,4 g",
+      "Eiweiß": "5,4 g"
+    },
+    "ingredients": [
+      "150 g Kartoffeln",
+      "125 g Möhren",
+      "125 g Lauch",
+      "1 Zehe(n) Knoblauch",
+      "1 EL Olivenöl",
+      "1,5 EL Gemüsebrühe",
+      "Thymian, gerebelt",
+      "1 Lorbeerblätter",
+      "0,25 TL Kurkuma",
+      "0,5 Zitrone",
+      "15 g Mandeln gehobelt",
+      "Salz",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Kartoffeln und Möhren schälen und in Würfel schneiden. Lauch putzen, in Ringe schneiden und waschen. Knoblauch schälen und fein würfeln.",
+      "In einem Topf Olivenöl erhitzen, Kartoffeln, Möhren und Lauch ca. 3 Minuten anbraten. Knoblauch dazugeben und kurz mitbraten.",
+      "Brühe in 1 l heißem Wasser anrühren und die Gemüsebrühe dazu gießen. Thymian, Lorbeerblätter und Kurkuma dazugeben und ca. 15 Minuten köcheln lassen.",
+      "Von der Zitrone die Schale abreiben und eine Hälfte auspressen. Mandeln in einer Pfanne ohne Fett goldgelb anrösten.",
+      "Lorbeerblätter entfernen, die Suppe pürieren, Zitronensaft dazugeben und mit Salz und Pfeffer würzen. Mandelblättchen und Zitronenschale über der Suppe verteilen und servieren."
+    ],
+    "id": "rec_79"
+  },
+  {
+    "title": "Schneller Nudelauflauf",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "602 kcal",
+      "Kohlenhydrate": "95 g",
+      "Fett": "15,9 g",
+      "Eiweiß": "23,8 g"
+    },
+    "ingredients": [
+      "200 g Farfalle",
+      "Salz",
+      "0,5 Zucchini",
+      "0,5 Aubergine",
+      "1 Zwiebeln",
+      "0,5 Zehe(n) Knoblauch",
+      "0,5 EL Olivenöl",
+      "1 Dose(n) stückige Tomaten (400 g)",
+      "Pfeffer",
+      "Paprikapulver edelsüß",
+      "Zucker",
+      "75 g Gratinkäse",
+      "Basilikum"
+    ],
+    "instructions": [
+      "Nudeln in Salzwasser sehr bissfest kochen.",
+      "Zucchini und Aubergine waschen und in Würfel schneiden. Zwiebeln und Knoblauch schälen und fein hacken.",
+      "Etwas Öl in einer Pfanne erhitzen und Zwiebeln und Knoblauch anschwitzen. Das Gemüse zugeben und anschwitzen. Tomaten zufügen und 5-10 Minuten köcheln lassen. Mit Salz, Pfeffer, Paprikapulver und Zucker abschmecken.",
+      "Nudeln abgießen und zusammen mit dem Gemüse in einer gefetteten Auflaufform verteilen. Gut vermengen, mit dem Käse bestreuen und im auf 180 °C Ober-/Unterhitze vorgeheizten Backofen ca. 15-20 Minuten überbacken bis der Käse geschmolzen ist.",
+      "Mit gehacktem Basilikum anrichten."
+    ],
+    "id": "rec_80"
+  },
+  {
+    "title": "Tortellini-Pfanne mit buntem Gemüse",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "760 kcal",
+      "Kohlenhydrate": "94 g",
+      "Fett": "32,6 g",
+      "Eiweiß": "26 g"
+    },
+    "ingredients": [
+      "0,5 Zwiebel",
+      "0,5 Brokkoli",
+      "125 g Cocktailtomaten",
+      "Salz",
+      "250 g Tortellini",
+      "35 g Speck",
+      "0,5 EL Rapsöl",
+      "100 ml Sahne",
+      "0,5 TL Speisestärke",
+      "Pfeffer",
+      "0,25 Bd . Schnittlauch"
+    ],
+    "instructions": [
+      "Zwiebel schälen und fein würfeln. Brokkoli waschen und kleine Röschen abschneiden. Tomaten waschen und halbieren. Brokkoli in Salzwasser kurz blanchieren.",
+      "Tortellini nach Packungsanweisung zubereiten.",
+      "Speck in einer beschichteten Pfanne auslassen, dann beiseitestellen. Etwas Öl erhitzen und die Zwiebel anschwitzen. Mit Sahne ablöschen. Brokkoli, Tomaten und Tortellini zugeben und kurz mitköcheln. Soße mit Speisestärke bei Bedarf etwas andicken. Speck zufügen, mit Salz und Pfeffer abschmecken.",
+      "Schnittlauch waschen, in Röllchen schneiden und Tortellini-Pfanne damit bestreuen."
+    ],
+    "id": "rec_81"
+  },
+  {
+    "title": "Kartoffelpuffer selber machen",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "477 kcal",
+      "Kohlenhydrate": "75 g",
+      "Fett": "15,9 g",
+      "Eiweiß": "9,9 g"
+    },
+    "ingredients": [
+      "0,5 kg Kartoffeln (vorwiegend festkochend oder mehligkochend)",
+      "0,5 Zwiebel",
+      "1 Eier",
+      "12,5 g Weizenmehl Type 405",
+      "12,5 g zarte Haferflocken",
+      "Salz",
+      "Pfeffer",
+      "Muskatnuss",
+      "2,5 EL Butterschmalz",
+      "0,5 Glas Apfelmus"
+    ],
+    "instructions": [
+      "Kartoffeln schälen, waschen und auf der Gemüsereibe fein reiben. Zwiebel abziehen und sehr fein hacken.",
+      "Kartoffelraspel in ein sauberes Küchentuch geben, das Tuch oben zusammendrehen und so die Flüssigkeit aus den Kartoffeln drücken.",
+      "In einer großen Schüssel Kartoffelraspeln, Zwiebeln, Eier, Mehl und Haferflocken vermengen. Masse mit Salz und wenig Pfeffer sowie Muskatnuss würzen.",
+      "2 EL Butterschmalz in einer beschichteten Pfanne erhitzen und mit Hilfe von zwei Esslöffeln aus der Kartoffelmasse flache Puffer in die Pfanne geben. Diese im heißen Fett von beiden Seiten bei mittlerer Hitze ca. 7 Minuten ausbacken. Mit dem restlichen Butterschmalz und Kartoffelmasse ebenso verfahren.",
+      "Fertige Puffer auf Küchenpapier abtropfen lassen, warm halten und mit Apfelmus servieren."
+    ],
+    "id": "rec_82"
+  },
+  {
+    "title": "American Pancakes",
+    "tags": [
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "252 kcal",
+      "Kohlenhydrate": "35,9 g",
+      "Fett": "9,8 g",
+      "Eiweiß": "5,4 g"
+    },
+    "ingredients": [
+      "12,5 g Butter",
+      "62,5 g Weizenmehl Type 405",
+      "20 g Zucker",
+      "0,5 TL Backpulver",
+      "0,13 TL Salz",
+      "75 ml Milch",
+      "0,25 Ei (Zimmertemperatur)",
+      "0,5 EL Öl"
+    ],
+    "instructions": [
+      "Butter schmelzen. Mehl, Zucker, Backpulver und Salz verrühren.",
+      "Flüssige Butter mit Milch und Ei verquirlen. Die flüssigen zu den trockenen Zutaten geben und mit einem Schneebesen verrühren.",
+      "Pfanne leicht (!) einfetten und bei mittlerer Hitze die Pancakes nacheinander ausbacken. Wenn sich Blasen auf der Oberfläche bilden, wenden und auf der anderen Seite kurz ausbacken."
+    ],
+    "id": "rec_83"
+  },
+  {
+    "title": "Vegane Pasta in Blumenkohlsosse",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "510 kcal",
+      "Kohlenhydrate": "86,6 g",
+      "Fett": "11,1 g",
+      "Eiweiß": "23,4 g"
+    },
+    "ingredients": [
+      "0,5 Kopf Blumenkohl",
+      "0,5 Schalotte",
+      "1 EL Öl",
+      "250 ml Gemüsebrühe",
+      "200 g Vollkorn-Spaghetti",
+      "Salz",
+      "150 ml Sojadrink",
+      "1 Zehe(n) Knoblauch",
+      "1,5 EL Hefeflocken",
+      "0,25 Zitrone",
+      "0,25 Bd . Petersilie",
+      "Pfeffer aus der Mühle"
+    ],
+    "instructions": [
+      "Blumenkohl waschen und grob in Röschen teilen. Schalotte schälen, würfeln, im heißen Öl anbraten, herausnehmen.",
+      "Gemüsebrühe in denselben Topf gießen und den Blumenkohl darin ca. 10 Minuten kochen.",
+      "Nudeln in kochendem Salzwasser bissfest garen.",
+      "Blumenkohl mit der Brühe, den Zwiebelwürfeln, Sojamilch und den geschälten Knoblauchzehen zu einer cremigen Soße pürieren. Mit Salz, Hefeflocken und Zitronensaft abschmecken. Soße nochmals erwärmen.",
+      "Petersilie waschen, trocken schütteln und hacken. Nudeln mit der Soße anrichten und mit Petersilie bestreuen."
+    ],
+    "id": "rec_84"
+  },
+  {
+    "title": "Schnelle Brokkoli-Nudelpfanne mit Hirtenkäse",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "618 kcal",
+      "Kohlenhydrate": "82,2 g",
+      "Fett": "23 g",
+      "Eiweiß": "24,2 g"
+    },
+    "ingredients": [
+      "0,5 Zwiebel",
+      "1 Zehe(n) Knoblauch",
+      "1 EL ja! Olivenöl",
+      "200 g ja! Brokkoli (TK)",
+      "50 ml ja! Gemüsebrühe",
+      "50 g ja! Schlagsahne",
+      "ja! Salz",
+      "ja! Pfeffer",
+      "0,5 TL ja! Paprikapulver edelsüß",
+      "200 g ja! Nudeln (z. B. Fusilli)",
+      "100 g ja! Hirtenkäse"
+    ],
+    "instructions": [
+      "Zwiebel und Knoblauch schälen und fein würfeln.",
+      "In einer großen Pfanne das Olivenöl bei mittlerer Temperatur erhitzen. Zwiebel und Knoblauch darin andünsten, bis sie weich sind. Tiefgefrorenen Brokkoli, Gemüsebrühe und die Schlagsahne untermengen. Mit Salz, Pfeffer und Paprikapulver abschmecken und ca. 10 Minuten köcheln lassen.",
+      "Parallel die Nudeln laut Packungsanleitung zubereiten. Anschließend in einem Sieb über der Spüle abgießen.",
+      "Die heißen Nudeln zum Gemüse in die Pfanne geben und einmal durchmischen. Den Hirtenkäse kurz vor dem Servieren über die Nudelpfanne bröseln."
+    ],
+    "id": "rec_85"
+  },
+  {
+    "title": "Pasta mit Erbsen-Joghurt-Soße",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "806 kcal",
+      "Kohlenhydrate": "110 g",
+      "Fett": "28,6 g",
+      "Eiweiß": "30,7 g"
+    },
+    "ingredients": [
+      "112,5 g Erbsen (TK)",
+      "250 g Orecchiette",
+      "Salz",
+      "0,5 Zitrone",
+      "25 g Pinienkerne",
+      "7,5 g Minze",
+      "0,5 Zehe(n) Knoblauch",
+      "125 g griechischer Joghurt",
+      "75 g Feta",
+      "1 EL natives Olivenöl",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Erbsen auftauen lassen. Nudeln nach Packungsanweisung in Salzwasser kochen.",
+      "In der Zwischenzeit Zitrone waschen, Schale abreiben. Pinienkerne in einer Pfanne ohne Fett goldgelb rösten. Minze waschen, trockenschütteln und Blättchen abzupfen.",
+      "Knoblauch abziehen. Joghurt mit 100 g Feta, Olivenöl, aufgetaute Erbsen und Knoblauch pürieren. mit Zitronenschale, Salz und Pfeffer kräftig würzen.",
+      "Nudeln abgießen, dabei 1 Suppenkelle Wasser auffangen. Joghurt-Soße und Nudelwasser zu Nudeln geben und vorsichtig verrühren. Übrigen Feta grob zerbröseln.",
+      "Mit Pinienkernen, Feta und Minze garniert servieren."
+    ],
+    "id": "rec_86"
+  },
+  {
+    "title": "Spaghetti mit Hähnchen & getrockneten Tomaten",
+    "tags": [
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "997 kcal",
+      "Kohlenhydrate": "165 g",
+      "Fett": "19,1 g",
+      "Eiweiß": "49,7 g"
+    },
+    "ingredients": [
+      "200 g ja! Hähnchenbrust-Filetsteaks",
+      "140 g ja! junge Erbsen",
+      "2 TL ja! Pinienkerne",
+      "4 ja ! Getrocknete Tomaten",
+      "3 EL ja! Olivenöl",
+      "Salz",
+      "400 g ja! Spaghetti",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Die Hähnchenbrust-Filetsteaks und die Erbsen auftauen lassen.",
+      "Die Pinienkerne in einer Pfanne ohne Fett anrösten und herausnehmen. Getrocknete Tomaten in feine Stücke schneiden.",
+      "3 EL Olivenöl in einer Pfanne erhitzen, die Hähnchenbrust-Filetsteaks darin rundherum goldbraun braten und durchgaren. Aus der Pfanne nehmen und warm halten.",
+      "Einen großen Topf mit Salzwasser aufsetzen. Pasta in das kochende Wasser geben, nach Packungsanweisung al dente garen. Abgießen und kurz beiseite stellen.",
+      "2 EL Olivenöl in die Pfanne, in der vorher das Fleisch war, geben und die Erbsen darin kurz anbraten. Die getrockneten Tomaten dazu geben, dann die Spaghetti dazugeben. 1 EL Olivenöl darüber geben, alles bei mittlerer Hitze vermengen und kurz braten.",
+      "Hähnchenbrust in Scheiben schneiden. Spaghetti auf Teller verteilen, mit Pinienkernen bestreuen und die aufgeschnittene Hähnchenbrust darauf legen. Mit Pfeffer und Salz würzen und sofort servieren."
+    ],
+    "id": "rec_87"
+  },
+  {
+    "title": "One-Pot-Gnocchi in cremiger Tomaten-Mozzarellasoße",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "679 kcal",
+      "Kohlenhydrate": "100,5 g",
+      "Fett": "22,1 g",
+      "Eiweiß": "20,8 g"
+    },
+    "ingredients": [
+      "0,5 Zwiebel",
+      "0,5 Zehe(n) Knoblauch",
+      "15 g Basilikum",
+      "1,5 EL Sonnenblumenöl",
+      "0,5 EL brauner Zucker",
+      "1 EL Tomatenmark",
+      "1 Dose(n) gehackte Tomaten",
+      "100 ml Gemüsebrühe",
+      "Salz",
+      "Pfeffer",
+      "0,5 kg Gnocchi",
+      "127,5 g Mini-Mozzarella"
+    ],
+    "instructions": [
+      "Zwiebel und Knoblauch schälen und fein hacken. Basilikum waschen und in feine Streifen schneiden.",
+      "Sonnenblumenöl in einer Pfanne erhitzen und Zwiebeln darin bei mittlerer Hitze glasig dünsten. Knoblauch und Zucker hinzufügen und karamellisieren lassen. Dann das Tomatenmark hinzugeben und kurz mitrösten.",
+      "Mit gehackten Tomaten und Gemüsebrühe ablöschen und kräftig mit Salz und Pfeffer würzen. Gnocchi in die Soße geben und alles 5-10 Minuten köcheln lassen. Vom Herd nehmen und Basilikum und Mozzarella unterrühren, bis der Käse Fäden zieht."
+    ],
+    "id": "rec_88"
+  },
+  {
+    "title": "Griechische Bauernpfanne",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "595 kcal",
+      "Kohlenhydrate": "38,5 g",
+      "Fett": "35,3 g",
+      "Eiweiß": "32,3 g"
+    },
+    "ingredients": [
+      "2 Tomaten",
+      "1 Paprika",
+      "1 rote Zwiebel",
+      "1 EL Öl",
+      "2 EL Tomatenmark",
+      "Salz",
+      "Pfeffer",
+      "Oregano",
+      "4 Eier",
+      "1 Pck . Feta",
+      "rustikales Weizenbrot"
+    ],
+    "instructions": [
+      "Tomaten und Paprika waschen. Zusammen mit der Zwiebel in kleine Würfel schneiden.",
+      "Pfanne erhitzen, Öl zugeben und die Zwiebeln andünsten. Paprika hinzugeben, einige Minuten schwenken. Zuletzt Tomaten und das Tomatenmark zugeben. Mit Salz, Pfeffer und Oregano würzen. Kurz umrühren und in eine Schüssel füllen.",
+      "Pfanne wieder auf die Flamme stellen. Vier Eier dicht beieinander in die Pfanne geben. Die Spiegeleier leicht stocken lassen. Das Gemüse über den Eiern verteilen.",
+      "Feta in zwei Teile brechen, mit der Hand über der Pfanne zerbröseln, einen Teil fein, einen Teil grob. Pfanne abdecken, Käse anschmelzen lassen.",
+      "Noch etwas Oregano über die Eier streuen und in der Pfanne servieren. Dazu passt ein Stück rustikales Brot."
+    ],
+    "id": "rec_89"
+  },
+  {
+    "title": "Möhrensuppe mit Kartoffeln und Curry-Croûtons",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Personen",
+    "nutritionalInfo": {
+      "Energie": "398 kcal",
+      "Kohlenhydrate": "67 g",
+      "Fett": "12,1 g",
+      "Eiweiß": "8,8 g"
+    },
+    "ingredients": [
+      "0,5 kg Möhren",
+      "375 g Kartoffeln",
+      "2 EL Öl",
+      "0,5 Zwiebel",
+      "2 TL Gemüsebrühe (Instant)",
+      "2 Scheibe(n) Toastbrot",
+      "1 TL mildes Currypulver",
+      "Salz",
+      "schwarzer Pfeffer aus der Mühle",
+      "0,25 Bd . glatte Petersilie"
+    ],
+    "instructions": [
+      "Möhren und Kartoffeln waschen, schälen und in Stücke schneiden. 2 EL Öl in einem Topf erhitzen, Möhren und Kartoffeln darin anbraten. Zwiebel schälen, in dünne Ringe schneiden und hinzufügen. Mit 1,25 l Wasser ablöschen, Brühe einrühren und aufkochen lassen. Ca. 15 Minuten zugedeckt köcheln lassen.",
+      "Inzwischen Brot entrinden und in Würfel schneiden. Restliches Öl in einer Pfanne erhitzen, Brotwürfel darin ca. 5 Minuten bei mittlerer Hitze rösten. Dabei Curry darüberstäuben. Mit Salz und Pfeffer würzen.",
+      "Petersilie waschen, trocken tupfen, Blättchen abzupfen und in feine Streifen schneiden. Suppe mit einem Kartoffelstampfer grob zerkleinern. Mit Salz und Pfeffer würzen. Mit Petersilie bestreuen. Dazu die Curry-Croûtons servieren."
+    ],
+    "id": "rec_90"
+  },
+  {
+    "title": "Reispfanne mit Gemüse",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "295 kcal",
+      "Kohlenhydrate": "53,9 g",
+      "Fett": "6,6 g",
+      "Eiweiß": "7,9 g"
+    },
+    "ingredients": [
+      "75 g ja! Parboiled Spitzenreis",
+      "Salz",
+      "1 rote Paprika",
+      "0,5 Zwiebel",
+      "0,5 Dose(n) ja! Mais (285 g)",
+      "1 EL ja! Rapsöl",
+      "50 g ja! TK Erbsen",
+      "Kräutersalz"
+    ],
+    "instructions": [
+      "Reis nach Packungsanweisung in Salzwasser gar kochen.",
+      "Paprika waschen, das Kerngehäuse entfernen und in Würfel schneiden. Zwiebel schälen und in Streifen schneiden. Mais abtropfen lassen.",
+      "Öl in einer Pfanne erhitzen und die Zwiebeln goldbraun anbraten. Gekochten Reis, Paprika, Mais und Erbsen zugeben und alles kurz mit andünsten, bis die Erbsen gar sind. Mit Kräutersalz abschmecken."
+    ],
+    "id": "rec_91"
+  },
+  {
+    "title": "Klassische Linsensuppe",
+    "tags": [
+      "Vegetarisch",
+      "Laktosefrei",
+      "Kalorienarm",
+      "Fettarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "312 kcal",
+      "Kohlenhydrate": "51,2 g",
+      "Fett": "8,2 g",
+      "Eiweiß": "15,2 g"
+    },
+    "ingredients": [
+      "100 g Berglinsen",
+      "0,5 l Gemüsebrühe (oder Rinderbrühe)",
+      "150 g Kartoffeln",
+      "0,5 Bd . Suppengrün",
+      "0,5 EL Butterschmalz",
+      "0,25 Bd . Petersilie",
+      "1,5 EL Weißweinessig",
+      "Pfeffer",
+      "Salz",
+      "Schnittlauch"
+    ],
+    "instructions": [
+      "Linsen waschen, abtropfen lassen und 15 Minuten in der Brühe kochen.",
+      "Währenddessen Kartoffeln und Suppengrün waschen, schälen und in sehr feine Würfel schneiden.",
+      "Butterschmalz in einem zweiten Topf erhitzen und Kartoffeln und Suppengrün darin andünsten. Brühe mit den Linsen über das Gemüse geben und nochmals 10 Minuten köcheln.",
+      "Petersilie waschen, trocken schütteln, hacken und in die Suppe geben. Suppe mit Essig, Pfeffer und Salz abschmecken und nach Belieben mit Schnittlauch garnieren."
+    ],
+    "id": "rec_92"
+  },
+  {
+    "title": "Mini Cordon Bleu mit Erbsenpüree und Tomaten-Mais-Salat",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "641 kcal",
+      "Kohlenhydrate": "56,3 g",
+      "Fett": "34,6 g",
+      "Eiweiß": "29,4 g"
+    },
+    "ingredients": [
+      "250 g Kartoffeln",
+      "Salz",
+      "150 g ja! Junge Erbsen (TK)",
+      "200 g Cherry Rispentomaten Dulcita",
+      "70 g ja! Sonnen-Mais natursüß",
+      "7,5 g Schnittlauch",
+      "4 EL ja! Rapsöl",
+      "1 EL Essig",
+      "0,5 TL Honig",
+      "0,5 Spritzer Orangensaft",
+      "Pfeffer",
+      "0,5 EL Butter",
+      "50 g Schlagsahne",
+      "0,5 Prise(n) Muskatnuss",
+      "200 g ja! Mini Cordon Bleu"
+    ],
+    "instructions": [
+      "Kartoffeln schälen, waschen, klein schneiden und in kochendem Salzwasser ca. 15 Minuten garen. Ca. 5 Minuten vor Ende der Garzeit die Erbsen zu den Kartoffeln geben.",
+      "Tomaten waschen, halbieren. Mais abtropfen lassen. Schnittlauch in Röllchen schneiden. Alles in eine Schüssel geben. 4 EL Öl mit Essig, Honig und Orangensaft zu einem Dressing verrühren. Mit Salz und Pfeffer würzen.",
+      "Zimmerwarme Butter und Sahne zu den Kartoffeln und Erbsen geben und grob zerstampfen. Mit Salz, Pfeffer und Muskatnuss abschmecken. Warm halten.",
+      "Mini Cordon Bleu in einer beschichteten Pfanne mit 4 EL Rapsöl bei mittlerer Hitze 6-8 Minuten braten.",
+      "Dressing über den Salat gießen. Mini Cordon Bleu mit Erbsenpüree und Salat anrichten."
+    ],
+    "id": "rec_93"
+  },
+  {
+    "title": "Zitronen-Linguine mit Rucola",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "463 kcal",
+      "Kohlenhydrate": "82,2 g",
+      "Fett": "9,3 g",
+      "Eiweiß": "14,8 g"
+    },
+    "ingredients": [
+      "200 g Linguine",
+      "Salz",
+      "1 rote Paprika",
+      "100 g Rucola",
+      "0,5 -Zitrone",
+      "0,5 Zehe(n) Knoblauch",
+      "1,5 EL Olivenöl",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Linguine nach Packungsanweisung in Salzwasser zubereiten.",
+      "Paprika waschen, Kerne entfernen und in kleine Würfel schneiden. Rucola verlesen, waschen und trocken schütteln. Zitrone unter heißem Wasser waschen, gut abtrocknen und anschließend die Schale abreiben. Zitrone dann halbieren und eine Hälfte auspressen. Knoblauch schälen und fein hacken.",
+      "Öl erhitzen und Paprika sowie Knoblauch anschwitzen.",
+      "Nudeln abgießen, 200 ml Nudelwasser auffangen. Nudeln mit dem aufgefangenen Wasser in die Pfanne geben und mit den Paprika vermischen.",
+      "Rucola und abgeriebene Zitronenschale unterrühren und mit Salz, Pfeffer und Zitronensaft abschmecken."
+    ],
+    "id": "rec_94"
+  },
+  {
+    "title": "Winterliche Kohlpfanne",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "526 kcal",
+      "Kohlenhydrate": "60,6 g",
+      "Fett": "25,1 g",
+      "Eiweiß": "18,7 g"
+    },
+    "ingredients": [
+      "0,5 Spitzkohl",
+      "1 Zwiebeln",
+      "92,5 g Räuchertofu",
+      "2 EL Rapsöl",
+      "0,5 TL Kümmel",
+      "100 ml Gemüsebrühe",
+      "Pfeffer",
+      "120 g Naturreis",
+      "1,5 EL Haselnusskerne"
+    ],
+    "instructions": [
+      "Spitzkohl vierteln, den Strunk entfernen und in feine Streifen schneiden. Zwiebeln schälen und in Streifen schneiden. Tofu fein würfeln.",
+      "Öl in einer Pfanne erhitzen und Zwiebeln und Tofu goldbraun anrösten. Kohl und Kümmel zugeben, mit anrösten und mit Gemüsebrühe aufgießen. 20 Minuten köcheln lassen und mit Pfeffer abschmecken.",
+      "Reis nach Packungsanweisung kochen. Haselnüsse in einer Pfanne ohne Fett rösten und grob hacken. Reis mit der Kohlpfanne servieren und mit Haselnüssen garnieren."
+    ],
+    "id": "rec_95"
+  },
+  {
+    "title": "Griechische Bowl",
+    "tags": [
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "847 kcal",
+      "Kohlenhydrate": "81,4 g",
+      "Fett": "38,9 g",
+      "Eiweiß": "44,4 g"
+    },
+    "ingredients": [
+      "160 g ja! Parboiled Spitzenreis",
+      "Salz",
+      "0,5 EL ja! Olivenöl",
+      "250 g Gyrosfleisch",
+      "0,25 Gurke",
+      "1 Zehe(n) Knoblauch",
+      "100 g ja! Vollmilch-Joghurt",
+      "Pfeffer",
+      "100 g Cherrytomaten",
+      "75 g ja! Hirtenkäse",
+      "7,5 g Petersilie",
+      "250 g ja! Krautsalat mit grüner Paprika"
+    ],
+    "instructions": [
+      "Reis nach Packungsanweisung in Salzwasser kochen.",
+      "Öl in einer Pfanne erhitzen, Fleisch ca. 10 Minuten rundherum braten.",
+      "Für das Tzatziki Gurke waschen, reiben, Wasser ausdrücken. Knoblauch schälen, fein hacken. Joghurt mit Gurke und Knoblauch verrühren. Mit Salz und Pfeffer würzen.",
+      "Tomaten waschen und halbieren. Hirtenkäse in Würfel schneiden. Petersilie waschen und hacken.",
+      "Reis auf 4 Schalen verteilen. Krautsalat, Tzatziki, Tomaten, Hirtenkäse und Gyros auf dem Reis anrichten und mit Petersilie bestreut servieren. Mit Salz und Pfeffer würzen."
+    ],
+    "id": "rec_96"
+  },
+  {
+    "title": "Cremiger Low-Carb Brokkoli-Auflauf mit Hähnchen",
+    "tags": [
+      "Low Carb"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "597 kcal",
+      "Kohlenhydrate": "12,5 g",
+      "Fett": "37,5 g",
+      "Eiweiß": "55,2 g"
+    },
+    "ingredients": [
+      "2 Stück Hähnchenbrustfilets",
+      "0,5 Zwiebel",
+      "0,5 Zehe(n) Knoblauch",
+      "0,25 Bd . frische Petersilie",
+      "300 g Brokkoli",
+      "1 EL Rapsöl",
+      "100 ml Brühe",
+      "50 ml Sahne",
+      "100 g Sahneschmelzkäse",
+      "Salz",
+      "Pfeffer",
+      "50 g Gratinkäse"
+    ],
+    "instructions": [
+      "Hähnchen in Würfel schneiden. Zwiebel und Knoblauch schälen und fein würfeln. Petersilie waschen und fein hacken. Brokkoli waschen und die Röschen abtrennen. Brokkoliröschen in reichlich Salzwasser für 3-4 Minuten blanchieren und anschließend in Eiswasser kalt abschrecken.",
+      "Öl in einer Pfanne erhitzen. Hähnchen darin scharf anbraten. Dann die Zwiebeln und den Knoblauch dazugeben und 1-2 Minuten mitbraten. Alles mit der Brühe ablöschen und Sahne und Schmelzkäse hinzufügen. Unter Rühren kurz aufkochen und köcheln lassen, bis der Schmelzkäse sich vollständig gelöst hat. Mit Salz und Pfeffer abschmecken. Dann den Brokkoli dazugeben.",
+      "Alles in eine ofenfeste Form geben, mit dem Käse bestreuen und im vorgeheizten Backofen bei 180 °C Ober-/Unterhitze für 20 Minuten backen. Nach dem Backen mit frischer Petersilie bestreuen."
+    ],
+    "id": "rec_97"
+  },
+  {
+    "title": "Gefüllte Paprika Vegetarisch",
+    "tags": [
+      "Vegetarisch",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "431 kcal",
+      "Kohlenhydrate": "59,1 g",
+      "Fett": "14,8 g",
+      "Eiweiß": "18,7 g"
+    },
+    "ingredients": [
+      "125 g Couscous",
+      "2 Paprika",
+      "250 g Blattspinat",
+      "0,5 Zehe(n) Knoblauch",
+      "0,5 Zwiebel",
+      "0,5 EL Öl",
+      "Salz",
+      "Pfeffer",
+      "Chiligewürz",
+      "75 g Feta",
+      "150 ml Gemüsebrühe"
+    ],
+    "instructions": [
+      "Couscous nach Packungsanweisung zubereiten. Backofen auf 200°C Ober-/ Unterhitze vorheizen.",
+      "Paprika waschen, Deckel abschneiden und die Kerne entfernen. Spinat waschen, trocken schleudern und ggf. lange Stiele entfernen. Knoblauch und Zwiebel schälen und fein hacken.",
+      "1 EL Öl erhitzen und Zwiebel, Knoblauch und Spinat anschwitzen, bis der Spinat zusammengefallen ist. Mit Salz, Pfeffer und Chiligewürz abschmecken.",
+      "Feta zerbröseln, mit dem Couscous und dem Spinat vermischen. Die Masse in die Paprikaschoten füllen.",
+      "Paprika nebeneinander in eine Auflaufform füllen, die Gemüsebrühe angießen und im vorgeheizten Backofen ca. 20-30 Minuten garen."
+    ],
+    "id": "rec_98"
+  },
+  {
+    "title": "Bami Goreng",
+    "tags": [
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "549 kcal",
+      "Kohlenhydrate": "68,9 g",
+      "Fett": "10,2 g",
+      "Eiweiß": "46,8 g"
+    },
+    "ingredients": [
+      "125 g Mie-Nudeln",
+      "0,5 Stück Ingwer",
+      "1 Zehe(n) Knoblauch",
+      "25 g Ketjap Manis",
+      "4 EL Sojasauce",
+      "0,5 TL Sambal Oelek",
+      "0,5 TL Currypulver",
+      "0,5 EL Wasser",
+      "0,5 TL Speisestärke",
+      "0,5 Pak Choi",
+      "0,25 Bd . Frühlingszwiebeln",
+      "100 g Zuckerschoten",
+      "1 Möhren",
+      "1 Hühnerbrüste",
+      "1,5 EL Öl",
+      "45 g Garnelen verzehrfertig"
+    ],
+    "instructions": [
+      "Nudeln nach Packungsanweisung al dente kochen und abgießen.",
+      "Ingwer und Knoblauch schälen und fein würfeln. Mit Ketjap Manis, 6 EL Sojasauce, Sambal Oelek und Currypulver zu einer Marinade verrühren. 1 EL kaltes Wasser mit 1 TL Speisestärke verrühren und dazugeben.",
+      "Pak Choi, Frühlingszwiebeln und Zuckerschoten waschen. Möhren schälen. Pak Choi in Streifen und Möhren in Stifte schneiden. Frühlingszwiebeln in feine Ringe schneiden. Die Zuckerschoten von den harten Enden befreien und ggf. störende Fäden abziehen.",
+      "Hähnchenbrust in Würfel schneiden. 2 El Öl in einem Wok erhitzen. Die Hähnchenbrust darin 5-7 Min. von allen Seiten anbraten und beiseite legen. Restliches Öl in die Pfanne geben und das Gemüse, mit Ausnahme der Frühlingszwiebeln, darin scharf anbraten. Kurz bevor das Gemüse gar ist, Hähnchen, Garnelen, Nudeln und die Marinade hinzufügen. Alles vermischen und für weitere 2-3 Minuten in der Pfanne schwenken.",
+      "Nudeln auf 4 Teller verteilen, mit Sojasauce beträufeln und mit Frühlingszwiebeln bestreuen."
+    ],
+    "id": "rec_99"
+  },
+  {
+    "title": "Zucchini-Puffer mit Feta",
+    "tags": [
+      "Vegetarisch",
+      "Low Carb",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 2 Portionen",
+    "nutritionalInfo": {
+      "Energie": "252 kcal",
+      "Kohlenhydrate": "13,1 g",
+      "Fett": "17,5 g",
+      "Eiweiß": "11,2 g"
+    },
+    "ingredients": [
+      "1 große Zucchini",
+      "Salz",
+      "0,5 Ei (L)",
+      "2 EL Weizenmehl Type 405",
+      "Pfeffer",
+      "65 g Feta",
+      "1,5 EL Rapsöl"
+    ],
+    "instructions": [
+      "Zucchini waschen und grob reiben. Leicht salzen und 5 Minuten stehen lassen. Raspel gut ausdrücken und die Flüssigkeit abgießen.",
+      "Ei, Mehl, Salz und Pfeffer hinzufügen und gut vermischen. Feta dazu krümeln und ebenfalls vermischen.",
+      "Öl in einer großen Pfanne erhitzen und nach und nach Puffer nach beliebiger Größe ausbacken. Mehrmals wenden und heiß servieren. Dazu schmeckt ein Joghurt- oder Kräuterdip."
+    ],
+    "id": "rec_100"
+  }
+]

--- a/data/recipes_4.json
+++ b/data/recipes_4.json
@@ -1,0 +1,3466 @@
+[
+  {
+    "title": "Reispfanne mit Pilzen und Frühlingszwiebeln",
+    "tags": [
+      "Vegetarisch",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "639 kcal",
+      "Kohlenhydrate": "104,7 g",
+      "Fett": "17 g",
+      "Eiweiß": "19,3 g"
+    },
+    "ingredients": [
+      "500 g Naturreis",
+      "Salz",
+      "2 Knoblauchzehen",
+      "500 g Champignons (braun)",
+      "1 Bd . Frühlingszwiebeln",
+      "4 EL Olivenöl",
+      "50 g Parmesan",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Reis in Salzwasser 25 bis 30 Minuten gar kochen.",
+      "Knoblauch schälen und in dünne Scheiben schneiden. Champignons putzen, säubern und längs vierteln.",
+      "Frühlingszwiebeln waschen, putzen und schräg in ca. 1 cm lange Stücke schneiden - das Weiße vom Grünen getrennt.",
+      "3 EL Olivenöl in der Pfanne erhitzen, Knoblauch 2 Minuten darin anbraten und herausnehmen.",
+      "Champignons in die Pfanne geben und ca. 5 Minuten scharf anbraten. Die weißen Frühlingszwiebel-Ringe dazugeben und weitere 5 Minuten anbraten.",
+      "Reis zu den Champignons geben. Das Grüne von den Frühlingszwiebeln und den Knoblauch dazugeben. Umrühren und 1 EL Olivenöl darüber träufeln. Parmesan darüber reiben und mit Pfeffer würzen."
+    ],
+    "id": "rec_1"
+  },
+  {
+    "title": "One Pot Gnocchi mit Buttergemüse",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "701 kcal",
+      "Kohlenhydrate": "99,9 g",
+      "Fett": "28,6 g",
+      "Eiweiß": "14,8 g"
+    },
+    "ingredients": [
+      "4 Zwiebeln",
+      "2 EL Rapsöl",
+      "800 g Gnocchi (Kühlregal)",
+      "2 Pck . ja! Buttergemüse (TK, à 300 g)",
+      "400 ml Gemüsebrühe",
+      "200 g Crème fraîche",
+      "10 g Schnittlauch"
+    ],
+    "instructions": [
+      "Zwiebeln schälen und hacken. Öl in einem Topf erhitzen und die Zwiebeln anschwitzen.",
+      "Gnocchi und TK-Gemüse zufügen. Kurz anschwitzen, dann Gemüsebrühe sowie Crème fraîche zufügen und 5-7 Minuten köcheln, bis das Gemüse weich ist.",
+      "Schnittlauch waschen, trocken schütteln und in Röllchen schneiden. Über die Gnocchi streuen und servieren."
+    ],
+    "id": "rec_2"
+  },
+  {
+    "title": "Rösti-Auflauf mit versunkenen Spiegeleiern",
+    "tags": [
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "513 kcal",
+      "Kohlenhydrate": "39,6 g",
+      "Fett": "25,7 g",
+      "Eiweiß": "30,5 g"
+    },
+    "ingredients": [
+      "800 g Kartoffeln (festkochend)",
+      "1 rote Zwiebel",
+      "100 g Schinkenwürfel",
+      "1 TL Butter",
+      "180 g Reibekäse",
+      "1 EL Senf",
+      "230 g Joghurt",
+      "Salz",
+      "Pfeffer",
+      "Paprikapulver",
+      "4 Eier",
+      "1 Bd . Schnittlauch"
+    ],
+    "instructions": [
+      "Die Kartoffeln schälen und auf einer groben Reibe raspeln. Kartoffelraspel portionsweise in die Hand nehmen und ausdrücken, sodass die Flüssigkeit abtropfen kann. Auf Küchenpapier ausbreiten.",
+      "Eine Kasserolle bereitstellen, den Backofen auf 200 Grad Ober-/Unterhitze vorheizen.",
+      "Die Zwiebel schälen und fein würfeln, mit den Schinkenwürfeln vermischen. Butter in einer Pfanne schmelzen, Zwiebel-Schinken-Mix darin kurz anbraten.",
+      "Aus Käse, Senf und Joghurt eine Soße anrühren und mit den Zwiebeln, den Kartoffeln und dem Schinken vermengen. Alles mit Salz, Pfeffer und Paprikapulver würzen und in die Kasserolle geben.",
+      "Kasserolle auf mittlerer Schiene auf einem Rost in den Ofen schieben und in ca. 45 Minuten ohne Deckel backen. Auflauf aus dem Ofen nehmen und mit Hilfe eines Esslöffels vier Mulden hineindrücken. In jede Mulde ein Ei schlagen, Auflauf zurück in den Ofen schieben und bis zum gewünschten Gargrad der Eier zu Ende backen.",
+      "Mit Schnittlauch bestreuen und in der Kasserolle servieren."
+    ],
+    "id": "rec_3"
+  },
+  {
+    "title": "Schneller Paprika-Tofu-Reis",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Fettarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "496 kcal",
+      "Kohlenhydrate": "80,1 g",
+      "Fett": "12,5 g",
+      "Eiweiß": "19,7 g"
+    },
+    "ingredients": [
+      "2 Zwiebeln",
+      "2 Knoblauchzehen",
+      "2 rote Paprikaschoten",
+      "2 gelbe Paprikaschoten",
+      "250 g Basilikum-Tofu",
+      "3 EL Öl",
+      "3 TL Rosenpaprika scharf",
+      "Salz",
+      "Zucker",
+      "250 g 10-Minuten-Reis",
+      "2 Dose(n) stückige Tomaten (à 425 g)",
+      "400 ml Gemüsebrühe",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Zwiebeln und Knoblauch schälen und fein würfeln. Paprikaschoten vierteln, entkernen und waschen. Paprikaschoten in ca. 2 cm große Stücke schneiden. Tofu in ca. 3 cm große Stücke schneiden.",
+      "Öl in einer großen Pfanne erhitzen, Tofu darin bei starker Hitze rundherum anbraten. Zwiebeln, Knoblauch und Paprikastücke zugeben und ca. 2 Minuten mitbraten. Mit Paprikapulver, Salz und 1 Prise Zucker würzen.",
+      "Reis, stückige Tomaten und Brühe zugeben. Alles aufkochen und zugedeckt 10 Min. garen. Mit Salz und Pfeffer abschmecken."
+    ],
+    "id": "rec_4"
+  },
+  {
+    "title": "Hack-Reis-Pfanne",
+    "tags": [
+      "Laktosefrei",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "508 kcal",
+      "Kohlenhydrate": "33,4 g",
+      "Fett": "30,1 g",
+      "Eiweiß": "27,4 g"
+    },
+    "ingredients": [
+      "125 g ja! Langkorn-Spitzenreis",
+      "ja! Jodsalz",
+      "2 rote Paprikaschoten",
+      "1 Salatgurke",
+      "2 Lauchzwiebeln",
+      "3 EL ja! Sonnenblumenöl",
+      "1 EL Weißweinessig",
+      "Pfeffer",
+      "1 TL Zucker",
+      "500 g ja! gemischtes Hackfleisch"
+    ],
+    "instructions": [
+      "Reis in kochendem Salzwasser nach Packungsanweisung zubereiten. Paprika putzen, waschen, entkernen und in Streifen schneiden. Gurke putzen, waschen und fein würfeln. Lauchzwiebeln putzen, waschen und in feine Ringe schneiden. Gurke, Lauchzwiebeln, 1 EL ÖL und Essig mischen. Mit Salz, Pfeffer und Zucker würzen.",
+      "2 EL Öl in einer Pfanne erhitzen. Hack darin krümelig braten. Mit Salz und Pfeffer würzen. Paprikastreifen zugeben, andünsten. Reis abgießen und zur Hackpfanne geben. Mit Salz und Pfeffer würzen. Hack-Reis-Pfanne anrichten. 2 EL Gurken- Lauchzwiebel-Mischung darüber streuen. Übrige Gurken-Lauchzwiebel-Mischung in einem Schälchen dazu reichen."
+    ],
+    "id": "rec_5"
+  },
+  {
+    "title": "Spaghetti mit Linsenbolognese",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "499 kcal",
+      "Kohlenhydrate": "86,6 g",
+      "Fett": "9,6 g",
+      "Eiweiß": "22,1 g"
+    },
+    "ingredients": [
+      "1 Zwiebel",
+      "200 g Möhren",
+      "100 g Staudensellerie",
+      "1 Zehe(n) Knoblauch",
+      "2 EL Olivenöl",
+      "150 g Rote Linsen",
+      "1 EL Tomatenmark",
+      "200 ml Gemüsebrühe",
+      "250 g Pizza-Tomaten",
+      "Salz",
+      "Pfeffer",
+      "320 g Vollkornspaghetti",
+      "15 g Basilikum"
+    ],
+    "instructions": [
+      "Zwiebel schälen und fein würfeln. Möhren schälen, Sellerie waschen und putzen und beides in kleine Würfel schneiden. Knoblauch schälen und fein hacken. Öl in einem Topf leicht erhitzen und Zwiebelwürfel darin andünsten. Möhren, Sellerie und Knoblauch zugeben und ca. 2 Minuten mit anschwitzen.",
+      "Linsen zugeben, Tomatenmark einrühren und kurz anrösten. Mit Brühe und Tomaten ablöschen und ca. 10 Minuten köcheln lassen. Mit Salz und Pfeffer abschmecken.",
+      "Vollkornspaghetti nach Packungsanweisung in Salzwasser kochen. Basilikum waschen, trocken schütteln. Spaghetti mit Linsenbolognese und Basilikumblättern servieren."
+    ],
+    "id": "rec_6"
+  },
+  {
+    "title": "Yum Yum Salat",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "561 kcal",
+      "Kohlenhydrate": "47,7 g",
+      "Fett": "35,3 g",
+      "Eiweiß": "18,2 g"
+    },
+    "ingredients": [
+      "80 ml Öl",
+      "4 EL Essig (hell)",
+      "2 EL Honig",
+      "1 TL Salz",
+      "1 TL Pfeffer",
+      "2 Pck . asiatische Instant Nudeln (Yum Yum, mit Gewürzmischung)",
+      "60 g Sonnenblumenkerne",
+      "100 g Erdnüsse",
+      "1 Chinakohl"
+    ],
+    "instructions": [
+      "In einer großen Schüssel Öl, Essig, Honig, Salz und Pfeffer miteinander verrühren. Die Gewürzmischung aus den Nudelpackungen ebenfalls unterrühren.",
+      "Die Nudeln zerbröseln und in das Dressing geben. Vorsichtig vermengen und 10 Minuten ziehen lassen.",
+      "Währenddessen die Sonnenblumenkerne und Erdnüsse in einer Pfanne ohne Fett bei mittlerer Temperatur anrösten. Die Pfanne dabei mehrmals rütteln, damit die Kerne von allen Seiten bräunen. Den Chinakohl in feine Streifen schneiden.",
+      "Chinakohl und geröstete Kerne in die Schüssel zu Nudeln und Dressing geben, den Salat gut durchmischen und servieren."
+    ],
+    "id": "rec_7"
+  },
+  {
+    "title": "Schnelle Gemüsesuppe mit weißen Bohnen",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "335 kcal",
+      "Kohlenhydrate": "53,4 g",
+      "Fett": "9 g",
+      "Eiweiß": "17,3 g"
+    },
+    "ingredients": [
+      "1 kleine Zwiebel",
+      "2 Karotten",
+      "2 Stange(n) Sellerie",
+      "1 Stange(n) Lauch",
+      "2 Zehe(n) Knoblauch",
+      "1 TL Olivenöl",
+      "3 EL Tomatenmark",
+      "450 g weiße Bohnen (Dose)",
+      "1 Dose(n) stückige Tomaten (400 g)",
+      "1,4 l Gemüsebrühe (glutenfrei)",
+      "1 Zweig(e) Thymian",
+      "Salz",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Zwiebeln und Karotten schälen und fein würfeln, Sellerie und Lauch putzen und in feine Stücke bzw. Ringe schneiden, Knoblauch schälen und fein hacken.",
+      "Das Olivenöl in einem großen Suppentopf erhitzen, die Zwiebel anbraten, die Karotten dazu geben, dann Sellerie, Lauch und Knoblauch. Kurz weiterbraten, dann das Tomatenmark einrühren.",
+      "Die Bohnen zusammen mit den Tomatenstücken dazu geben, mit der Brühe aufgießen, den Thymian dazu geben, dann 15 Minuten köcheln lassen. Thymianzweig rausnehmen. Mit Salz und Pfeffer abschmecken und in Schälchen servieren."
+    ],
+    "id": "rec_8"
+  },
+  {
+    "title": "Schales mit Rettich: saarländischer Kartoffelkuchen",
+    "tags": [
+      "Laktosefrei",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "483 kcal",
+      "Kohlenhydrate": "58,1 g",
+      "Fett": "17,4 g",
+      "Eiweiß": "24,9 g"
+    },
+    "ingredients": [
+      "1 kg Kartoffeln, vorwiegend festkochend",
+      "Salz",
+      "1 Stange(n) Lauch",
+      "250 g Speckwürfel",
+      "2 Eier",
+      "Pfeffer",
+      "1 Msp . Muskatnuss",
+      "neutrales Öl",
+      "1 Rettich",
+      "1 Bd . Petersilie",
+      "1 EL Zitronensaft",
+      "1 EL Honig"
+    ],
+    "instructions": [
+      "Kartoffeln waschen, schälen und fein reiben. Geriebene Kartoffeln salzen und kurz ziehen lassen. Lauch halbieren, waschen und in feine Streifen schneiden.",
+      "Eine mittelgroße Pfanne erhitzen und zunächst die Speckwürfel darin für etwa 5 Minuten braten. Dann Lauch dazugeben und 2 bis 3 Min. mitbraten.",
+      "Kartoffeln gut ausdrücken und das Wasser abschütten. Lauch und Speckwürfel mit den Eiern unter die geriebenen Kartoffeln mischen. Mit Salz, Pfeffer und Muskatnuss abschmecken.",
+      "Backofen vorheizen (180 °C, Ober- und Unterhitze). Eine Springform mit neutralem Öl fetten. Den rohen Kartoffelteig darin verteilen und leicht andrücken. Für 1,5 bis 2 Stunden goldbraun backen.",
+      "In der Zwischenzeit den Rettich schälen. Dann mit dem Spiralschneider oder Sparschäler in feine Streifen schneiden. Petersilie waschen, trocken schütteln und grob hacken. Mit Zitronensaft, Honig und Rettich mischen. Mit Salz und Pfeffer würzen.",
+      "Schales nach dem Backen etwa 15 Minuten abkühlen lassen, aus der Springform lösen und auf einer Platte anrichten. Dazu den Rettich servieren."
+    ],
+    "id": "rec_9"
+  },
+  {
+    "title": "Flammkuchen mit Kartoffeln und Rosmarin",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "912 kcal",
+      "Kohlenhydrate": "165,7 g",
+      "Fett": "15,7 g",
+      "Eiweiß": "34,2 g"
+    },
+    "ingredients": [
+      "700 g Dinkel-Vollkornmehl",
+      "60 g Hefewürfel",
+      "500 ml fettarme H-Milch",
+      "2 TL Olivenöl",
+      "Salz",
+      "400 g Speisekartoffeln Drillinge (z. B. von )",
+      "6 EL Schmand",
+      "6 Zweig(e) Rosmarin",
+      "Tellicherry-Pfeffer Mühle (z. B. von Feine Welt)",
+      "4 EL Honig"
+    ],
+    "instructions": [
+      "Dinkelvollkornmehl in eine Schüssel sieben. In die Mitte eine Mulde drücken. Backhefe hineinbröseln. H-Milch in einem Topf oder in der Mikrowelle kurz erwärmen. Lauwarme H-Milch, Olivenöl und etwas Salz in die Mulde geben. Teig so lange kneten, bis er sich vom Schüsselrand löst und elastisch auseinanderziehen lässt. Ist der Teig noch zu klebrig, noch etwas Dinkelmehl zufügen. Mit einem feucht-warmen Handtuch abdecken und an einem warmen Ort für 30 Minuten gehen lassen. Teig erneut kneten. Auf einem Stück Backpapier ausrollen.",
+      "Speisekartoffeln waschen und 20 Minuten in Salzwasser kochen. Backofen auf 220°C Ober-/Unterhitze vorheizen.",
+      "Grundteig auf ein Backpapier ausrollen. Mit Schmand bestreichen. Rosmarinnadeln abzupfen und grob hacken. Speisekartoffeln nach Belieben geschält oder ungeschält in Scheiben schneiden und auf dem Teig verteilen. Mit den gehackten Rosmarinnadeln bestreuen. Mit Pfeffer und Salz würzen.",
+      "Den fertig belegten Flammkuchen im Backofen auf der untersten Schiene 12 bis 15 Minuten goldbraun backen. Honig über den Kartoffeln verteilen und servieren."
+    ],
+    "id": "rec_10"
+  },
+  {
+    "title": "Mediterrane Reis-Gemüse-Pfanne mit Hackfleisch",
+    "tags": [
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "752 kcal",
+      "Kohlenhydrate": "50 g",
+      "Fett": "45,1 g",
+      "Eiweiß": "38 g"
+    },
+    "ingredients": [
+      "200 g Reis",
+      "Salz",
+      "3 Paprikaschoten",
+      "1 Zucchini",
+      "2 Knoblauchzehen",
+      "200 g Schafskäse",
+      "2 EL Olivenöl",
+      "500 g gemischtes Hackfleisch",
+      "1 EL Tomatenmark",
+      "200 ml Gemüsebrühe",
+      "125 g grüne Oliven",
+      "Pfeffer",
+      "Paprikapulver rosenscharf"
+    ],
+    "instructions": [
+      "Reis nach Packungsanweisung in Salzwasser garen.",
+      "Paprika waschen, Kerne entfernen und in Würfel schneiden. Zucchini waschen und würfeln. Knoblauch schälen und fein hacken. Schafskäse abtropfen lassen und zerbröseln.",
+      "Öl in einer Pfanne erhitzen, Hackfleisch anschwítzen. Tomatenmark, Knoblauch, Paprika und Zucchini zugeben und anbraten. Mit Brühe ablöschen und einige Minuten köcheln lassen, bis Hackfleisch und Gemüse gar sind.",
+      "Reis abtropfen lassen und unter das Hackfleisch mengen. Oliven abtropfen lassen und zusammen mit dem Schafskäse unterheben. Mit Salz, Pfeffer und Paprikapulver abschmecken."
+    ],
+    "id": "rec_11"
+  },
+  {
+    "title": "Rote Linsensuppe mit Feta-Topping",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "303 kcal",
+      "Kohlenhydrate": "38,9 g",
+      "Fett": "10,1 g",
+      "Eiweiß": "17,7 g"
+    },
+    "ingredients": [
+      "2 Zwiebeln",
+      "1 EL Bratöl",
+      "1 EL Kreuzkümmel",
+      "1 EL Currypulver",
+      "200 g Rote Linsen",
+      "400 ml Gemüsebrühe",
+      "1 Dose(n) Tomaten in Stücken (280 g)",
+      "Salz",
+      "Pfeffer",
+      "1 Zitrone",
+      "100 g Feta"
+    ],
+    "instructions": [
+      "Zwiebeln schälen und klein schneiden.",
+      "Öl erhitzen und die Zwiebeln anschwitzen. Kreuzkümmel, Curry und Linsen zugeben und kurz mit anschwitzen. Mit angerührter Brühe und Tomaten ablöschen. Zugedeckt bei schwacher bis mittlerer Hitze ca. 15 Minuten köcheln, bis die Linsen weich sind.",
+      "Linsensuppe pürieren, mit Salz, Pfeffer und Zitronensaft abschmecken.",
+      "Feta zerbröseln und die Suppe mit Fetabröseln servieren."
+    ],
+    "id": "rec_12"
+  },
+  {
+    "title": "Überbackene Pfannkuchenrollen",
+    "tags": [],
+    "difficulty": "Mittel",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "634 kcal",
+      "Kohlenhydrate": "82,5 g",
+      "Fett": "22,7 g",
+      "Eiweiß": "24,7 g"
+    },
+    "ingredients": [
+      "300 g ja! Weizenmehl",
+      "500 ml ja! fettarme H-Milch",
+      "3 Eier (Größe M)",
+      "ja! Jodsalz",
+      "4 EL ja! Markenbutter",
+      "2 kleine Zucchini",
+      "200 g ja! Delikatess Kochschinken",
+      "1 Dose(n) gehackte Tomaten",
+      "Pfeffer",
+      "100 g ja! geriebener Gratin- und Pizzakäse"
+    ],
+    "instructions": [
+      "Mehl, Milch und Eier zu einem glatten Pfannkuchenteig verrühren. Mit Salz würzen. Butter portionsweise in einer Pfanne erhitzen. Nacheinander ca. 8-10 dünne Pfannkuchen aus dem Teig backen.",
+      "Backofen auf 150°C Umluft vorheizen. Zucchini waschen, putzen und mit einem Sparschäler in dünne Streifen schneiden. Pfannkuchen mit Zucchinischeiben und Schinken belegen, aufrollen und in jeweils 3-4 Rollen schneiden.",
+      "Dosentomaten mit Salz und Pfeffer würzen, in einer Auflaufform verteilen. Pfannkuchenröllchen in die Tomatensoße setzen, mit Käse bestreuen und im vorgeheizten Backofen ca. 20 Minuten gratinieren."
+    ],
+    "id": "rec_13"
+  },
+  {
+    "title": "Kartoffel-Möhren-Stampf mit Fischstäbchen",
+    "tags": [
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "319 kcal",
+      "Kohlenhydrate": "39,2 g",
+      "Fett": "13,7 g",
+      "Eiweiß": "11,5 g"
+    },
+    "ingredients": [
+      "600 g Kartoffeln",
+      "400 g Möhren",
+      "300 ml Gemüsebrühe",
+      "100 ml Milch",
+      "Salz",
+      "Pfeffer",
+      "Muskatnuss",
+      "Petersilie",
+      "8 Fischstäbchen",
+      "1 EL Rapsöl"
+    ],
+    "instructions": [
+      "Kartoffeln waschen, schälen und in kleine Stücke schneiden. Möhren schälen und in Scheiben schneiden.",
+      "Kartoffeln und Möhren in einem Topf mit Gemüsebrühe gar kochen. Abgießen und zusammen mit der Milch stampfen. Mit Salz, Pfeffer und Muskat abschmecken.",
+      "Petersilie waschen, trocken schütteln, fein hacken und über den Kartoffel-Möhren-Stampf streuen.",
+      "Fischstäbchen in etwas Öl goldbraun braten und zusammen mit dem Kartoffel-Möhren-Stampf anrichten."
+    ],
+    "id": "rec_14"
+  },
+  {
+    "title": "One Pot Pasta mit Spinat",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "628 kcal",
+      "Kohlenhydrate": "81,7 g",
+      "Fett": "25,3 g",
+      "Eiweiß": "21,5 g"
+    },
+    "ingredients": [
+      "2 Zwiebeln",
+      "1 Pck . ja! Rahmspinat (450 g)",
+      "400 g ja! Spaghetti",
+      "800 ml ja! Gemüsebrühe",
+      "200 ml ja! Schlagsahne",
+      "50 g Parmesan"
+    ],
+    "instructions": [
+      "Zwiebeln schälen und hacken. Zusammen mit dem gefrorenen Spinat und den Spaghetti in einen großen Topf geben.",
+      "Gemüsebrühe und Sahne zugießen und mit geschlossenem Deckel aufkochen. Nach dem Aufkochen Deckel entfernen und die Nudeln bei schwacher bis mäßiger Hitze ca. 10 Minuten köcheln, bis sie gar sind. Zwischendurch umrühren, ggf. noch etwas Wasser zufügen.",
+      "Mit Parmesan bestreuen und servieren."
+    ],
+    "id": "rec_15"
+  },
+  {
+    "title": "Penne mit Erbsen-Schinken-Sahne-Sauce",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "726 kcal",
+      "Kohlenhydrate": "107 g",
+      "Fett": "20,6 g",
+      "Eiweiß": "31,7 g"
+    },
+    "ingredients": [
+      "200 g ja! TK-Erbsen",
+      "500 g Penne",
+      "Salz",
+      "1 Zwiebel",
+      "0,5 Zehe(n) Knoblauch",
+      "200 g gekochter Schinken",
+      "2 EL Rapsöl",
+      "100 ml Gemüsebrühe",
+      "150 ml Sahne",
+      "Pfeffer",
+      "0,5 Zitrone"
+    ],
+    "instructions": [
+      "Erbsen auftauen lassen. Penne nach Packungsanweisung in Salzwasser gar kochen und abtropfen lassen.",
+      "In der Zwischenzeit Zwiebel und Knoblauch schälen und fein hacken. Schinken in kleine Stücke schneiden.",
+      "Öl in einer großen Pfanne erhitzen und Zwiebel und Knoblauch darin andünsten. Nun Schinken dazugeben und mitbraten. Salzen und Pfeffern. Gemüsebrühe und Sahne angießen und Erbsen ebenfalls untermischen. Etwas einköcheln lassen. Falls die Sauce zu dünn ist, ggf. mit 1 TL Mehl abbinden. Dafür das Mehl mit einem Schneebesen einrühren.",
+      "Zitronenhälfte auspressen und mit 1 TL Zitronensaft und Salz und Pfeffer abschmecken. Penne unterheben und servieren."
+    ],
+    "id": "rec_16"
+  },
+  {
+    "title": "Kartoffel-Gemüse-Pfanne",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "395 kcal",
+      "Kohlenhydrate": "55,4 g",
+      "Fett": "15,9 g",
+      "Eiweiß": "11,9 g"
+    },
+    "ingredients": [
+      "800 g Drillings Kartoffeln",
+      "4 Zehe(n) Knoblauch",
+      "6 rote Zwiebeln",
+      "500 g braune Champignons",
+      "2 grüne Paprika",
+      "6 Möhren",
+      "4 Zweig(e) Rosmarin",
+      "4 Zweig(e) Thymian",
+      "30 g Petersilie",
+      "Salz",
+      "6 EL Olivenöl",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Kartoffeln waschen und halbieren. Knoblauch und Zwiebeln abziehen. Knoblauch fein hacken, Zwiebeln vierteln. Champignons putzen und vierteln. Paprika entkernen und in Streifen schneiden.",
+      "Möhren waschen, schälen und schräg in dünne Scheiben schneiden. Kräuter waschen und trocken schütteln. Rosmarin und Thymianblättchen von den Stielen streifen und grob hacken.",
+      "Salzwasser in einem Topf zum Kochen bringen und Kartoffeln etwa 10 Minuten vorgaren. Wasser abgießen.",
+      "Olivenöl in einer Pfanne erhitzen. Erst Knoblauch und Zwiebeln glasig andünsten. Restliches Gemüse und Kartoffeln zufügen und etwa 5 anbraten. Kräuter hinzufügen und ca. 3 Minuten mitbraten. Mit Salz und Pfeffer abschmecken."
+    ],
+    "id": "rec_17"
+  },
+  {
+    "title": "Blumenkohlauflauf Mac ‘n‘ Cheese",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "721 kcal",
+      "Kohlenhydrate": "82,9 g",
+      "Fett": "31,5 g",
+      "Eiweiß": "29,5 g"
+    },
+    "ingredients": [
+      "400 g ja! Penne",
+      "300 g ja! Blumenkohl (TK)",
+      "1 Zehe(n) Knoblauch",
+      "2 EL ja! Butter",
+      "1 EL ja! Weizenmehl (Type 405)",
+      "200 ml ja! Vollmilch",
+      "100 g ja! Schlagsahne",
+      "ja! Salz",
+      "ja! Pfeffer",
+      "1 TL ja! Paprikapulver edelsüß",
+      "200 g ja! Cheddar"
+    ],
+    "instructions": [
+      "Penne laut Packungsanleitung zubereiten und ca. 3 Minuten vor Ende der Garzeit den gefrorenen Blumenkohl dazugeben.",
+      "Knoblauch schälen. In einem großen Topf die Butter bei kleiner Temperatur schmelzen und den Knoblauch, durch eine Knoblauchpresse gedrückt, dazugeben. Wenige Minuten andünsten. Das Mehl einrühren. Dann unter ständigem Rühren Milch und Sahne unterrühren. Einmal kurz aufkochen lassen und dann mit Salz, Pfeffer und Paprikapulver abschmecken. Die Soße bei niedriger Hitze köcheln lassen, bis sie leicht eindickt.",
+      "Backofen auf 180 °C Ober- und Unterhitze vorheizen. Eine Auflaufform (38 x 26 cm) mit etwas Butter einreiben.",
+      "Den Cheddar in kleine Würfel schneiden und die Hälfte vom Cheddar (100 g) in die Soße rühren.",
+      "Pasta und Blumenkohl in einem Sieb über der Spüle abtropfen lassen und in die Auflaufform geben. Die Soße gleichmäßig darauf verteilen und alles einmal gut durchmischen. Den restlichen Cheddar auf dem Auflauf verteilen.",
+      "Den Blumenkohlauflauf Mac ‘n‘ Cheese im Backofen ca. 20 Minuten backen, bis der Käse goldbraun ist."
+    ],
+    "id": "rec_18"
+  },
+  {
+    "title": "Schnelle Tomaten-One-Pot-Pasta",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "782 kcal",
+      "Kohlenhydrate": "108 g",
+      "Fett": "27,4 g",
+      "Eiweiß": "29,3 g"
+    },
+    "ingredients": [
+      "800 ml ja! Tomatencremesuppe",
+      "500 g Penne Mezzane Rigate",
+      "100 g Getrocknete Tomaten in Öl",
+      "1 TL Knoblauchpulver",
+      "Pfeffer",
+      "Salz",
+      "2 ja ! Mozzarella"
+    ],
+    "instructions": [
+      "Tomatencremesuppe, 750 ml Wasser und Penne in einen Topf geben, erhitzen und für 15 Minuten köcheln lassen, bis die Penne al dente sind.",
+      "3 Minuten vor Ende der Garzeit die getrockneten Tomaten würfeln und mit 1 TL Öl zur Pasta geben. Mit Knoblauchpulver, Pfeffer und Salz abschmecken.",
+      "Mozzarella in Stücke zupfen und unter die Pasta heben."
+    ],
+    "id": "rec_19"
+  },
+  {
+    "title": "Einfaches Risi Bisi",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "600 kcal",
+      "Kohlenhydrate": "111,8 g",
+      "Fett": "11,3 g",
+      "Eiweiß": "15,1 g"
+    },
+    "ingredients": [
+      "300 g Ja! TK-Erbsen",
+      "480 g Ja! Langkorn-Reis",
+      "1 mittlere Zwiebel",
+      "0,5 Zehe(n) Knoblauch",
+      "0,5 Bd . frische Petersilie",
+      "1 Kopfsalat",
+      "4 EL Rapsöl",
+      "2 EL Essig",
+      "1 TL Senf",
+      "Salz",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Erbsen auftauen lassen. Reis mit der doppelten Menge Salzwasser aufkochen lassen. Bei schwacher Hitze so lange quellen lassen, bis die Flüssigkeit aufgesogen und der Reis gar ist.",
+      "In der Zwischenzeit Zwiebel und Knoblauch schälen und beides fein hacken. Petersilie waschen und ebenfalls hacken.",
+      "Salat waschen, trocknen und in Stücke zupfen. Aus 3 EL Öl, Essig, Senf, Salz und Pfeffer das Dressing zubereiten und unter die Salatblätter mischen.",
+      "Restliches Öl in einer Pfanne erhitzen und die Zwiebel andünsten, dann Knoblauch hinzufügen und kurz mitbraten. Erbsen und kurze Zeit später Reis und Petersilie unterrühren und gut mischen. Mit Salz und Pfeffer würzen.",
+      "Risi Bisi auf Teller verteilen und mit dem Salat servieren."
+    ],
+    "id": "rec_20"
+  },
+  {
+    "title": "Vollkorn-Spaghetti mit Cherrytomaten aus dem Ofen",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "654 kcal",
+      "Kohlenhydrate": "104 g",
+      "Fett": "21,3 g",
+      "Eiweiß": "19,3 g"
+    },
+    "ingredients": [
+      "1 kg Cherry-Rispentomaten",
+      "0,25 Knolle(n) Knoblauch",
+      "15 g Rosmarin",
+      "75 ml Olivenöl",
+      "Salz",
+      "0,5 TL Pfeffer",
+      "2 EL Aceto Balsamico",
+      "Zucker",
+      "500 g Vollkorn-Spaghetti"
+    ],
+    "instructions": [
+      "Backofen auf 200 °C Umluft vorheizen.",
+      "Cherrytomaten waschen und trocknen. 4 schöne Rispen intakt lassen und die restlichen Tomaten abzupfen.",
+      "Knoblauch schälen. Rosmarin waschen.",
+      "Olivenöl mit Salz, Pfeffer, Aceto Balsamico und Zucker verrühren. Tomaten, Knoblauch und Rosmarin hinzufügen und gut mischen.",
+      "Tomaten, Knoblauch und Kräuter in einer einzelnen Lage in eine große Auflaufform geben und im Ofen 25 Minuten backen.",
+      "Spaghetti in Salzwasser nach Packungsanweisung garen.",
+      "Spaghetti sofort mit den gebackenen Cherrytomaten sowie dem Sud vermischen. Mit den Rispen garnieren und servieren."
+    ],
+    "id": "rec_21"
+  },
+  {
+    "title": "Bandnudeln mit Butternut-Kürbis",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "609 kcal",
+      "Kohlenhydrate": "104 g",
+      "Fett": "15,6 g",
+      "Eiweiß": "19,1 g"
+    },
+    "ingredients": [
+      "1 Kürbis (600 g, Butternut oder Hokkaido)",
+      "1 Zwiebel",
+      "1 Zehe(n) Knoblauch",
+      "2 Zweig(e) Thymian",
+      "2 EL Olivenöl",
+      "300 ml Gemüsebrühe",
+      "Salz",
+      "Pfeffer",
+      "Cayennepfeffer",
+      "400 g Bandnudeln",
+      "50 g Walnüsse"
+    ],
+    "instructions": [
+      "Kürbis halbieren, Kerne entfernen und schälen, dann klein würfeln. Zwiebel und Knoblauch schälen und fein hacken. Thymianblättchen ebenfalls fein hacken.",
+      "Öl erhitzen und die Zwiebel anschwitzen. Kürbis und Knoblauch zufügen und kurz mitbraten, dann mit der Gemüsebrühe ablöschen und ca. 15 Minuten bei schwacher Hitze köcheln, bis der Kürbis gar ist. Mit Salz, Pfeffer und Cayennepfeffer würzen.",
+      "Bandnudeln nach Packungsanweisung kochen.",
+      "Walnüsse hacken.",
+      "Die Bandnudeln mit dem Kürbis anrichten und mit gehackten Walnüssen sowie Thymian bestreuen."
+    ],
+    "id": "rec_22"
+  },
+  {
+    "title": "Asia-Suppe mit Huhn & Gemüse",
+    "tags": [
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "295 kcal",
+      "Kohlenhydrate": "32 g",
+      "Fett": "7,1 g",
+      "Eiweiß": "26,6 g"
+    },
+    "ingredients": [
+      "3 Frühlingszwiebeln",
+      "2 Zehe(n) Knoblauch",
+      "1 kleine rote Zwiebel",
+      "1 Karotte",
+      "350 g Hähnchenbrustfilet",
+      "2 EL Rapsöl",
+      "1 Stück Ingwer",
+      "2 EL Sojasauce",
+      "150 g Wok Nudeln (chinesische Eiernudeln)",
+      "2 Zweig(e) Koriander"
+    ],
+    "instructions": [
+      "Frühlingszwiebeln waschen und in feine Ringe schneiden, Knoblauch und Zwiebel schälen, Knoblauch fein hacken, Zwiebeln in halbe Ringe schneiden. Karotte schälen und in Stifte schneiden.",
+      "Hähnchenbrust in 1 l Wasser ca. 20 Minuten kochen, aus der Brühe nehmen und mit einer Gabel grob zerrupfen. Brühe abgießen und auffangen.",
+      "In dem Topf Rapsöl erhitzen, Zwiebeln, Knoblauch und Karotten kurz anbraten, mit der Brühe aufgießen, das Gemüse wenige Minuten garen. Mit geriebenem Ingwer und Sojasauce abschmecken.",
+      "Die Nudeln in die Suppe geben und al dente kochen, das Fleisch zurück in die Suppe geben und mit frisch gezupften Korianderblättern servieren."
+    ],
+    "id": "rec_23"
+  },
+  {
+    "title": "Rigatoni mit Tomatensoße",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "692 kcal",
+      "Kohlenhydrate": "110,2 g",
+      "Fett": "17,3 g",
+      "Eiweiß": "26,2 g"
+    },
+    "ingredients": [
+      "3 Knoblauchzehen",
+      "3 EL Öl",
+      "3 EL Tomatenmark",
+      "2 Dose(n) Tomaten",
+      "Salz",
+      "Pfeffer",
+      "Chiliflocken",
+      "2 EL Balsamico",
+      "2 TL Zucker",
+      "500 g Rigatoni",
+      "0,5 Bd . Basilikum",
+      "100 g Parmesan"
+    ],
+    "instructions": [
+      "Knoblauch schälen und in dünne Scheiben schneiden. Öl erhitzen, Knoblauch darin kurz anschwitzen. Tomatenmark zugeben und anrösten. Tomaten zugeben und etwas zerdrücken. Mit Salz, Pfeffer, Chili, Balsamico und Zucker würzen. Soße ca. 15 Minuten köcheln lassen.",
+      "Nudeln nach Packungsanweisung in kochendem Salzwasser bissfest garen. In der Zwischenzeit Basilikum waschen, trocken schütteln und hacken. Parmesan hobeln.",
+      "Nudeln mit Tomatensoße anrichten und mit Basilikum und Parmesan bestreut servieren."
+    ],
+    "id": "rec_24"
+  },
+  {
+    "title": "Schnüsch-Gratin",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "560 kcal",
+      "Kohlenhydrate": "47 g",
+      "Fett": "34,7 g",
+      "Eiweiß": "18,5 g"
+    },
+    "ingredients": [
+      "500 g Kartoffeln (vorwiegend festkochend)",
+      "300 g Möhren",
+      "1 Kohlrabi",
+      "2 Stange(n) Lauch",
+      "0,5 Bd . Kerbel",
+      "0,5 Bd . Petersilie",
+      "2 EL Rapsöl",
+      "150 ml Gemüsebrühe",
+      "Salz",
+      "Pfeffer",
+      "Muskat",
+      "1 EL Butter",
+      "1 EL Weizenmehl Type 405",
+      "400 ml Milch",
+      "200 g Sahne",
+      "100 g geriebener Käse"
+    ],
+    "instructions": [
+      "Kartoffeln, Möhren und Kohlrabi schälen. Kartoffeln und Möhren in Scheiben, Kohlrabi in dünne Spalten schneiden. Lauch putzen, waschen und das Weiße in feine Ringe schneiden. Kräuter waschen und Blättchen hacken. Einen kleinen Teil der Kräuter für die Deko beiseitestellen.",
+      "Öl erhitzen und die Möhren sowie den Kohlrabi anschwitzen. Lauch und Kartoffeln zufügen und kurz mitgaren. 150 ml Gemüsebrühe zufügen und bei schwacher Hitze gut 15 Minuten garen, bis Gemüse und Kartoffeln fast gar sind. Mit Salz, Pfeffer und Muskat würzen.",
+      "Butter schmelzen, Mehl zufügen und unter Rühren aufschäumen lassen. Milch und Sahne zufügen, aufkochen und bei schwacher Hitze gut 15 Minuten köcheln lassen. Mit Salz, Pfeffer und Muskat würzen.",
+      "Gemüse, Kartoffeln und Kräuter in eine Auflaufform geben und vermengen. Soße darüber gießen, mit Käse bestreuen und im auf 240 °C Oberhitze (oder Grillfunktion) vorgeheizten Backofen 5-7 Minuten goldbraun überbacken. Mit den beiseitegelegten Kräutern anrichten."
+    ],
+    "id": "rec_25"
+  },
+  {
+    "title": "Pasta mit Linsenbällchen",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "770 kcal",
+      "Kohlenhydrate": "136,6 g",
+      "Fett": "13,2 g",
+      "Eiweiß": "31,6 g"
+    },
+    "ingredients": [
+      "200 g rote Linsen",
+      "Salz",
+      "4 Knoblauchzehen",
+      "4 EL Öl",
+      "6 EL Tomatenmark",
+      "5 Stiel(e) Petersilie",
+      "1 EL Sojasoße",
+      "5 EL zarte Haferflocken",
+      "Paprikapulver",
+      "1 große Zwiebel",
+      "1 Dose(n) gehackte Tomaten",
+      "100 ml Rotwein",
+      "1 TL Zucker",
+      "Chilipulver",
+      "400 g Spaghetti",
+      "3 Stiel(e) Basilikum"
+    ],
+    "instructions": [
+      "Für die Linsenbällchen Linsen in 400 ml kochendem Salzwasser ca. 15 Minuten kochen, abgießen und sehr gut abtropfen lassen. Backofen auf 180°C Umluft vorheizen.",
+      "Knoblauch schälen und fein hacken. Hälfte Knoblauch in 2 EL Öl anrösten, 1 EL Tomatenmark zugeben und mitrösten. Mischung zu den Linsen geben. Petersilie waschen, trocken schütteln und fein hacken. Petersilie, Sojasoße und Haferflocken ebenfalls zu den Linsen geben und alles zu einer homogenen Masse verkneten. Mit Paprikapulver und evtl. etwas Salz würzen.",
+      "Aus der Masse kleine Bällchen formen, diese auf ein mit Backpapier belegtes Backblech legen und im vorgeheizten Backofen ca. 30 Minuten backen.",
+      "Für die Tomatensoße Zwiebel schälen und in kleine Würfel schneiden. 2 EL Öl in einem Topf erhitzen, Zwiebel darin andünsten und übrigen Knoblauch hinzufügen. 5 EL Tomatenmark und gehackte Tomaten zugeben. Mit Rotwein ablöschen, 100 ml Wasser zugeben, mit Salz, Zucker und Chili würzen. Soße ca. 20 Minuten köcheln lassen.",
+      "Spaghetti nach Packungsanweisung in Salzwasser kochen. Basilikum waschen, trocken schütteln.",
+      "Linsenbällchen vorsichtig unter die Tomatensoße heben und mit Nudeln anrichten. Mit dem Basilikum garnieren."
+    ],
+    "id": "rec_26"
+  },
+  {
+    "title": "Penne all’arrabbiata",
+    "tags": [
+      "Vegetarisch",
+      "Zuckerfrei",
+      "Kalorienarm",
+      "Fettarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "421 kcal",
+      "Kohlenhydrate": "65,2 g",
+      "Fett": "12,7 g",
+      "Eiweiß": "13,5 g"
+    },
+    "ingredients": [
+      "400 g reife Tomaten",
+      "2 Knoblauchzehen",
+      "2 Chilischoten",
+      "40 ml Olivenöl",
+      "Salz",
+      "Pfeffer",
+      "1 Handvoll glatte Petersilie",
+      "1 Stück Pecorino",
+      "320 g Penne Rigate"
+    ],
+    "instructions": [
+      "Tomaten mit Wasser überbrühen und die Schale abziehen, dann in kleine Würfel schneiden. Knoblauch schälen und halbieren, Chilischoten in feine Ringe schneiden.",
+      "Olivenöl in einer Pfanne erhitzen, Knoblauch und Chiliringe darin anbraten, die Tomatenwürfel dazugeben, mitbraten und mit Salz und Pfeffer würzen.",
+      "Petersilie fein hacken, Pecorino reiben. Nudeln in reichlich Salzwasser nach Packungsanleitung al dente garen.",
+      "Knoblauch aus der Pfanne nehmen, Nudeln abgießen und sofort in die Pfanne geben. Alles miteinander vermengen, erneut mit Salz und Pfeffer abschmecken, Petersilie und Pecorino unterrühren und sofort servieren."
+    ],
+    "id": "rec_27"
+  },
+  {
+    "title": "Vegetarisches Kartoffelgulasch",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "336 kcal",
+      "Kohlenhydrate": "63,7 g",
+      "Fett": "5,8 g",
+      "Eiweiß": "8,7 g"
+    },
+    "ingredients": [
+      "4 Zwiebeln",
+      "2 Zehe(n) Knoblauch",
+      "1,2 g Kartoffeln, festkochend",
+      "2 rote Paprika",
+      "2 EL Natives Olivenöl extra",
+      "4 EL Tomatenmark",
+      "1 l Gemüsebrühe",
+      "Pfeffer",
+      "Salz",
+      "4 TL Paprika edelsüß gemahlen",
+      "1 Bd . Petersilie"
+    ],
+    "instructions": [
+      "Zwiebeln und Knoblauch schälen und fein würfeln. Kartoffeln schälen, waschen und in mundgerechte Stücke schneiden (ca. 1 x 1,5 cm). Paprika waschen, entkernen und ebenfalls in gleicher Größe würfeln.",
+      "Öl in einem großen Topf erhitzen. Zwiebeln und Knoblauch darin glasig dünsten. Kartoffel zufügen und kurz anbraten. Tomatenmark zufügen und ebenfalls mit anbraten.",
+      "Alles mit Gemüsebrühe ablöschen und die Gewürze zufügen. Für circa 15 Minuten köcheln lassen, dann die Paprika zufügen. Für weitere 5 Minuten köcheln lassen.",
+      "Petersilie waschen, trocken schütteln, zupfen und grob hacken.",
+      "Gulasch mit frischer Petersilie bestreut servieren."
+    ],
+    "id": "rec_28"
+  },
+  {
+    "title": "Schneller Couscous-Salat",
+    "tags": [
+      "Vegetarisch",
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "286 kcal",
+      "Kohlenhydrate": "58,7 g",
+      "Fett": "2,1 g",
+      "Eiweiß": "9,3 g"
+    },
+    "ingredients": [
+      "250 g Instant-Couscous",
+      "1 Salatgurke",
+      "250 g Cherrytomaten",
+      "1 Bd . glatte Petersilie",
+      "1 Bd . Minze",
+      "2 Limette",
+      "1 TL flüssiger Honig",
+      "5 EL Ajvar pikant",
+      "Salz",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Couscous nach Packungsanweisung zubereiten. Gurke waschen, längs vierteln und entkernen. In grobe Würfel schneiden. Cherrytomaten waschen und halbieren.",
+      "Kräuter waschen, trocken schütteln und Blätter hacken. Saft der Limette auspressen und mit Honig verrühren.",
+      "Ajvar unter den Couscous rühren und nach Belieben mit Salz und Pfeffer würzen. Gurken und Tomaten hinzugeben und vermengen. Kräuter und Limetten-Honig-Saft unter die Mischung heben."
+    ],
+    "id": "rec_29"
+  },
+  {
+    "title": "Vegane Kohlrabi-Schnitzel mit Gurkensalat",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "306 kcal",
+      "Kohlenhydrate": "39,8 g",
+      "Fett": "14 g",
+      "Eiweiß": "7,5 g"
+    },
+    "ingredients": [
+      "2 Kohlrabi",
+      "6 EL Cornflakes, ungezuckert",
+      "6 EL Paniermehl",
+      "Salz",
+      "Pfeffer",
+      "Paprikapulver",
+      "3 EL Weizenmehl Type 405",
+      "3 EL Soja-Kochcreme",
+      "2 Salatgurken",
+      "4 EL Sonnenblumenöl",
+      "2 EL Limettensaft",
+      "1 TL Ahornsirup",
+      "1 TL Senf",
+      "1 Bd . Dill",
+      "1 rote Zwiebel"
+    ],
+    "instructions": [
+      "Die Kohlrabi schälen und in 5 mm dicke Scheiben schneiden. Blanchiert diese ca. 5 Minuten, bis sie weich sind. Gut trocken tupfen. Die Cornflakes grob mit den Fingern zerbröseln und mit dem Paniermehl mischen. Salz, Pfeffer, Paprikapulver untermischen. Auf einem großen Teller Mehl und Sojacreme zu einer glatten Creme verrühren. Die Kohlrabischeiben erst in der Creme, dann in der Cornflakes-Panade wälzen. Die Panade ca. 10 Minuten anziehen lassen.",
+      "Die Salatgurken gut waschen, die Enden abschneiden und die Gurken der Länge nach halbieren. Mit einem Teelöffel das kernige Innere auskratzen und anschließend in dünne Scheiben schneiden. Für die Salatsoße Öl, Limettensaft, Ahornsirup und Senf miteinander glatt rühren. Mit Salz und Pfeffer abschmecken und unter die Gurkenscheiben rühren. Dill waschen und fein hacken. Die rote Zwiebel abziehen und in sehr feine Ringe schneiden. Beides unter den Salat mischen und ziehen lassen.",
+      "In einer großen, beschichteten Pfanne Öl erhitzen und die Schnitzel von beiden Seiten ca. 3 Minuten knusprig anbraten. Anschließend kurz auf einem Küchenpapier abtropfen lassen und mit dem Gurkensalat servieren."
+    ],
+    "id": "rec_30"
+  },
+  {
+    "title": "Khao Phad - Thailändischer Bratreis",
+    "tags": [
+      "Vegetarisch",
+      "Laktosefrei",
+      "Glutenfrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "415 kcal",
+      "Kohlenhydrate": "56 g",
+      "Fett": "15,1 g",
+      "Eiweiß": "14,7 g"
+    },
+    "ingredients": [
+      "4 Zehe(n) Knoblauch",
+      "4 Lauchzwiebeln",
+      "250 g Möhren",
+      "3 EL Öl",
+      "5 Eier",
+      "1 kg gekochter Reis (z. B. vom Vortag)",
+      "Salz",
+      "Zucker",
+      "weißer Pfeffer",
+      "2 -Limetten"
+    ],
+    "instructions": [
+      "Knoblauch schälen und hacken. Lauchzwiebeln waschen und in Ringe schneiden. Möhren schälen und in feine Stifte schneiden.",
+      "Öl in einem Wok erhitzen. Knoblauch darin kurz anbraten, dann die Eier zugeben, verrühren und stocken lassen. Reis untermischen, Möhren und Lauchzwiebeln ebenfalls zugeben und alles ca. 5 Minuten anbraten. Mit Salz, Zucker, Pfeffer und Saft von einer Limette abschmecken.",
+      "Andere Limette waschen und in Spalten schneiden. Fertigen Reis mit Limetten garniert anrichten."
+    ],
+    "id": "rec_31"
+  },
+  {
+    "title": "Süßkartoffel Curry",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "758 kcal",
+      "Kohlenhydrate": "126,4 g",
+      "Fett": "25 g",
+      "Eiweiß": "13,8 g"
+    },
+    "ingredients": [
+      "4 Süßkartoffeln (ca. 800 g)",
+      "2 Zwiebel",
+      "2 daumengroßes Stück Ingwer (3 g)",
+      "6 EL Rapsöl",
+      "4 EL Garam Masala",
+      "2 TL Kurkuma",
+      "1 TL Kreuzkümmel (gemahlen)",
+      "1400 g passierte Tomaten (400 g)",
+      "2 EL Erdnussmus",
+      "Salz",
+      "30 g Koriander"
+    ],
+    "instructions": [
+      "Süßkartoffel schälen und in ca. 2 cm große Würfel schneiden. Zwiebel schälen und in Streifen schneiden. Ingwer schälen und fein würfeln.",
+      "Öl in einem Topf erhitzen und Süßkartoffeln und Zwiebeln darin anrösten. Ingwer, Garam Masala, Kurkuma und Kreuzkümmel zugeben, kurz anrösten und die passierten Tomaten zugeben. 15 Minuten köcheln lassen.",
+      "Erdnussmus unterrühren und mit Salz abschmecken. Koriander waschen, trocken schütteln und grob hacken. Curry mit Koriander garniert servieren."
+    ],
+    "id": "rec_32"
+  },
+  {
+    "title": "Schupfnudeln mit Kohl",
+    "tags": [
+      "Laktosefrei"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "582 kcal",
+      "Kohlenhydrate": "38,7 g",
+      "Fett": "38,8 g",
+      "Eiweiß": "23,5 g"
+    },
+    "ingredients": [
+      "1 Spitzkohl",
+      "2 Zwiebeln",
+      "2 EL Butterschmalz",
+      "400 g Schupfnudeln",
+      "1 Prise(n) Kümmel",
+      "1 Prise(n) Pfeffer",
+      "Salz",
+      "4 geräucherte Mettenden"
+    ],
+    "instructions": [
+      "Spitzkohl putzen, halbieren, den Strunk entfernen und in ca. 1 cm breite Streifen schneiden. Zwiebeln schälen und würfeln.",
+      "Butterschmalz in einer großen Pfanne erhitzen und die Schupfnudeln bei mittlerer Hitze rundherum goldbraun braten. Zwiebeln und Kohl dazugeben. Mit Kümmel, Pfeffer und Salz würzen und alles 5 Minuten braten.",
+      "Mettenden in Scheiben schneiden und in die Pfanne geben. Alles gut durchmischen und nochmals 5-6 Minuten bei mittlerer Hitze braten. Nochmals abschmecken und servieren."
+    ],
+    "id": "rec_33"
+  },
+  {
+    "title": "Beamtenstippe zu Kartoffeln",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "673 kcal",
+      "Kohlenhydrate": "34,2 g",
+      "Fett": "41 g",
+      "Eiweiß": "42,7 g"
+    },
+    "ingredients": [
+      "600 g Kartoffeln (festkochend)",
+      "2 Zwiebeln",
+      "2 EL Butter",
+      "800 g Hackfleisch (gemischt)",
+      "Salz",
+      "Pfeffer",
+      "2 EL Weizenmehl Type 405",
+      "3 EL Tomatenmark",
+      "300 ml Brühe",
+      "3 Gewürzgurken",
+      "2 EL Petersilie"
+    ],
+    "instructions": [
+      "Kartoffeln schälen und in heißem Wasser ca. 20 Minuten kochen, abgießen und warm stellen.",
+      "In der Zwischenzeit die Zwiebeln schälen und würfeln. Butter in einer Pfanne zerlassen. Die Zwiebelwürfel in die Pfanne geben und 5 Minuten glasig dünsten.",
+      "Hackfleisch dazugeben und goldbraun anbraten. Dabei das Fleisch mit einem Löffel zerkleinern, bis es krümelig ist. Mit Salz und Pfeffer würzen und mit Mehl bestäuben.",
+      "Tomatenmark unterrühren und mit Brühe ablöschen. Die Hitze reduzieren und ca. 10 Minuten köcheln lassen.",
+      "Gurken in Würfel schneiden und zum Hackfleisch geben. 200 ml vom Gurkenwasser dazugeben und das Ganze noch einmal aufkochen lassen.",
+      "Die Petersilie waschen, trocken tupfen und fein hacken.",
+      "Die Beamtenstippe mit den Salzkartoffeln servieren und mit Petersilie bestreuen."
+    ],
+    "id": "rec_34"
+  },
+  {
+    "title": "Schnelle Pasta mit Wirsing und Cranberries",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "566 kcal",
+      "Kohlenhydrate": "80,3 g",
+      "Fett": "19,8 g",
+      "Eiweiß": "24,1 g"
+    },
+    "ingredients": [
+      "300 g Vollkorn-Fusilli",
+      "800 g Wirsing",
+      "Salz",
+      "2 Schalotte",
+      "2 EL Öl",
+      "60 g Pinienkerne",
+      "60 g getrocknete Cranberries",
+      "Pfeffer",
+      "60 g Parmesan"
+    ],
+    "instructions": [
+      "Nudeln nach Packungsanweisung zubereiten. Wirsing putzen, in Streifen schneiden und in kochendem Salzwasser ca. 5 Minuten bissfest kochen. Schalotte schälen und fein würfeln. Wirsing abgießen, etwas Kochwasser zurückbehalten.",
+      "Öl in einer Pfanne erhitzen und Schalotte darin glasig dünsten. Pinienkerne zugeben und kurz anrösten. Wirsing und Cranberries zugeben und mit 100-200 ml Kochwasser ablöschen. Nudeln abgießen und in die Pfanne geben. Mit Salz und Pfeffer abschmecken. Auf Tellern verteilen und Parmesan darüber hobeln."
+    ],
+    "id": "rec_35"
+  },
+  {
+    "title": "Spaghetti Amatriciana",
+    "tags": [
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "856 kcal",
+      "Kohlenhydrate": "111,4 g",
+      "Fett": "30,4 g",
+      "Eiweiß": "38,5 g"
+    },
+    "ingredients": [
+      "2 kleine Zwiebel",
+      "2 Zehe(n) Knoblauch",
+      "400 g Spaghetti",
+      "Salz",
+      "2 TL Olivenöl",
+      "300 g Speckwürfel",
+      "Chiliflocken",
+      "2 Dose(n) stückige Tomaten (400 ml)",
+      "4 EL Pecorino (gerieben)",
+      "Zucker",
+      "Pfeffer",
+      "2 Zweig(e) frisches Basilikum"
+    ],
+    "instructions": [
+      "Zwiebel und Knoblauch schälen und fein hacken. Nudeln in Salzwasser nach Packungsanweisung al dente kochen.",
+      "Olivenöl in einer Pfanne erhitzen, den Speck darin anbraten, dann Zwiebeln, Knoblauch und Chiliflocken dazugeben und mitbraten.",
+      "Tomaten sowie eine Kelle vom Nudelwasser dazugeben und alles ca. 10 Minuten einköcheln lassen. Die Hälfte des Pecorino einrühren, mit etwas Zucker, Pfeffer und Salz abschmecken.",
+      "Spaghetti und Sauce vermischen, auf Tellern anrichten und mit dem übrigen Pecorino sowie frischem Basilikum servieren."
+    ],
+    "id": "rec_36"
+  },
+  {
+    "title": "Schinken-Käse-Nudelauflauf",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "655 kcal",
+      "Kohlenhydrate": "60,3 g",
+      "Fett": "30,7 g",
+      "Eiweiß": "35,7 g"
+    },
+    "ingredients": [
+      "300 g kurze Nudeln (z.B. Penne)",
+      "1 TL Butter",
+      "200 g Kochschinken",
+      "150 g Bergkäse",
+      "150 ml Milch",
+      "150 g Crème Fraîche",
+      "2 Eier",
+      "Pfeffer",
+      "Salz",
+      "1 Prise(n) Muskat"
+    ],
+    "instructions": [
+      "Die Nudeln nach Packungsanleitung al dente kochen und danach mit kaltem Wasser abschrecken.",
+      "Den Backofen auf 200 °C Ober-/ Unterhitze vorheizen. Eine Auflaufform mit Butter fetten. Den Schinken in Streifen schneiden. Den Käse fein hobeln.",
+      "Milch, Crème Fraîche und Eier miteinander verquirlen und mit Pfeffer, Salz und Muskat würzen.",
+      "Nudeln und Schinken in die Auflaufform geben und vermischen. Die Eiermilch gleichmäßig darüber verteilen. Mit Käse bestreuen und in ca. 25 Minuten goldbraun backen."
+    ],
+    "id": "rec_37"
+  },
+  {
+    "title": "Nudelauflauf mit Gemüse vom Blech",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "768 kcal",
+      "Kohlenhydrate": "77,4 g",
+      "Fett": "37,3 g",
+      "Eiweiß": "33,8 g"
+    },
+    "ingredients": [
+      "160 g TK-Erbsen",
+      "320 g Spiralnudeln",
+      "Salz",
+      "3,2 Eier (Größe M)",
+      "160 ml Schlagsahne",
+      "160 ml Milch",
+      "Pfeffer",
+      "Muskatnuss",
+      "120 g Kochschinken (in Scheiben)",
+      "120 g mittelalter Gouda",
+      "2,4 EL Semmelbrösel",
+      "2,4 EL Sonnenblumenöl"
+    ],
+    "instructions": [
+      "Erbsen auftauen lassen. Nudeln in reichlich kochendem Salzwasser nach Packungsanweisung bissfest garen, abgießen und abtropfen lassen. Eier mit Sahne und Milch verquirlen und mit Salz, Pfeffer und Muskat würzen.",
+      "Schinken würfeln. Käse raspeln und mit den Semmelbröseln mischen. Ein tiefes Blech mit 2 EL Sonnenblumenöl fetten. Nudeln mit Erbsen und Schinken mischen und auf dem Blech verteilen. Eier-Sahne-Mischung darübergießen. Käse-Brösel-Mischung gleichmäßig darüberstreuen. Alles mit 1 EL Sonnenblumenöl beträufeln.",
+      "Nudelauflauf im vorgeheizten Ofen bei 220 Grad Ober- und Unterhitze (Umluft 200 Grad) auf der mittleren Schiene 20 Min. goldbraun backen."
+    ],
+    "id": "rec_38"
+  },
+  {
+    "title": "Bandnudeln mit Spinatsoße",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "585 kcal",
+      "Kohlenhydrate": "80,7 g",
+      "Fett": "20,9 g",
+      "Eiweiß": "21,2 g"
+    },
+    "ingredients": [
+      "400 g tiefgefrorener Blattspinat",
+      "2 EL Rapsöl",
+      "30 g Pinienkerne",
+      "2 Schalotten",
+      "1 Knoblauchzehe",
+      "200 ml Gemüsebrühe",
+      "Salz",
+      "weißer Pfeffer",
+      "Muskatnuss (frisch gerieben)",
+      "100 g Schmand",
+      "400 g Bandnudeln",
+      "40 g Parmesan (oder veg. Alternative)"
+    ],
+    "instructions": [
+      "Spinat auftauen. 1 EL Öl in einer Pfanne erhitzen. Pinienkerne darin unter Wenden ca. 3 Minuten rösten.",
+      "Schalotten und Knoblauch schälen und würfeln. 1 EL Öl in einem Topf erhitzen und Schalottenwürfel darin ca. 10 Minuten glasig dünsten. Knoblauch zufügen und kurz mitdünsten. Spinat leicht ausdrücken und nach ca. 5 Minuten zu den Schalottenwürfeln geben. Mit Brühe ablöschen und aufkochen. Mit Salz, Pfeffer und Muskat abschmecken. Schmand einrühren.",
+      "Inzwischen Nudeln in kochendem Salzwasser nach Packungsanweisung zubereiten. Käse fein reiben. Nudeln abgießen. Mit Spinat mischen und auf Tellern anrichten. Mit Käse und gerösteten Pinienkerne bestreuen."
+    ],
+    "id": "rec_39"
+  },
+  {
+    "title": "Vegetarischer Bohneneintopf",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "346 kcal",
+      "Kohlenhydrate": "58,9 g",
+      "Fett": "7,1 g",
+      "Eiweiß": "20,2 g"
+    },
+    "ingredients": [
+      "1 grüne Paprika",
+      "300 g weiße Bohnen (Dose)",
+      "1 Dose(n) Kidneybohnen (255 g)",
+      "0,5 Dose(n) Kichererbsen",
+      "2 EL Rapsöl nativ",
+      "2 Zehe(n) Knoblauch",
+      "1 Zwiebel",
+      "500 ml Gemüsebrühe (glutenfrei)",
+      "1 Dose(n) stückige Tomaten (400 g)",
+      "Salz",
+      "Pfeffer",
+      "1 TL Chili Gewürzmischung gemahlen",
+      "1 TL Paprikapulver",
+      "0,25 Bd . frische Petersilie",
+      "2 EL Essig"
+    ],
+    "instructions": [
+      "Paprika waschen, entkernen und würfeln. Bohnen und Kichererbsen in ein Sieb abgießen, waschen und abtropfen lassen.",
+      "Öl in einem großen Topf erhitzen. Knoblauch und Zwiebeln schälen, fein hacken und in Öl anschwitzen. Paprika, Kichererbsen und Bohnen in den Topf geben. Mit Gemüsebrühe und stückigen Tomaten ablöschen.",
+      "Gewürze hinzufügen und Eintopf circa 20 Minuten köcheln lassen.",
+      "Petersilie waschen, trocken schütteln und zupfen. Essig zum Eintopf geben und den Eintopf abschmecken.",
+      "Eintopf in vier Schüsseln verteilen und mit Petersilie garnieren."
+    ],
+    "id": "rec_40"
+  },
+  {
+    "title": "Grüner Kartoffelsalat",
+    "tags": [
+      "Vegan",
+      "Laktosefrei",
+      "Glutenfrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "415 kcal",
+      "Kohlenhydrate": "62,8 g",
+      "Fett": "13,4 g",
+      "Eiweiß": "11,2 g"
+    },
+    "ingredients": [
+      "1 kg festkochende Kartoffeln",
+      "1 große rote Zwiebel",
+      "180 ml Gemüsebrühe (glutenfrei)",
+      "1,5 TL Senf (glutenfrei)",
+      "1 Prise(n) Zucker",
+      "3 EL Apfelessig",
+      "3 EL Walnussöl",
+      "Salz",
+      "Pfeffer",
+      "70 g Sonnenblumenkerne geschält",
+      "200 g Feldsalat",
+      "250 g grüne, kernlose Trauben"
+    ],
+    "instructions": [
+      "Kartoffeln in kochendem Salzwasser ca. 20 Minuten gar kochen. Abschrecken, 15 Minuten stehen lassen, pellen und in dünne Scheiben schneiden.",
+      "Zwiebel schälen und fein würfeln. Mit den Kartoffelscheiben mischen. Brühe erhitzen, Senf und Zucker einrühren. Essig und Brühe über die Kartoffeln gießen und mischen. Öl unterheben und mit Salz und Pfeffer würzen. Abkühlen lassen. Sonnenblumenkerne in einer Pfanne ohne Fett rösten.",
+      "Feldsalat waschen, trocken schleudern. Trauben halbieren. Feldsalat, Trauben und Sonnenblumenkerne unter den Salat heben."
+    ],
+    "id": "rec_41"
+  },
+  {
+    "title": "Schnelle Spaghetti Bolognese",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "823 kcal",
+      "Kohlenhydrate": "82,7 g",
+      "Fett": "36 g",
+      "Eiweiß": "44,2 g"
+    },
+    "ingredients": [
+      "2 Zwiebeln",
+      "1 Zehe(n) Knoblauch",
+      "100 g Möhren",
+      "2 EL Rapsöl nativ",
+      "500 g Hackfleisch gemischt",
+      "2 EL ja! Tomatenmark 3-fach konzentriert",
+      "2 Dose(n) Tomaten geschält à 400g",
+      "ja! Jodsalz",
+      "ja! Pfeffer schwarz gemahlen",
+      "ja! Raffinade Zucker",
+      "2 TL Oregano gerebelt",
+      "400 g ja! Spaghetti",
+      "50 g ja! geriebener Mozzarella"
+    ],
+    "instructions": [
+      "Zwiebeln und Knoblauch schälen und fein hacken. Möhren schälen und fein würfeln.",
+      "Öl erhitzen und Zwiebeln, Knoblauch und Hackfleisch anbraten. Möhren und Tomatenmark zufügen, kurz mitbraten, Tomaten zugeben und diese mit einer Gabel zerdrücken. Bei schwacher Hitze gut 20 Minuten köcheln lassen, ggf. etwas Wasser zufügen. Mit Salz, Pfeffer, Zucker und Oregano abschmecken.",
+      "Spaghetti in Salzwasser nach Packungsanweisung zubereiten.",
+      "Spaghetti mit der Bolognese anrichten und nach Belieben mit etwas geriebenem Mozzarella bestreut servieren."
+    ],
+    "id": "rec_42"
+  },
+  {
+    "title": "Schnelle Tomaten-Schnitten",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "476 kcal",
+      "Kohlenhydrate": "29,1 g",
+      "Fett": "37,8 g",
+      "Eiweiß": "6,39 g"
+    },
+    "ingredients": [
+      "1 Pck . Blätterteig",
+      "150 g Schmand",
+      "Salz",
+      "Pfeffer",
+      "600 g Tomaten",
+      "0,5 Topf Basilikum",
+      "100 g Naturjoghurt",
+      "1 EL Olivenöl"
+    ],
+    "instructions": [
+      "Blätterteig auf einem mit Backpapier belegten Backblech entrollen. Schmand mit Salz und Pfeffer verrühren, Teig damit gleichmäßig bestreichen.",
+      "Tomaten putzen, waschen und in Scheiben schneiden. Tomaten auf dem Blätterteig verteilen und im vorgeheizten Backofen bei 180 °C ca. 20 Minuten backen.",
+      "In der Zwischenzeit Basilikumblättchen waschen und zusammen mit Joghurt und Öl pürieren. Mit Salz und Pfeffer abschmecken.",
+      "Fertige Tomatentarte aus dem Ofen nehmen, mit dem Basilikum-Joghurt beträufeln und in längliche Streifen schneiden."
+    ],
+    "id": "rec_43"
+  },
+  {
+    "title": "Omelett mit Kartoffeln",
+    "tags": [
+      "Vegetarisch",
+      "Laktosefrei",
+      "Glutenfrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "350 kcal",
+      "Kohlenhydrate": "36,9 g",
+      "Fett": "16 g",
+      "Eiweiß": "14,9 g"
+    },
+    "ingredients": [
+      "800 g Kartoffeln (überwiegend festkochend)",
+      "1 TL Salz",
+      "2 Zwiebeln",
+      "3 EL Öl",
+      "6 Eier (Größe M)",
+      "1 EL gemischte Kräuter (frisch gehackt)",
+      "1 Msp . Pfeffer"
+    ],
+    "instructions": [
+      "Die Kartoffeln waschen und in Salzwasser 20–30 Minuten, je nach Größe, garen. Darauf achten, dass die Kartoffeln ungefähr gleich groß sind, damit sie eine ähnlich lange Garzeit haben. Große Kartoffeln ggfs. halbieren oder vierteln. Nach der Kochzeit abgießen und abkühlen lassen.",
+      "Die abgekühlten Kartoffeln pellen und in Scheiben schneiden. Die Zwiebeln schälen und fein würfeln.",
+      "Das Öl in einer großen Pfanne erhitzen und die Zwiebelwürfel darin anschwitzen. Nach einigen Minuten die Kartoffelscheiben dazugeben und mitbraten, bis sie leicht knusprig werden.",
+      "Die Eier gründlich mit den Kräutern, 1 TL Salz und Pfeffer verquirlen und über die Kartoffeln in der Pfanne gießen. Bei mittlerer Temperatur 5–6 Minuten stocken lassen und braten, bis die Unterseite goldbraun ist.",
+      "Einen großen Teller verkehrt herum auf die Pfanne legen und die Pfanne mit Schwung umdrehen, sodass das Omelett auf dem Teller liegt. Dann das Omelett wieder in die Pfanne gleiten lassen, mit der hellen Seite nach unten. Noch einmal ca. 5 Minuten backen. Dann kurz abkühlen lassen und servieren. Dazu passt ein grüner Salat."
+    ],
+    "id": "rec_44"
+  },
+  {
+    "title": "Linsen-Curry-Topf mit Koriander-Joghurt",
+    "tags": [
+      "Vegetarisch",
+      "Glutenfrei",
+      "Zuckerfrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "290 kcal",
+      "Kohlenhydrate": "42,1 g",
+      "Fett": "8,9 g",
+      "Eiweiß": "14 g"
+    },
+    "ingredients": [
+      "2 Zwiebeln",
+      "1 Knoblauchzehe",
+      "3 Möhren",
+      "1 Zucchini",
+      "1 Bd . Frühlingszwiebeln",
+      "2 EL Rapsöl",
+      "120 g rote Linsen",
+      "2 EL Currypulver",
+      "400 g gehackte Tomaten",
+      "1 EL Tomatenmark",
+      "Salz",
+      "Pfeffer",
+      "1 Bd . Koriander",
+      "300 g Naturjoghurt"
+    ],
+    "instructions": [
+      "Zwiebeln, Knoblauch und Möhren schälen und fein würfeln. Zucchini waschen und klein schneiden. Frühlingszwiebeln waschen und in Röllchen schneiden.",
+      "Öl in einem großen Topf erhitzen. Zwiebeln und Knoblauch anschwitzen. Linsen, Zucchini und Möhren sowie Currypulver, gehackte Tomaten und Tomatenmark zufügen. Kurz anschwitzen und mit gut 600 ml Wasser ablöschen. Frühlingszwiebeln zufügen und gut 10-15 Minuten köcheln lassen, bis die Linsen gar sind. Bei Bedarf noch etwas Wasser zufügen. Mit Salz, Pfeffer und Curry abschmecken.",
+      "Koriander waschen, trocken schütteln und fein hacken. Unter den Joghurt rühren und mit Salz und Pfeffer würzen. Zum Linsen-Curry-Topf servieren."
+    ],
+    "id": "rec_45"
+  },
+  {
+    "title": "Spinat mit Spiegelei und Salzkartoffeln",
+    "tags": [
+      "Laktosefrei",
+      "Glutenfrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "389 kcal",
+      "Kohlenhydrate": "34 g",
+      "Fett": "19,4 g",
+      "Eiweiß": "21,2 g"
+    },
+    "ingredients": [
+      "800 g frischer Spinat",
+      "1 Zwiebel",
+      "2 EL Butter",
+      "125 g Speckwürfel",
+      "800 g Kartoffeln (z. B. Sorte Linda)",
+      "4 Eier",
+      "Salz",
+      "Pfeffer",
+      "0,25 Bd . Petersilie"
+    ],
+    "instructions": [
+      "Spinat waschen. Zwiebel schälen und in kleine Würfel schneiden.",
+      "1 EL Butter in einem Topf schmelzen, Zwiebel und Speck darin andünsten. Spinat zugeben und zusammenfallen lassen. Kartoffeln schälen und in Salzwasser ca. 20 Minuten kochen.",
+      "Übrige Butter in einer beschichteten Pfanne erhitzen. Eier darin nacheinander zu Spiegeleiern braten (je nach Belieben mit gestocktem oder flüssigem Eigelb). Mit Salz und Pfeffer würzen.",
+      "Petersilie hacken und auf Kartoffeln und Spiegeleier streuen."
+    ],
+    "id": "rec_46"
+  },
+  {
+    "title": "Spaghetti in Paprikasoße mit Hähnchen",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "643 kcal",
+      "Kohlenhydrate": "97,7 g",
+      "Fett": "15 g",
+      "Eiweiß": "32,4 g"
+    },
+    "ingredients": [
+      "400 g Spaghetti",
+      "Salz",
+      "125 g tiefgefrorene Erbsen",
+      "250 g Hähnchenbrustfilet",
+      "1 Glas Tomatenpaprika (à 650 g)",
+      "1 EL Öl",
+      "Pfeffer",
+      "100 ml Gemüsebrühe (Instant)",
+      "125 ml Schlagsahne",
+      "2 EL Soßenbinder, hell",
+      "getrocknete Kräuter",
+      "Rosmarin zum Garnieren"
+    ],
+    "instructions": [
+      "Nudeln nach Packungsanweisung in kochendem Salzwasser zubereiten. Inzwischen Erbsen auftauen lassen. Hähnchenfilet waschen, trocken tupfen, in Würfel schneiden. Paprika abtropfen lassen. 2 Paprikastücke in Würfel schneiden, übrige Paprika pürieren.",
+      "Öl erhitzen. Hähnchenwürfel darin unter Wenden braun anbraten. Mit Salz und Pfeffer würzen. Pürierte Paprika, Brühe und Sahne zufügen, aufkochen. Soßenbinder einstreuen. Unter Rühren nochmals aufkochen. Erbsen und Paprikawürfel darin erwärmen.",
+      "Mit Salz, Pfeffer und getrockneten Kräutern abschmecken. Nudeln und Soße portionsweise mit Rosmarin garniert anrichten."
+    ],
+    "id": "rec_47"
+  },
+  {
+    "title": "Gemüse-Kartoffel-Wedges-Pfanne",
+    "tags": [
+      "Vegetarisch",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "406 kcal",
+      "Kohlenhydrate": "48,1 g",
+      "Fett": "19,3 g",
+      "Eiweiß": "11,8 g"
+    },
+    "ingredients": [
+      "800 g Kartoffeln (festkochend)",
+      "50 g Palmin Kokosfett",
+      "Salz",
+      "Pfeffer",
+      "2 Zucchini",
+      "1 rote Paprika",
+      "1 gelbe Paprika",
+      "250 g Cherrytomaten",
+      "2 Zwiebeln",
+      "150 ml Gemüsebrühe",
+      "Paprikapulver edelsüß",
+      "100 g Feta"
+    ],
+    "instructions": [
+      "Kartoffeln waschen und in Wedges/Spalten schneiden. 30 g Palmin Kokosfett erhitzen und die Kartoffeln unter regelmäßigem Wenden ca. 20 Minuten knusprig braten. Mit Salz und Pfeffer würzen.",
+      "In der Zwischenzeit Zucchini waschen, halbieren und in Scheiben schneiden. Paprika waschen, Kerne entfernen und das Fruchtfleisch in Würfel schneiden. Tomaten waschen und halbieren. Zwiebeln schälen und hacken.",
+      "Fertige Kartoffeln aus der Pfanne nehmen und warm halten. 20 g Palmin in die Pfanne geben, schmelzen und die Zwiebeln anschwitzen. Paprika und Zucchini zugeben und mitbraten. Mit Brühe ablöschen und 5-10 Minuten bei schwacher Hitze garen, bis das Gemüse gar ist. Nach 5 Minuten die Tomaten zugeben.",
+      "Kartoffel-Wedges in die Pfanne geben und mit Paprikapulver, Salz und Pfeffer abschmecken. Feta darüber bröseln und sofort servieren."
+    ],
+    "id": "rec_48"
+  },
+  {
+    "title": "Tortelloni-Gratin",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "830 kcal",
+      "Kohlenhydrate": "40,6 g",
+      "Fett": "56,8 g",
+      "Eiweiß": "43,4 g"
+    },
+    "ingredients": [
+      "1 Pck . Spinat-Ricotta-Tortelloni",
+      "400 g Tomaten",
+      "100 g Parmesankäse",
+      "400 g Schlagsahne",
+      "Fett für die Form",
+      "150 g Pizzakäse (gerieben)",
+      "2 Zweig(e) Oregano"
+    ],
+    "instructions": [
+      "Backofen auf 200 °C Ober-/Unterhitze vorheizen. Tortelloni in kochendem Salzwasser nach Packungsanweisung zubereiten. Tomaten waschen, putzen, vierteln und entkernen. Fruchtfleisch in kleine Würfel schneiden. Tortelloni abgießen, abtropfen lassen und in kaltem Wasser abschrecken. Parmesan fein reiben.",
+      "Sahne in einem Topf aufkochen, vom Herd nehmen und Parmesan darin schmelzen. 4 Auflaufformen (à ca. 250 ml Inhalt) fetten. Tomatenwürfel mit den Tortelloni mischen und in die Formen geben. Mit Käse-Sahne-Mischung übergießen und mit Pizzakäse bestreuen. Im vorgeheizten Backofen 10–15 Minuten goldbraun backen. Oregano waschen, trocken schütteln und Blättchen von den Stielen zupfen. Aufläufe nach dem Backen mit Oregano bestreuen."
+    ],
+    "id": "rec_49"
+  },
+  {
+    "title": "Spinat-Reis-Tortilla",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "468 kcal",
+      "Kohlenhydrate": "51 g",
+      "Fett": "21,2 g",
+      "Eiweiß": "18,7 g"
+    },
+    "ingredients": [
+      "250 g Basmatireis",
+      "200 g TK-Rahmspinat",
+      "2 Zehe(n) Knoblauch",
+      "150 g Feta",
+      "2 EL Bratöl",
+      "Salz",
+      "Pfeffer",
+      "Muskatnuss",
+      "4 Spitz & Bube Eier (M)"
+    ],
+    "instructions": [
+      "Reis nach Packungsanweisung zubereiten. In der Zwischenzeit Spinat in einem Topf auftauen. Knoblauch schälen und fein hacken. Feta zerbröseln. Ofen auf 180 °C Umluft (200 °C Ober-/Unterhitze) vorheizen.",
+      "Öl in einer großen, ofenfesten Pfanne erhitzen und den Knoblauch anschwitzen. Reis und Spinat zufügen und mit Salz, Pfeffer sowie Muskat würzen.",
+      "Eier verquirlen und unter den Reis mischen. Mit Feta bestreuen und ca. 20 Minuten backen."
+    ],
+    "id": "rec_50"
+  },
+  {
+    "title": "Bergischer Pillekuchen - Kartoffelpuffer mit Speck",
+    "tags": [
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "380 kcal",
+      "Kohlenhydrate": "48 g",
+      "Fett": "13,8 g",
+      "Eiweiß": "16,2 g"
+    },
+    "ingredients": [
+      "1 kg mehlig kochende Kartoffeln",
+      "2 Schalotten",
+      "130 g geräucherter Speck",
+      "3 Eier",
+      "2 EL Weizenmehl Type 405",
+      "Salz",
+      "Pfeffer",
+      "1 Prise(n) Muskatnuss",
+      "5 Stiel(e) Petersilie"
+    ],
+    "instructions": [
+      "Kartoffeln schälen und reiben. Schalotten schälen und in feine Würfel schneiden.",
+      "Speck würfeln und in einer Pfanne ohne Fett knusprig auslassen. Schalotten zugeben und anschwitzen. Geraspelte Kartoffeln zugeben und weitere 5 Minuten braten.",
+      "Eier in einer Schüssel verquirlen. Mehl unterrühren und die Mischung mit Salz, Pfeffer und Muskat würzen. Mischung über die Kartoffeln gießen und bei schwacher Hitze ca. 15 Minuten mit geschlossenem Deckel stocken lassen.",
+      "Petersilie waschen, trocken schütteln und hacken. Fertige Pillekuchen mit Petersilie bestreut servieren."
+    ],
+    "id": "rec_51"
+  },
+  {
+    "title": "Ofenkürbis mit Kartoffeln und Schmand Dip",
+    "tags": [
+      "Vegetarisch",
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "510 kcal",
+      "Kohlenhydrate": "44,8 g",
+      "Fett": "34 g",
+      "Eiweiß": "8,9 g"
+    },
+    "ingredients": [
+      "600 g Kartoffeln",
+      "5 EL Olivenöl",
+      "Salz",
+      "Pfeffer",
+      "1 Hokkaido Kürbis (ca. 850 g)",
+      "2 rote Zwiebeln",
+      "20 g Kürbiskerne",
+      "6 Zweig(e) Majoran",
+      "250 g Schmand",
+      "2 TL Agavendicksaft"
+    ],
+    "instructions": [
+      "Kartoffeln schälen, waschen und in Spalten schneiden. Mit 3 EL Öl, Salz und Pfeffer mischen. Auf ein Backblech geben. Im vorgeheizten Backofen (E-Herd: 200 °C/ Umluft: 175 °C/ Gas: s. Hersteller) ca. 40 Minuten garen.",
+      "Kürbis waschen, halbieren und entkernen. Zwiebeln schälen. Kürbis und Zwiebeln in Spalten schneiden. Majoran waschen und trocken schütteln. Kürbis und Zwiebeln mit 2 EL Öl, Salz und Pfeffer mischen. Mit Kürbiskernen und Majoran nach ca. 20 Minuten mit auf das Backblech geben und weitergaren. Gemüse und Kartoffeln zwischendurch wenden.",
+      "Schmand und Agavendicksaft verrühren. Mit Salz und Pfeffer abschmecken. Gemüse aus dem Ofen nehmen. Schmand dazureichen."
+    ],
+    "id": "rec_52"
+  },
+  {
+    "title": "Ofenkartoffeln mit Radieschen-Kräuterquark",
+    "tags": [
+      "Vegetarisch",
+      "Glutenfrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "440 kcal",
+      "Kohlenhydrate": "58 g",
+      "Fett": "15,3 g",
+      "Eiweiß": "17,5 g"
+    },
+    "ingredients": [
+      "8 Backkartoffeln (à ca. 150 g)",
+      "200 g Radieschen",
+      "50 g Radieschensprossen",
+      "1 Bd . Petersilie",
+      "2 Becher Speisequark Halbfettstufe",
+      "1 Becher Schmand",
+      "Salz",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Kartoffeln gründlich waschen und in kochendem Wasser ca. 25 Minuten garen. Kartoffeln abgießen, auf einem mit Backpapier ausgelegten Backblech verteilen und im vorgeheizten Backofen (E-Herd: 200 °C/ Umluft: 175 °C/ Gas: Stufe 3) ca. 20 Minuten backen.",
+      "Inzwischen Radieschen putzen, waschen, trocken tupfen und in Stifte schneiden. Sprossen mit kaltem Wasser gründlich abspülen und gut abtropfen lassen. Petersilie waschen, trocken schütteln. Bis auf etwas zum Garnieren, Blättchen von den Stielen zupfen und in feine Streifen schneiden.",
+      "Quark und Schmand verrühren. Mit Salz und Pfeffer würzen. Sprossen, Radieschen und Petersilie mischen. Hälfte unter den Quark mengen. Kartoffeln aus dem Ofen nehmen, aufbrechen. Je 2 Kartoffeln mit einem Klecks Quark und restlicher Sprossenmischung auf 4 Tellern anrichten, mit Petersilie garnieren. Restlichen Quark dazureichen."
+    ],
+    "id": "rec_53"
+  },
+  {
+    "title": "Knoblauchnudeln",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "542 kcal",
+      "Kohlenhydrate": "97,9 g",
+      "Fett": "10,7 g",
+      "Eiweiß": "16,4 g"
+    },
+    "ingredients": [
+      "500 g Spaghetti",
+      "Salz",
+      "5 Zehe(n) Knoblauch",
+      "250 g Kirschtomaten",
+      "10 g Basilikum",
+      "4 EL Olivenöl",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Spaghetti nach Packungsanweisung in Salzwasser kochen.",
+      "Knoblauch schälen und nach Belieben in feine Scheiben schneiden oder fein hacken. Tomaten waschen und halbieren. Basilikum waschen, trocken schütteln, Blätter abzupfen und hacken.",
+      "4-5 Minuten, bevor die Nudeln al dente sind, Öl erhitzen und den Knoblauch vorsichtig anbraten, er sollte nicht verbrennen. Tomaten zugeben und kurz andünsten.",
+      "Nudeln abgießen, dabei etwas Nudelwasser auffangen. Spaghetti zum Knoblauch in die Pfanne geben und vorsichtig unterheben. 3-4 EL Nudelwasser zugeben. Mit Salz und Pfeffer würzen. Basilikum darüber streuen und sofort servieren."
+    ],
+    "id": "rec_54"
+  },
+  {
+    "title": "Schnitzel mit Gurkensalat und Bratkartoffeln",
+    "tags": [],
+    "difficulty": "Mittel",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "647 kcal",
+      "Kohlenhydrate": "80,6 g",
+      "Fett": "14,9 g",
+      "Eiweiß": "47,1 g"
+    },
+    "ingredients": [
+      "1 Salatgurke",
+      "3 Stiel(e) Dill",
+      "2 EL ja! Schmand",
+      "3 EL ja! Condimento bianco",
+      "1 TL ja! Senf mittelscharf",
+      "ja! Jodsalz",
+      "ja! Pfeffer schwarz gemahlen",
+      "800 g Kartoffeln",
+      "2 Zwiebeln",
+      "3 EL ja! Natives Rapsöl",
+      "600 g Schweine-Schinkenschnitzel",
+      "2 Eier",
+      "4 EL ja! Weizenmehl Type 405",
+      "150 g ja! Paniermehl",
+      "1 Zitrone"
+    ],
+    "instructions": [
+      "Gurke waschen, nach Belieben schälen und in feine Scheiben hobeln. Dill waschen, trocken schütteln und fein hacken, einen Teil beiseitelegen. Schmand, Essig und Senf verrühren. Mit den Gurkenscheiben und dem Dill mischen und mit Salz und Pfeffer würzen. Mit dem restlichen Dill bestreuen.",
+      "Kartoffeln schälen und in dünne Scheiben schneiden. Zwiebeln schälen und würfeln. 1 EL Öl in einer Pfanne erhitzen und die Kartoffelscheiben anbraten. Unter gelegentlichem Wenden gut 10 Minuten mit Deckel braten, dann Zwiebeln zugeben und weitere 10 Minuten ohne Deckel braten, bis Kartoffelscheiben gar und knusprig sind. Mit Salz und Pfeffer würzen.",
+      "Schnitzel waschen und trocken tupfen, flach klopfen. Mit Salz und Pfeffer würzen.",
+      "Eier in einem tiefen Teller verquirlen. Mehl auf einen flachen Teller geben, Paniermehl auf einen weiteren Teller.",
+      "Schnitzel erst von beiden Seiten im Mehl wenden, dann durch das verquirlte Ei ziehen und zum Schluss im Paniermehl wälzen.",
+      "2 EL Öl erhitzen und die Schnitzel bei mittlerer Hitze von beiden Seiten knusprig braten. Auf Küchenpapier abtropfen lassen.",
+      "Zitrone waschen, in Spalten schneiden und zusammen mit Schnitzel und dem Gurkensalat anrichten."
+    ],
+    "id": "rec_55"
+  },
+  {
+    "title": "Tagliatelle mit Fenchel",
+    "tags": [
+      "Vegan",
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "441 kcal",
+      "Kohlenhydrate": "83,3 g",
+      "Fett": "6,5 g",
+      "Eiweiß": "14,6 g"
+    },
+    "ingredients": [
+      "400 g Tagliatelle",
+      "Salz",
+      "2 Knolle(n) Fenchel",
+      "1 Zitrone",
+      "1 Bd . Petersilie",
+      "2 EL Öl",
+      "2 Zehe(n) Knoblauch",
+      "Pfeffer, frisch gemahlen"
+    ],
+    "instructions": [
+      "Nudeln nach Packungsanweisung in kochendem Salzwasser garen. Fenchel putzen, waschen, Strunk entfernen und Fenchel in dünne Streifen schneiden. Zitrone heiß waschen, Schale abreiben und Saft auspressen. Petersilie waschen, trocken schütteln, zupfen und grob hacken.",
+      "Öl in einer Pfanne erhitzen. Knoblauch schälen, fein hacken und in Öl anbraten. Fenchel hinzufügen und in der Pfanne anrösten.",
+      "Nudeln abgießen, dabei ein kleines Glas des Nudelwassers auffangen.",
+      "Nudelwasser und Zitronensaft zum Fenchel geben, kurz köcheln lassen und mit Salz und Pfeffer würzen. Nudeln, Petersilie und etwas Zitronenabrieb hinzugeben und alles vermengen.",
+      "Nudeln auf vier tiefen Tellern anrichten und servieren."
+    ],
+    "id": "rec_56"
+  },
+  {
+    "title": "Spaghetti mit köstlichem Tomatenpesto",
+    "tags": [
+      "Vegetarisch",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "605 kcal",
+      "Kohlenhydrate": "103 g",
+      "Fett": "12,8 g",
+      "Eiweiß": "21,3 g"
+    },
+    "ingredients": [
+      "500 g Spaghetti",
+      "Salz",
+      "1 Knoblauch Zehe(n)",
+      "280 ml getrocknete Tomaten in Öl mit Oregano",
+      "1 Dose(n) stückige Tomaten",
+      "4 Stiel(e) Basilikum",
+      "2 TL ja! Tomatenmark",
+      "Bunter Pfeffer aus der Mühle",
+      "Fleur de Sel",
+      "Zucker",
+      "evtl. Aceto Balsamico",
+      "30 g Parmesan"
+    ],
+    "instructions": [
+      "Nudeln in kochendem Salzwasser nach Packungsanweisung zubereiten.",
+      "Knoblauch schälen und mit den getrockneten Tomaten in ein hohes Rührgefäß geben. Die Hälfte der stückigen Tomaten und etwas Tomatenöl (aus dem Glas) zufügen und mit dem Pürierstab fein pürieren.",
+      "Basilikum waschen, trocken schütteln. Blättchen von 2 Stielen fein hacken, mit dem Schneebesen unter das Pesto rühren. Die restlichen stückigen Tomaten unterheben und mit Tomatenmark, buntem Pfeffer aus der Mühle, etwas Fleur de Sel, Zucker und evtl. Balsamico-Essig abschmecken. Nudeln abgießen und sofort mit dem Pesto locker vermengen. Nudeln anrichten und mit Basilikum garnieren. Parmesan darüberhobeln."
+    ],
+    "id": "rec_57"
+  },
+  {
+    "title": "Vegetarische Partysuppe mit Bohnen",
+    "tags": [
+      "Vegetarisch",
+      "Low Carb",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "263 kcal",
+      "Kohlenhydrate": "28,6 g",
+      "Fett": "12,2 g",
+      "Eiweiß": "9,1 g"
+    },
+    "ingredients": [
+      "0,5 Zwiebel",
+      "1,5 Zehe(n) Knoblauch",
+      "1 rote Paprika",
+      "1 gelbe Paprika",
+      "250 g weiße Riesenbohnen",
+      "2 EL Olivenöl",
+      "1 TL Zucker",
+      "3 EL Tomatenmark",
+      "0,5 Dose(n) stückige Tomaten (400 g)",
+      "125 ml Rotwein (trocken)",
+      "0,6 l Gemüsebrühe",
+      "0,25 Bd . Petersilie",
+      "Pfeffer",
+      "Salz",
+      "Chiliflocken",
+      "150 g saure Sahne"
+    ],
+    "instructions": [
+      "Zwiebel und Knoblauch schälen und in Würfel schneiden. Paprika waschen, entkernen und in Würfel schneiden. Bohnen abtropfen lassen.",
+      "Olivenöl in einem Topf erhitzen, Zwiebeln und Knoblauch darin anbraten. Mit Zucker kurz karamellisieren lassen. Tomatenmark, stückige Tomaten und Paprika hinzufügen und mit Rotwein ablöschen. Dann Gemüsebrühe zugeben und alles ca. 20 Minuten köcheln lassen. Ca. 2 Minuten vor Ende der Garzeit die Bohnen zugeben.",
+      "Währenddessen Petersilie waschen, trocken schütteln und hacken.",
+      "Suppe mit Pfeffer, Salz und Chiliflocken abschmecken und die saure Sahne unterziehen.",
+      "Mit Petersilie garniert servieren."
+    ],
+    "id": "rec_58"
+  },
+  {
+    "title": "Haferflockenschnitzel mit Gurkensalat",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "454 kcal",
+      "Kohlenhydrate": "61,9 g",
+      "Fett": "19,5 g",
+      "Eiweiß": "11,3 g"
+    },
+    "ingredients": [
+      "220 g zarte Haferflocken",
+      "1,5 TL Senf",
+      "Salz",
+      "3 TL Paprikapulver edelsüß",
+      "1 TL Knoblauchpulver",
+      "Pfeffer",
+      "2 Salatgurken",
+      "1 Schalotte",
+      "0,5 Beet(e) Kresse",
+      "1 EL Weißweinessig",
+      "2 EL Rapsöl",
+      "80 g Paniermehl",
+      "Öl zum Braten",
+      "1 Zitrone"
+    ],
+    "instructions": [
+      "Haferflocken mit 250 ml kochendem Wasser übergießen. Senf, Salz, Paprikapulver, Knoblauchpulver und Pfeffer zugeben, alles verrühren und 10 Minuten quellen lassen.",
+      "Währenddessen die Gurke waschen und in dünne Scheiben hobeln. Schalotte schälen und fein würfeln. Gurken, Schalotten und Kresse in eine Salatschüssel geben. Essig und Öl verrühren und mit Pfeffer und Salz würzen. Paniermehl auf einen Teller geben. 4 Kugeln aus der Hafermasse formen und im Paniermehl zu Schnitzeln drücken und wenden.",
+      "Öl in einer Pfanne erhitzen und die Schnitzel nacheinander ausbraten. Zitrone in Spalten schneiden. Dressing an den Salat geben und Schnitzel mit Salat und Zitronenspalten servieren."
+    ],
+    "id": "rec_59"
+  },
+  {
+    "title": "Nudelauflauf mit Schmand und Hack",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "1136 kcal",
+      "Kohlenhydrate": "91,8 g",
+      "Fett": "64,5 g",
+      "Eiweiß": "52 g"
+    },
+    "ingredients": [
+      "300 g ja! Buttergemüse (TK)",
+      "320 g ja! Penne Rigate",
+      "Salz",
+      "1 große Zwiebel",
+      "2 Zehe(n) Knoblauch",
+      "2 EL ja! Rapsöl",
+      "400 g ja! Hackfleisch gemischt",
+      "500 g ja! Tomaten passiert",
+      "Pfeffer",
+      "1 Prise(n) Zucker",
+      "0,5 TL Oregano getrocknet",
+      "0,25 TL Thymian getrocknet",
+      "200 g ja! Schmand",
+      "250 g ja! geriebener Gratin- und Pizzakäse"
+    ],
+    "instructions": [
+      "Buttergemüse antauen lassen. Nudeln in Salzwasser bissfest kochen. Zwiebel und Knoblauch schälen, würfeln. Backofen auf 180 °C Ober-/Unterhitze vorheizen.",
+      "Öl in einer Pfanne erhitzen, Hackfleisch scharf anbraten. Zwiebeln, Buttergemüse und Knoblauch dazugeben und kurz mitdünsten. Tomaten zufügen, aufkochen. Mit Salz, Pfeffer, Zucker, Oregano und Thymian abschmecken. Schmand unterrühren.",
+      "Nudeln und Soße in eine Auflaufform geben. Gut vermengen und mit Käse bestreuen. Im Ofen 15-20 Minuten backen."
+    ],
+    "id": "rec_60"
+  },
+  {
+    "title": "Einfacher Wrap",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "828 kcal",
+      "Kohlenhydrate": "73,7 g",
+      "Fett": "46 g",
+      "Eiweiß": "32,2 g"
+    },
+    "ingredients": [
+      "4 ja ! Hähnchen Mini Schnitzel",
+      "4 Tortilla -Wraps",
+      "4 EL Frischkäse",
+      "50 g Nachos",
+      "1 Avocado",
+      "0,5 Limette",
+      "Chilisalz",
+      "Kreuzkümmel (gemahlen)",
+      "2 Salatherzen",
+      "2 EL Rapsöl",
+      "100 g Cheddar, gerieben"
+    ],
+    "instructions": [
+      "Mini Hähnchenschnitzel auftauen lassen (ggf. in der Mikrowelle).",
+      "Tortillawraps zu ¼ einschneiden und ¼ mit 1 EL Frischkäse bestreichen. Darüber je eine Handvoll Nachos zerbröseln.",
+      "Avocado schälen, den Kern entfernen und das Fruchtfleisch in Scheiben schneiden. Sofort mit Limettensaft beträufeln und mit Chilisalz und Kreuzkümmel würzen. Auf dem nächsten Viertel verteilen.",
+      "Salatherzen waschen, trocken schleudern und in Streifen schneiden. ¼ des Wraps mit Salat belegen.",
+      "Hähnchenschnitzel in 2 EL Öl anbraten, in Streifen schneiden und das nächste Viertel damit belegen. Cheddar auf die Hähnchenstreifen streuen.",
+      "Wrap von Viertel zu Viertel aufeinander falten (mit dem Frischkäse-Tortilla-Chips-Viertel beginnen) und kurz in der Pfanne oder einem Kontaktgrill grillen."
+    ],
+    "id": "rec_61"
+  },
+  {
+    "title": "Pizzataschen mit Schinken",
+    "tags": [
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "435 kcal",
+      "Kohlenhydrate": "36,9 g",
+      "Fett": "26,3 g",
+      "Eiweiß": "13,9 g"
+    },
+    "ingredients": [
+      "0,33 Zwiebel",
+      "0,33 rote Zwiebel",
+      "1 EL ja! Sonnenblumenöl",
+      "41,7 g ja! Schinkenwürfel",
+      "66,7 g ja! Frischkäse Natur Doppelrahmstufe",
+      "33,3 g ja! Schmand",
+      "1 Zweig(e) Basilikum",
+      "1,7 Tomaten",
+      "Salz",
+      "Pfeffer",
+      "0,67 Pck . Pizzateig (Kühlregal)",
+      "2 TL Paniermehl",
+      "0,33 Eigelb",
+      "0,67 EL ja! Milch",
+      "66,7 g ja! Geriebener Gouda",
+      "66,7 g Cocktailtomaten",
+      "0,5 Stück Romana-Salatherzen",
+      "1,3 EL Weißwein-Essig",
+      "0,17 TL ja! mittelscharfer Senf",
+      "Zucker"
+    ],
+    "instructions": [
+      "Zwiebeln schälen. Die weiße Zwiebel fein würfeln, die rote Zwiebel in Ringe schneiden und für den Salat beiseitelegen. 1 EL Öl in einer Pfanne erhitzen. Zwiebel- und Schinkenwürfel zugeben, 2–3 Minuten dünsten. Zwiebel-Schinkenmischung herausnehmen und in eine Schüssel geben. Frischkäse und Schmand zugeben, glatt rühren.",
+      "Basilikum waschen und trocken schütteln. Blättchen abzupfen und hacken. Tomaten waschen und putzen, dann vierteln und entkernen. Fruchtfleisch in kleine Würfel schneiden. Tomatenwürfel und Basilikum unter die Frischkäsecreme heben. Käsecreme mit Salz und Pfeffer würzen.",
+      "Teig entrollen. Teig vom Papier lösen und auf eine bemehlte Arbeitsfläche legen. Teig je in 6 Vierecke schneiden und mittig je mit 1/2 TL Paniermehl bestreuen. Käsecreme in die Teigmitte geben. Eigelb und Milch verrühren. Teigränder damit einpinseln. Vierecke diagonal zusammenklappen, die Ränder zusammendrücken. Pizzataschen auf ein mit Backpapier ausgelegtes Backblech legen. Mit der Eigelbmischung bestreichen und Käse darüberstreuen. Im vorgeheizten Backofen (E-Herd: 200 °C/ Umluft: 175 °C/ Gas: Stufe 3) 20 Minuten backen.",
+      "Für den Salat die Cocktailtomaten waschen und halbieren. Salat waschen, trocken schütteln und die Blätter klein zupfen. Essig und Senf verrühren. Mit Salz, Pfeffer und Zucker würzen. 2 EL Öl darunterschlagen und nochmals abschmecken. Vinaigrette, Zwiebelringe und Tomaten vermengen. Pizzataschen aus dem Backofen nehmen. Mit Salat auf Tellern anrichten."
+    ],
+    "id": "rec_62"
+  },
+  {
+    "title": "Blumenkohl-Hack-Nudelauflauf",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "1082 kcal",
+      "Kohlenhydrate": "106 g",
+      "Fett": "52,9 g",
+      "Eiweiß": "50,9 g"
+    },
+    "ingredients": [
+      "500 g Fusilli",
+      "Salz",
+      "1 Blumenkohl",
+      "1 große Zwiebel",
+      "1 Zehe(n) Knoblauch",
+      "3 EL Rapsöl",
+      "500 g gemischtes Hackfleisch",
+      "2 EL Tomatenmark",
+      "Pfeffer",
+      "100 ml Gemüsebrühe",
+      "4 Eier",
+      "200 ml Sahne"
+    ],
+    "instructions": [
+      "Nudeln nach Packungsanleitung in Salzwasser gar kochen und abtropfen lassen.",
+      "Währenddessen Blumenkohl waschen und in Röschen schneiden. In Salzwasser etwa 3-4 Minuten blanchieren, mit kaltem Wasser abschrecken und gut abtropfen lassen. Backofen auf 180 °C Ober-/Unterhitze vorheizen.",
+      "Zwiebel und Knoblauch schälen und fein hacken. Öl in einer Pfanne erhitzen, beides darin anschwitzen und das Hackfleisch zufügen. Tomatenmark unterrühren, salzen, pfeffern und mit 100 ml Gemüsebrühe ablöschen. Vom Herd nehmen.",
+      "Eier kräftig verquirlen, Sahne unterrühren und mit Salz und Pfeffer würzen.",
+      "In eine Auflaufform zuerst die Nudeln, dann das Hackfleisch, dann die Blumenkohlröschen schichten und zum Schluß mit der Eiersahne übergießen. 45 Minuten goldgelb backen."
+    ],
+    "id": "rec_63"
+  },
+  {
+    "title": "Herzhafter Brotauflauf",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "527 kcal",
+      "Kohlenhydrate": "46,6 g",
+      "Fett": "32,6 g",
+      "Eiweiß": "14,3 g"
+    },
+    "ingredients": [
+      "3 Fleischtomaten",
+      "250 g Brot (z. B. Ciabatta oder Graubrot)",
+      "Fett für die Form",
+      "2 Becher Crème fraîche",
+      "5 EL Milch",
+      "3 Eier (Größe M)",
+      "Salz",
+      "Pfeffer",
+      "0,25 Bd . Basilikum"
+    ],
+    "instructions": [
+      "Tomaten putzen, waschen und in Scheiben schneiden. Brot ebenfalls in Scheiben schneiden. Eine Auflaufform fetten und Tomaten und Brot abwechselnd einschichten. Backofen auf 200°C Ober-/ Unterhitze vorheizen.",
+      "Crème fraîche, Milch und Eier verquirlen. Mit Salz und Pfeffer abschmecken und über den Auflauf gießen. Auflauf im vorgeheizten Backofen ca. 20 Minuten backen, bis das Ei gestockt ist. Basilikum waschen, trocken schütteln und hacken. Basilikum über den fertigen Auflauf streuen."
+    ],
+    "id": "rec_64"
+  },
+  {
+    "title": "Kartoffelsalat mit Mayonnaise",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "525 kcal",
+      "Kohlenhydrate": "47,5 g",
+      "Fett": "32,2 g",
+      "Eiweiß": "11,7 g"
+    },
+    "ingredients": [
+      "1 kg festkochende Kartoffeln",
+      "Salz",
+      "1 TL Kümmel",
+      "2 Zwiebeln",
+      "200 ml Gemüsebrühe",
+      "3 EL Obstessig",
+      "3 EL mittelscharfer Senf",
+      "1 EL ja! Zucker",
+      "Pfeffer",
+      "3 EL Pflanzenöl",
+      "100 g ja! Delikatess-Mayonnaise",
+      "4 Gewürzgurken",
+      "3 Eier"
+    ],
+    "instructions": [
+      "Kartoffeln waschen und mit Schale in Salzwasser gar kochen. Kümmel dazugeben. Zwiebel schälen und in feine Würfel schneiden. Kartoffeln pellen und etwas auskühlen lassen, dann in Scheiben schneiden und in eine Schüssel geben. Gewürzgurken in Würfel schneiden. Eier hart kochen, abkühlen lassen und vierteln.",
+      "Gemüsebrühe in einem Topf aufkochen, Zwiebelwürfel hinzugeben und die Brühe kräftig mit Essig, Senf, Zucker, Salz und Pfeffer würzen. Öl zur Brühe geben und Topf vom Herd nehmen.",
+      "Die heiße Brühe über die warmen Kartoffelscheiben gießen und vorsichtig unterheben. Kartoffelsalat 20-30 Minuten durchziehen lassen. Mayonnaise vorsichtig unterheben, Gurken und Eier dazu geben und mit Salz und Pfeffer abschmecken."
+    ],
+    "id": "rec_65"
+  },
+  {
+    "title": "Kartoffelsuppe mit Würstchen",
+    "tags": [
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "495 kcal",
+      "Kohlenhydrate": "69,4 g",
+      "Fett": "17,7 g",
+      "Eiweiß": "15,5 g"
+    },
+    "ingredients": [
+      "1 Zwiebel",
+      "2 Karotten",
+      "1,5 kg mehlige Kartoffeln",
+      "2 EL Sonnenblumenöl",
+      "1,2 l Gemüsebrühe",
+      "Salz",
+      "Pfeffer",
+      "2 TL getrockneter Majoran",
+      "2 Bockwürste",
+      "0,5 Bd . Petersilie"
+    ],
+    "instructions": [
+      "Zwiebel schälen und würfeln. Karotten schälen und in Scheiben schneiden. Kartoffeln schälen und grob würfeln.",
+      "Zwiebel in Öl goldgelb anbraten. Dann Karotten-und Kartoffelwürfel dazugeben und mitdünsten.",
+      "Mit Gemüsebrühe angießen. Mit Salz, Pfeffer und Majoran würzen und etwa 20 Minuten köcheln lassen.",
+      "Würste in Scheiben schneiden. Suppe entweder mit dem Kartoffelstampfer zerdrücken oder, wer es feiner mag, mit dem Pürierstab pürieren. Petersilie waschen, trocken schütteln und fein hacken. Suppe mit Würstchen und Petersilie garnieren und servieren."
+    ],
+    "id": "rec_66"
+  },
+  {
+    "title": "Kichererbsen-Pfanne mit Spinat",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Low Carb",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "232 kcal",
+      "Kohlenhydrate": "32,5 g",
+      "Fett": "8,4 g",
+      "Eiweiß": "10,7 g"
+    },
+    "ingredients": [
+      "2 Gläser Kichererbsen 220g",
+      "300 g Blattspinat",
+      "400 g Tomaten",
+      "2 große Zwiebeln",
+      "2 EL Olivenöl",
+      "Salz",
+      "1 TL Curry"
+    ],
+    "instructions": [
+      "Kichererbsen abtropfen lassen. Spinat und Tomaten waschen. Tomaten in grobe Würfel schneiden. Zwiebel schälen und in feine Würfel schneiden.",
+      "Öl in einer Pfanne erhitzen und Zwiebeln darin anbraten. Kichererbsen, Tomaten und Spinat dazugeben und kurz andünsten. Mit Salz und Curry würzen."
+    ],
+    "id": "rec_67"
+  },
+  {
+    "title": "Risi Bisi mit Erbsen und Champignons",
+    "tags": [
+      "Vegetarisch",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "394 kcal",
+      "Kohlenhydrate": "67 g",
+      "Fett": "7,82 g",
+      "Eiweiß": "16,6 g"
+    },
+    "ingredients": [
+      "250 g ja! Langkorn-Reis",
+      "600 ml ja! Gemüsebrühe",
+      "300 g ja! TK-Erbsen",
+      "250 g Champignons",
+      "2 Zwiebeln",
+      "1 EL ja! Rapsöl",
+      "100 g ja! Hirtenkäse"
+    ],
+    "instructions": [
+      "Reis mit der Gemüsebrühe aufkochen und bei schwacher Hitze ca. 10 Minuten quellen, bis der Reis gar und die Flüssigkeit aufgesogen ist. Nach 5 Minuten die gefrorenen Erbsen zugeben.",
+      "In der Zwischenzeit Champignons putzen und in Scheiben schneiden. Zwiebeln schälen und hacken.",
+      "Öl erhitzen, die Zwiebeln und Champignons braten. Unter das fertige Risi Bisi heben.",
+      "Hirtenkäse zerbröseln und über das Risi Bisi streuen."
+    ],
+    "id": "rec_68"
+  },
+  {
+    "title": "Spaghetti Carbonara vegan",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "797 kcal",
+      "Kohlenhydrate": "103 g",
+      "Fett": "32,3 g",
+      "Eiweiß": "27,7 g"
+    },
+    "ingredients": [
+      "200 g Räuchertofu",
+      "500 g Spaghetti",
+      "Salz",
+      "1 Schalotte",
+      "1 Zehe(n) Knoblauch",
+      "15 g Petersilie",
+      "2 EL Olivenöl",
+      "400 ml Sojacreme Cuisine",
+      "2 EL Margarine (ggf. vegan)",
+      "Pfeffer",
+      "Kala Namak (Schwefelsalz)",
+      "2 EL Sonnenblumenkerne"
+    ],
+    "instructions": [
+      "Tofu klein würfeln. Nudeln nach Packungsanweisung in Salzwasser al dente kochen. 1 Tasse Nudelwasser aufbewahren.",
+      "Schalotte und Knoblauch schälen, fein würfeln. Petersilie waschen, trocken schütteln, hacken.",
+      "1 EL Öl in einer Pfanne erhitzen. Räuchertofu darin ca. 5 Minuten kross anbraten, herausnehmen.",
+      "1 EL Öl in der Pfanne erhitzen, Schalotte und Knoblauch darin anschwitzen, mit Sojacreme ablöschen, Margarine einrühren. Mit Salz, Pfeffer und etwas Kala Namak (für den Ei-Geschmack) abschmecken.",
+      "Nudeln abgießen, abtropfen lassen und mit dem Tofu in die Pfanne geben. Sonnenblumenkerne in einer Pfanne ohne Fett rösten. Alles gut durchschwenken, nochmals erhitzen, ggf. etwas Nudelwasser zufügen und mit Petersilie und Kernen bestreut servieren."
+    ],
+    "id": "rec_69"
+  },
+  {
+    "title": "Rinderrouladen mit Kartoffeln und Rotkohl",
+    "tags": [
+      "Laktosefrei"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "476 kcal",
+      "Kohlenhydrate": "50,9 g",
+      "Fett": "20,6 g",
+      "Eiweiß": "23,3 g"
+    },
+    "ingredients": [
+      "4 ja ! Cornichons",
+      "320 g ja! Rinder Minutensteaks",
+      "2 TL ja! Senf mittelscharf",
+      "1 Zwiebel",
+      "2 EL ja! Natives Rapsöl",
+      "1 EL ja! Tomatenmark 3-fach konzentriert",
+      "200 ml Traubensaft",
+      "200 ml ja! Klare Gemüsebrühe (Pulver)",
+      "2 Lorbeerblätter",
+      "800 g Kartoffeln",
+      "ja! Jodsalz",
+      "720 g ja! Rotkohl mit Apfelstücken",
+      "ja! Pfeffer schwarz gemahlen",
+      "1 TL Küchenmeister Speisestärke"
+    ],
+    "instructions": [
+      "Gurken in feine Streifen schneiden. Minutensteaks flach klopfen, mit Senf bestreichen und mit Gurkenscheiben belegen. Das Fleisch eng aufrollen und mit Zahnstochern oder Rouladennadeln feststecken.",
+      "Zwiebel schälen und in feine Würfel schneiden. Öl in einem Topf mit dickem Boden erhitzen und Rouladen kräftig anbraten. Zwiebeln zugeben und kurz mitbraten. Tomatenmark zugeben, kurz mitbraten, dann mit Traubensaft und Brühe ablöschen. Lorbeerblätter zugeben. Deckel auflegen und bei mittlerer Hitze gut 70 Minuten schmoren.",
+      "Kartoffeln schälen und in Salzwasser garen.",
+      "Rotkohl erwärmen.",
+      "Das fertig gegarte Fleisch aus der Soße nehmen. Speisestärke mit etwas Wasser anrühren, in die Soße geben und andicken. Mit Salz und Pfeffer abschmecken. Rouladen wieder zugeben.",
+      "Rouladen mit Kartoffeln und Rotkohl anrichten."
+    ],
+    "id": "rec_70"
+  },
+  {
+    "title": "Hackbällchen in Tomatensauce",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "488,2 kcal",
+      "Kohlenhydrate": "14,8 g",
+      "Fett": "33,6 g",
+      "Eiweiß": "34,3 g"
+    },
+    "ingredients": [
+      "600 g Wilhelm Brandenburg Hackfleisch (gemischt)",
+      "1 Ei (Zimmertemperatur)",
+      "2 EL Paniermehl",
+      "1 EL Senf",
+      "Salz",
+      "Pfeffer",
+      "1 TL Italienische Kräuter",
+      "2 EL Sonnenblumenöl nativ",
+      "400 g Porree",
+      "1 Dose(n) stückige Tomaten (500 g)",
+      "2 EL ja! Tomatenmark",
+      "150 ml Gemüsebrühe"
+    ],
+    "instructions": [
+      "Hackfleisch, Ei, Paniermehl und Senf verkneten. Mit Salz, Pfeffer und 0,5 TL getrockneten Kräutern würzen. Aus der Hackmasse kleine Bällchen formen.",
+      "Öl in einer Pfanne erhitzen. Bällchen darin bei mittlerer Hitze 10 Minuten lang braten. Porree putzen, waschen und in Ringe schneiden. Hackklößchen herausnehmen.",
+      "Porree im Bratöl kurz andünsten. Tomaten und Tomatenmark zugeben. Brühe angießen und aufkochen. Alles ca. 5 Minuten kochen lassen. Mit Salz, Pfeffer und 0,5 TL getrockneten Kräutern abschmecken. Hackbällchen zugeben und kurz mit erwärmen. Mit Baguette servieren."
+    ],
+    "id": "rec_71"
+  },
+  {
+    "title": "Schnelles Chili con Carne",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "652 kcal",
+      "Kohlenhydrate": "49,8 g",
+      "Fett": "36,3 g",
+      "Eiweiß": "38,1 g"
+    },
+    "ingredients": [
+      "2 Zwiebeln (à ca. 60 g)",
+      "2 Knoblauchzehen",
+      "1 Dose(n) ja! Kidney-Bohnen (255 g)",
+      "1 Dose(n) ja! Super Sweet Mais (425 ml)",
+      "2 EL ja! Natives Rapsöl",
+      "500 g ja! Hackfleisch gemischt",
+      "1 EL ja! Tomatenmark 3-fach konzentriert",
+      "1 Dose(n) ja! Fein gehackte Tomaten (400 g)",
+      "200 ml ja! Gemüsebrühe",
+      "3 Stiel(e) Petersilie",
+      "Salz",
+      "Pfeffer",
+      "0,5 TL Kreuzkümmel (gemahlen)",
+      "Zucker",
+      "4 Spritzer Tabasco",
+      "150 g ja! Saure Sahne"
+    ],
+    "instructions": [
+      "Zwiebeln schälen, halbieren und fein würfeln. Knoblauch schälen und fein hacken. Bohnen in ein Sieb gießen, mit kaltem Wasser abspülen und gut abtropfen lassen. Mais zu den Bohnen geben und ebenfalls abtropfen lassen.",
+      "Öl in einem großen Topf erhitzen. Hack darin 6–8 Minuten krümelig anbraten. Tomatenmark darin anschwitzen. Zwiebeln und Knoblauch darin andünsten. Mit Tomaten und Brühe ablöschen, aufkochen lassen. Bohnen und Mais zugeben. Ca. 10 bis 15 Minuten bei niedriger Hitze köcheln lassen.",
+      "Inzwischen Petersilie waschen trocken schütteln, Blättchen von den Stielen zupfen und fein hacken. 2/3 der Petersilie unter das Chili rühren. Mit Salz, Pfeffer, Kreuzkümmel, Zucker und Tabasco abschmecken. Chili in Schälchen anrichten. Je einen Klecks saure Sahne darauf geben und mit restlicher Petersilie bestreuen. Dazu schmecken Tortillachips."
+    ],
+    "id": "rec_72"
+  },
+  {
+    "title": "Mac'n'Cheese (Käse-Makkaroni)",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "700 kcal",
+      "Kohlenhydrate": "59,8 g",
+      "Fett": "39,4 g",
+      "Eiweiß": "28,6 g"
+    },
+    "ingredients": [
+      "250 g Makkaroni",
+      "Salz",
+      "45 g Butter",
+      "20 g Weizenmehl Type 405",
+      "200 ml Milch",
+      "100 g Sahne",
+      "Pfeffer",
+      "0,5 TL Senf",
+      "0,5 TL Paprikapulver",
+      "100 g Cheddar",
+      "100 g Emmentaler",
+      "50 g Parmesan",
+      "0,5 Knoblauchzehe",
+      "25 g Paniermehl"
+    ],
+    "instructions": [
+      "Makkaroni nach Packungsanweisung in kochendem Salzwasser bissfest kochen.",
+      "60 g Butter in einem Topf schmelzen und Mehl darübersieben. Unter Rühren kurz anschwitzen lassen und Milch und Sahne langsam unter Rühren zugießen. Aufkochen und mit Salz und Pfeffer würzen und Senf und Paprikapulver unterrühren. Ca. 10 Minuten bei schwacher Hitze köcheln lassen. Cheddar, Emmentaler und Parmesan reiben.",
+      "Makkaroni abgießen und mit der Béchamelsoße und den 3 Käsesorten in einer Schüssel mischen, der Käse sollte dabei schmelzen. Knoblauchzehe schälen, halbieren und eine Auflaufform mit der halbierten Zehe ausstreichen. Käse-Nudel-Masse in die Auflaufform füllen.",
+      "30 g Butter in einer Pfanne schmelzen und Paniermehl darin kurz anrösten. Geröstetes Paniermehl über den Makkaroni verteilen und den Auflauf im vorgeheizten Backofen (Ober-/ Unterhitze: 175 °C) ca. 35 Minuten goldbraun backen."
+    ],
+    "id": "rec_73"
+  },
+  {
+    "title": "Orientalischer Instant-Couscous im Topf",
+    "tags": [
+      "Vegetarisch",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "604 kcal",
+      "Kohlenhydrate": "121 g",
+      "Fett": "7,7 g",
+      "Eiweiß": "18,2 g"
+    },
+    "ingredients": [
+      "16 Aprikosen , getrocknet",
+      "2 Tasse(n) Couscous",
+      "4 EL gesalzene Pistazien",
+      "6 TL Gemüsebrühe",
+      "1 TL Knoblauch granuliert",
+      "2 TL Zwiebeln granuliert",
+      "2 TL Kurkuma",
+      "1 TL Chiliflocken",
+      "1 TL Ras el Hanout",
+      "2 Msp . Pfeffer"
+    ],
+    "instructions": [
+      "Aprikosen in Streifen oder Würfel schneiden.",
+      "Zusammen mit Couscous, Pistazien, Gemüsebrühe, Knoblauchgranulat, Zwiebelgranulat und Gewürzen in einen verschließbaren Plastikbeutel geben. Gut durchschütteln.",
+      "Für die Zubereitung 2 Tassen Wasser auf dem Gaskocher in einem Topf erhitzen, den Beutel öffnen und den Beutelinhalt in das kochende Wasser einrühren. Kurz ziehen lassen und servieren."
+    ],
+    "id": "rec_74"
+  },
+  {
+    "title": "Gemüse-Pasta mit Speck",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "758 kcal",
+      "Kohlenhydrate": "104,9 g",
+      "Fett": "33 g",
+      "Eiweiß": "21,8 g"
+    },
+    "ingredients": [
+      "50 g ja! Delicatess Bacon",
+      "800 g ja! Kaisergemüse TK",
+      "1 Zwiebel",
+      "1 EL ja! Sonnenblumenöl",
+      "200 g ja! Schlagsahne",
+      "ja! Jodsalz",
+      "Pfeffer",
+      "400 g ja! Fusilli",
+      "1 Knoblauchzehe",
+      "2 Scheibe(n) ja! American Sandwich",
+      "2 EL ja! Markenbutter"
+    ],
+    "instructions": [
+      "Gemüse auftauen lassen. Zwiebel schälen und fein würfeln. Öl in einer Pfanne erhitzen, Zwiebel darin andünsten. Gemüse zugeben und mitbraten. Mit Sahne ablöschen, mit Salz und Pfeffer würzen und ca. 5 Minuten köcheln lassen.",
+      "Nudeln nach Packungsanweisung in Salzwasser kochen. Speck in einer Pfanne ohne Fett knusprig auslassen. Knoblauch schälen und fein hacken. Toast würfeln. Speck aus der Pfanne nehmen. Butter im Speckfett schmelzen. Knoblauch und Toastwürfel kurz darin braten.",
+      "Nudeln abgießen, mit der Soße mischen. Mit Speck und Croutons anrichten."
+    ],
+    "id": "rec_75"
+  },
+  {
+    "title": "Vegetarisches Chili (Chili sin carne)",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "489 kcal",
+      "Kohlenhydrate": "69,5 g",
+      "Fett": "15,8 g",
+      "Eiweiß": "25,9 g"
+    },
+    "ingredients": [
+      "100 g Soja-Schnetzel",
+      "450 ml Gemüsebrühe",
+      "2 große Zwiebeln",
+      "3 Knoblauchzehen",
+      "2 rote Chilischoten",
+      "1 rote Paprika",
+      "2 gelbe Paprika",
+      "1 Zucchini",
+      "3 EL Öl",
+      "1 TL Kreuzkümmel (gemahlen)",
+      "500 ml passierte Tomaten (400 g)",
+      "Salz",
+      "1 Dose(n) Kidneybohnen (255 g)",
+      "1 Dose(n) Mais (285 g)",
+      "150 g Crème fraîche"
+    ],
+    "instructions": [
+      "Soja-Schnetzel ca. 15 Minuten in heißer Gemüsebrühe einweichen. Zwiebeln und Knoblauch schälen und würfeln. Chilis waschen, entkernen und hacken. Paprikaschoten putzen, waschen und würfeln. Zucchini waschen und in Scheiben schneiden.",
+      "Öl in einem großen Topf erhitzen. Zwiebeln, Knoblauch, Chilis und Kreuzkümmel darin anschwitzen. Soja-Schnetzel abgießen, ausdrücken und zugeben. Paprika und Zucchini zugeben und mit andünsten. Mit passierten Tomaten ablöschen und mit Salz würzen. Ca. 15 Minuten köcheln lassen.",
+      "Kidneybohnen und Mais abgießen und zum Chili hinzufügen. Nochmals aufkochen und abschmecken. Mit einem Klecks Crème fraîche servieren. Dazu passt Reis."
+    ],
+    "id": "rec_76"
+  },
+  {
+    "title": "Blumenkohl-Kartoffel-Auflauf",
+    "tags": [
+      "Vegetarisch",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "447 kcal",
+      "Kohlenhydrate": "36,5 g",
+      "Fett": "27,9 g",
+      "Eiweiß": "16,2 g"
+    },
+    "ingredients": [
+      "1 kleiner Blumenkohl",
+      "500 g Kartoffeln (vorwiegend festkochend)",
+      "1 Zwiebel",
+      "Salz",
+      "1 EL Rapsöl",
+      "300 ml Gemüsebrühe",
+      "200 g Sahne",
+      "1 TL Speisestärke",
+      "Pfeffer",
+      "Muskat",
+      "100 g Gratinkäse"
+    ],
+    "instructions": [
+      "Blumenkohl putzen und in Röschen teilen. Kartoffeln schälen und in Scheiben schneiden. Zwiebel schälen und fein hacken.",
+      "Blumenkohl und Kartoffeln getrennt voneinander in kochendem Salzwasser ca. 5 Minuten blanchieren.",
+      "Öl erhitzen und Zwiebeln darin anschwitzen. Gemüsebrühe sowie Sahne zugießen und etwas einköcheln lassen. Stärke mit einem EL Wasser verrühren, unterrühren und kurz aufkochen lassen. Mit Salz, Pfeffer und Muskat würzen.",
+      "Kartoffeln und Blumenkohl in eine Auflaufform schichten. Sahnesoße darübergießen und mit Käse bestreuen. Im auf 175 °C Ober-/Unterhitze vorgeheizten Backofen 35-40 Minuten backen."
+    ],
+    "id": "rec_77"
+  },
+  {
+    "title": "Kartoffelgratin mit Käse",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "499 kcal",
+      "Kohlenhydrate": "43,5 g",
+      "Fett": "27,6 g",
+      "Eiweiß": "19,5 g"
+    },
+    "ingredients": [
+      "450 ml Milch",
+      "2 Lorbeerblätter",
+      "2 Zehe(n) Knoblauch",
+      "2 EL Butter",
+      "2 EL Weizenmehl Type 405",
+      "50 ml Sahne",
+      "Pfeffer",
+      "Salz",
+      "1 Prise(n) Muskat",
+      "1 kg Kartoffeln",
+      "200 g Gratinkäse"
+    ],
+    "instructions": [
+      "Milch mit Lorbeerblättern und geschälten Knoblauchzehen kurz aufkochen und anschließend 15 Minuten ziehen lassen. Danach Knoblauch und Lorbeerblätter herausnehmen. Butter in einem Topf zerlassen, Mehl darübersieben und kurz anschwitzen. Milch unter ständigem Rühren dazugeben. Soße kurz aufkochen lassen und anschließend 10 Minuten köcheln lassen. Sahne dazugeben. Mit Pfeffer, Salz und Muskat würzen.",
+      "Kartoffeln schälen und in dünne Scheiben hobeln. Auflaufform einfetten und die Kartoffelscheiben und die Soße abwechselnd in die Form schichten. Mit Gratinkäse bedecken.",
+      "Kartoffelgratin im vorgeheizten Backofen bei 180 °C Ober-/Unterhitze 40-45 Minuten backen."
+    ],
+    "id": "rec_78"
+  },
+  {
+    "title": "Kartoffel-Lauch-Suppe",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Zuckerfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "198 kcal",
+      "Kohlenhydrate": "25,4 g",
+      "Fett": "9,4 g",
+      "Eiweiß": "5,4 g"
+    },
+    "ingredients": [
+      "300 g Kartoffeln",
+      "250 g Möhren",
+      "250 g Lauch",
+      "2 Zehe(n) Knoblauch",
+      "2 EL Olivenöl",
+      "3 EL Gemüsebrühe",
+      "Thymian, gerebelt",
+      "2 Lorbeerblätter",
+      "0,5 TL Kurkuma",
+      "1 Zitrone",
+      "30 g Mandeln gehobelt",
+      "Salz",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Kartoffeln und Möhren schälen und in Würfel schneiden. Lauch putzen, in Ringe schneiden und waschen. Knoblauch schälen und fein würfeln.",
+      "In einem Topf Olivenöl erhitzen, Kartoffeln, Möhren und Lauch ca. 3 Minuten anbraten. Knoblauch dazugeben und kurz mitbraten.",
+      "Brühe in 1 l heißem Wasser anrühren und die Gemüsebrühe dazu gießen. Thymian, Lorbeerblätter und Kurkuma dazugeben und ca. 15 Minuten köcheln lassen.",
+      "Von der Zitrone die Schale abreiben und eine Hälfte auspressen. Mandeln in einer Pfanne ohne Fett goldgelb anrösten.",
+      "Lorbeerblätter entfernen, die Suppe pürieren, Zitronensaft dazugeben und mit Salz und Pfeffer würzen. Mandelblättchen und Zitronenschale über der Suppe verteilen und servieren."
+    ],
+    "id": "rec_79"
+  },
+  {
+    "title": "Schneller Nudelauflauf",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "602 kcal",
+      "Kohlenhydrate": "95 g",
+      "Fett": "15,9 g",
+      "Eiweiß": "23,8 g"
+    },
+    "ingredients": [
+      "400 g Farfalle",
+      "Salz",
+      "1 Zucchini",
+      "1 Aubergine",
+      "2 Zwiebeln",
+      "1 Zehe(n) Knoblauch",
+      "1 EL Olivenöl",
+      "2 Dose(n) stückige Tomaten (400 g)",
+      "Pfeffer",
+      "Paprikapulver edelsüß",
+      "Zucker",
+      "150 g Gratinkäse",
+      "Basilikum"
+    ],
+    "instructions": [
+      "Nudeln in Salzwasser sehr bissfest kochen.",
+      "Zucchini und Aubergine waschen und in Würfel schneiden. Zwiebeln und Knoblauch schälen und fein hacken.",
+      "Etwas Öl in einer Pfanne erhitzen und Zwiebeln und Knoblauch anschwitzen. Das Gemüse zugeben und anschwitzen. Tomaten zufügen und 5-10 Minuten köcheln lassen. Mit Salz, Pfeffer, Paprikapulver und Zucker abschmecken.",
+      "Nudeln abgießen und zusammen mit dem Gemüse in einer gefetteten Auflaufform verteilen. Gut vermengen, mit dem Käse bestreuen und im auf 180 °C Ober-/Unterhitze vorgeheizten Backofen ca. 15-20 Minuten überbacken bis der Käse geschmolzen ist.",
+      "Mit gehacktem Basilikum anrichten."
+    ],
+    "id": "rec_80"
+  },
+  {
+    "title": "Tortellini-Pfanne mit buntem Gemüse",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "760 kcal",
+      "Kohlenhydrate": "94 g",
+      "Fett": "32,6 g",
+      "Eiweiß": "26 g"
+    },
+    "ingredients": [
+      "1 Zwiebel",
+      "1 Brokkoli",
+      "250 g Cocktailtomaten",
+      "Salz",
+      "500 g Tortellini",
+      "70 g Speck",
+      "1 EL Rapsöl",
+      "200 ml Sahne",
+      "1 TL Speisestärke",
+      "Pfeffer",
+      "0,5 Bd . Schnittlauch"
+    ],
+    "instructions": [
+      "Zwiebel schälen und fein würfeln. Brokkoli waschen und kleine Röschen abschneiden. Tomaten waschen und halbieren. Brokkoli in Salzwasser kurz blanchieren.",
+      "Tortellini nach Packungsanweisung zubereiten.",
+      "Speck in einer beschichteten Pfanne auslassen, dann beiseitestellen. Etwas Öl erhitzen und die Zwiebel anschwitzen. Mit Sahne ablöschen. Brokkoli, Tomaten und Tortellini zugeben und kurz mitköcheln. Soße mit Speisestärke bei Bedarf etwas andicken. Speck zufügen, mit Salz und Pfeffer abschmecken.",
+      "Schnittlauch waschen, in Röllchen schneiden und Tortellini-Pfanne damit bestreuen."
+    ],
+    "id": "rec_81"
+  },
+  {
+    "title": "Kartoffelpuffer selber machen",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "477 kcal",
+      "Kohlenhydrate": "75 g",
+      "Fett": "15,9 g",
+      "Eiweiß": "9,9 g"
+    },
+    "ingredients": [
+      "1 kg Kartoffeln (vorwiegend festkochend oder mehligkochend)",
+      "1 Zwiebel",
+      "2 Eier",
+      "25 g Weizenmehl Type 405",
+      "25 g zarte Haferflocken",
+      "Salz",
+      "Pfeffer",
+      "Muskatnuss",
+      "5 EL Butterschmalz",
+      "1 Glas Apfelmus"
+    ],
+    "instructions": [
+      "Kartoffeln schälen, waschen und auf der Gemüsereibe fein reiben. Zwiebel abziehen und sehr fein hacken.",
+      "Kartoffelraspel in ein sauberes Küchentuch geben, das Tuch oben zusammendrehen und so die Flüssigkeit aus den Kartoffeln drücken.",
+      "In einer großen Schüssel Kartoffelraspeln, Zwiebeln, Eier, Mehl und Haferflocken vermengen. Masse mit Salz und wenig Pfeffer sowie Muskatnuss würzen.",
+      "2 EL Butterschmalz in einer beschichteten Pfanne erhitzen und mit Hilfe von zwei Esslöffeln aus der Kartoffelmasse flache Puffer in die Pfanne geben. Diese im heißen Fett von beiden Seiten bei mittlerer Hitze ca. 7 Minuten ausbacken. Mit dem restlichen Butterschmalz und Kartoffelmasse ebenso verfahren.",
+      "Fertige Puffer auf Küchenpapier abtropfen lassen, warm halten und mit Apfelmus servieren."
+    ],
+    "id": "rec_82"
+  },
+  {
+    "title": "American Pancakes",
+    "tags": [
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "252 kcal",
+      "Kohlenhydrate": "35,9 g",
+      "Fett": "9,8 g",
+      "Eiweiß": "5,4 g"
+    },
+    "ingredients": [
+      "25 g Butter",
+      "125 g Weizenmehl Type 405",
+      "40 g Zucker",
+      "1 TL Backpulver",
+      "0,25 TL Salz",
+      "150 ml Milch",
+      "0,5 Ei (Zimmertemperatur)",
+      "1 EL Öl"
+    ],
+    "instructions": [
+      "Butter schmelzen. Mehl, Zucker, Backpulver und Salz verrühren.",
+      "Flüssige Butter mit Milch und Ei verquirlen. Die flüssigen zu den trockenen Zutaten geben und mit einem Schneebesen verrühren.",
+      "Pfanne leicht (!) einfetten und bei mittlerer Hitze die Pancakes nacheinander ausbacken. Wenn sich Blasen auf der Oberfläche bilden, wenden und auf der anderen Seite kurz ausbacken."
+    ],
+    "id": "rec_83"
+  },
+  {
+    "title": "Vegane Pasta in Blumenkohlsosse",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "510 kcal",
+      "Kohlenhydrate": "86,6 g",
+      "Fett": "11,1 g",
+      "Eiweiß": "23,4 g"
+    },
+    "ingredients": [
+      "1 Kopf Blumenkohl",
+      "1 Schalotte",
+      "2 EL Öl",
+      "500 ml Gemüsebrühe",
+      "400 g Vollkorn-Spaghetti",
+      "Salz",
+      "300 ml Sojadrink",
+      "2 Zehe(n) Knoblauch",
+      "3 EL Hefeflocken",
+      "0,5 Zitrone",
+      "0,5 Bd . Petersilie",
+      "Pfeffer aus der Mühle"
+    ],
+    "instructions": [
+      "Blumenkohl waschen und grob in Röschen teilen. Schalotte schälen, würfeln, im heißen Öl anbraten, herausnehmen.",
+      "Gemüsebrühe in denselben Topf gießen und den Blumenkohl darin ca. 10 Minuten kochen.",
+      "Nudeln in kochendem Salzwasser bissfest garen.",
+      "Blumenkohl mit der Brühe, den Zwiebelwürfeln, Sojamilch und den geschälten Knoblauchzehen zu einer cremigen Soße pürieren. Mit Salz, Hefeflocken und Zitronensaft abschmecken. Soße nochmals erwärmen.",
+      "Petersilie waschen, trocken schütteln und hacken. Nudeln mit der Soße anrichten und mit Petersilie bestreuen."
+    ],
+    "id": "rec_84"
+  },
+  {
+    "title": "Schnelle Brokkoli-Nudelpfanne mit Hirtenkäse",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "618 kcal",
+      "Kohlenhydrate": "82,2 g",
+      "Fett": "23 g",
+      "Eiweiß": "24,2 g"
+    },
+    "ingredients": [
+      "1 Zwiebel",
+      "2 Zehe(n) Knoblauch",
+      "2 EL ja! Olivenöl",
+      "400 g ja! Brokkoli (TK)",
+      "100 ml ja! Gemüsebrühe",
+      "100 g ja! Schlagsahne",
+      "ja! Salz",
+      "ja! Pfeffer",
+      "1 TL ja! Paprikapulver edelsüß",
+      "400 g ja! Nudeln (z. B. Fusilli)",
+      "200 g ja! Hirtenkäse"
+    ],
+    "instructions": [
+      "Zwiebel und Knoblauch schälen und fein würfeln.",
+      "In einer großen Pfanne das Olivenöl bei mittlerer Temperatur erhitzen. Zwiebel und Knoblauch darin andünsten, bis sie weich sind. Tiefgefrorenen Brokkoli, Gemüsebrühe und die Schlagsahne untermengen. Mit Salz, Pfeffer und Paprikapulver abschmecken und ca. 10 Minuten köcheln lassen.",
+      "Parallel die Nudeln laut Packungsanleitung zubereiten. Anschließend in einem Sieb über der Spüle abgießen.",
+      "Die heißen Nudeln zum Gemüse in die Pfanne geben und einmal durchmischen. Den Hirtenkäse kurz vor dem Servieren über die Nudelpfanne bröseln."
+    ],
+    "id": "rec_85"
+  },
+  {
+    "title": "Pasta mit Erbsen-Joghurt-Soße",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "806 kcal",
+      "Kohlenhydrate": "110 g",
+      "Fett": "28,6 g",
+      "Eiweiß": "30,7 g"
+    },
+    "ingredients": [
+      "225 g Erbsen (TK)",
+      "500 g Orecchiette",
+      "Salz",
+      "1 Zitrone",
+      "50 g Pinienkerne",
+      "15 g Minze",
+      "1 Zehe(n) Knoblauch",
+      "250 g griechischer Joghurt",
+      "150 g Feta",
+      "2 EL natives Olivenöl",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Erbsen auftauen lassen. Nudeln nach Packungsanweisung in Salzwasser kochen.",
+      "In der Zwischenzeit Zitrone waschen, Schale abreiben. Pinienkerne in einer Pfanne ohne Fett goldgelb rösten. Minze waschen, trockenschütteln und Blättchen abzupfen.",
+      "Knoblauch abziehen. Joghurt mit 100 g Feta, Olivenöl, aufgetaute Erbsen und Knoblauch pürieren. mit Zitronenschale, Salz und Pfeffer kräftig würzen.",
+      "Nudeln abgießen, dabei 1 Suppenkelle Wasser auffangen. Joghurt-Soße und Nudelwasser zu Nudeln geben und vorsichtig verrühren. Übrigen Feta grob zerbröseln.",
+      "Mit Pinienkernen, Feta und Minze garniert servieren."
+    ],
+    "id": "rec_86"
+  },
+  {
+    "title": "Spaghetti mit Hähnchen & getrockneten Tomaten",
+    "tags": [
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "997 kcal",
+      "Kohlenhydrate": "165 g",
+      "Fett": "19,1 g",
+      "Eiweiß": "49,7 g"
+    },
+    "ingredients": [
+      "400 g ja! Hähnchenbrust-Filetsteaks",
+      "280 g ja! junge Erbsen",
+      "4 TL ja! Pinienkerne",
+      "8 ja ! Getrocknete Tomaten",
+      "6 EL ja! Olivenöl",
+      "Salz",
+      "800 g ja! Spaghetti",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Die Hähnchenbrust-Filetsteaks und die Erbsen auftauen lassen.",
+      "Die Pinienkerne in einer Pfanne ohne Fett anrösten und herausnehmen. Getrocknete Tomaten in feine Stücke schneiden.",
+      "3 EL Olivenöl in einer Pfanne erhitzen, die Hähnchenbrust-Filetsteaks darin rundherum goldbraun braten und durchgaren. Aus der Pfanne nehmen und warm halten.",
+      "Einen großen Topf mit Salzwasser aufsetzen. Pasta in das kochende Wasser geben, nach Packungsanweisung al dente garen. Abgießen und kurz beiseite stellen.",
+      "2 EL Olivenöl in die Pfanne, in der vorher das Fleisch war, geben und die Erbsen darin kurz anbraten. Die getrockneten Tomaten dazu geben, dann die Spaghetti dazugeben. 1 EL Olivenöl darüber geben, alles bei mittlerer Hitze vermengen und kurz braten.",
+      "Hähnchenbrust in Scheiben schneiden. Spaghetti auf Teller verteilen, mit Pinienkernen bestreuen und die aufgeschnittene Hähnchenbrust darauf legen. Mit Pfeffer und Salz würzen und sofort servieren."
+    ],
+    "id": "rec_87"
+  },
+  {
+    "title": "One-Pot-Gnocchi in cremiger Tomaten-Mozzarellasoße",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "679 kcal",
+      "Kohlenhydrate": "100,5 g",
+      "Fett": "22,1 g",
+      "Eiweiß": "20,8 g"
+    },
+    "ingredients": [
+      "1 Zwiebel",
+      "1 Zehe(n) Knoblauch",
+      "30 g Basilikum",
+      "3 EL Sonnenblumenöl",
+      "1 EL brauner Zucker",
+      "2 EL Tomatenmark",
+      "2 Dose(n) gehackte Tomaten",
+      "200 ml Gemüsebrühe",
+      "Salz",
+      "Pfeffer",
+      "1 kg Gnocchi",
+      "255 g Mini-Mozzarella"
+    ],
+    "instructions": [
+      "Zwiebel und Knoblauch schälen und fein hacken. Basilikum waschen und in feine Streifen schneiden.",
+      "Sonnenblumenöl in einer Pfanne erhitzen und Zwiebeln darin bei mittlerer Hitze glasig dünsten. Knoblauch und Zucker hinzufügen und karamellisieren lassen. Dann das Tomatenmark hinzugeben und kurz mitrösten.",
+      "Mit gehackten Tomaten und Gemüsebrühe ablöschen und kräftig mit Salz und Pfeffer würzen. Gnocchi in die Soße geben und alles 5-10 Minuten köcheln lassen. Vom Herd nehmen und Basilikum und Mozzarella unterrühren, bis der Käse Fäden zieht."
+    ],
+    "id": "rec_88"
+  },
+  {
+    "title": "Griechische Bauernpfanne",
+    "tags": [
+      "Vegetarisch"
+    ],
+    "difficulty": "Mittel",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "595 kcal",
+      "Kohlenhydrate": "38,5 g",
+      "Fett": "35,3 g",
+      "Eiweiß": "32,3 g"
+    },
+    "ingredients": [
+      "4 Tomaten",
+      "2 Paprika",
+      "2 rote Zwiebel",
+      "2 EL Öl",
+      "4 EL Tomatenmark",
+      "Salz",
+      "Pfeffer",
+      "Oregano",
+      "8 Eier",
+      "2 Pck . Feta",
+      "rustikales Weizenbrot"
+    ],
+    "instructions": [
+      "Tomaten und Paprika waschen. Zusammen mit der Zwiebel in kleine Würfel schneiden.",
+      "Pfanne erhitzen, Öl zugeben und die Zwiebeln andünsten. Paprika hinzugeben, einige Minuten schwenken. Zuletzt Tomaten und das Tomatenmark zugeben. Mit Salz, Pfeffer und Oregano würzen. Kurz umrühren und in eine Schüssel füllen.",
+      "Pfanne wieder auf die Flamme stellen. Vier Eier dicht beieinander in die Pfanne geben. Die Spiegeleier leicht stocken lassen. Das Gemüse über den Eiern verteilen.",
+      "Feta in zwei Teile brechen, mit der Hand über der Pfanne zerbröseln, einen Teil fein, einen Teil grob. Pfanne abdecken, Käse anschmelzen lassen.",
+      "Noch etwas Oregano über die Eier streuen und in der Pfanne servieren. Dazu passt ein Stück rustikales Brot."
+    ],
+    "id": "rec_89"
+  },
+  {
+    "title": "Möhrensuppe mit Kartoffeln und Curry-Croûtons",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Personen",
+    "nutritionalInfo": {
+      "Energie": "398 kcal",
+      "Kohlenhydrate": "67 g",
+      "Fett": "12,1 g",
+      "Eiweiß": "8,8 g"
+    },
+    "ingredients": [
+      "1 kg Möhren",
+      "750 g Kartoffeln",
+      "4 EL Öl",
+      "1 Zwiebel",
+      "4 TL Gemüsebrühe (Instant)",
+      "4 Scheibe(n) Toastbrot",
+      "2 TL mildes Currypulver",
+      "Salz",
+      "schwarzer Pfeffer aus der Mühle",
+      "0,5 Bd . glatte Petersilie"
+    ],
+    "instructions": [
+      "Möhren und Kartoffeln waschen, schälen und in Stücke schneiden. 2 EL Öl in einem Topf erhitzen, Möhren und Kartoffeln darin anbraten. Zwiebel schälen, in dünne Ringe schneiden und hinzufügen. Mit 1,25 l Wasser ablöschen, Brühe einrühren und aufkochen lassen. Ca. 15 Minuten zugedeckt köcheln lassen.",
+      "Inzwischen Brot entrinden und in Würfel schneiden. Restliches Öl in einer Pfanne erhitzen, Brotwürfel darin ca. 5 Minuten bei mittlerer Hitze rösten. Dabei Curry darüberstäuben. Mit Salz und Pfeffer würzen.",
+      "Petersilie waschen, trocken tupfen, Blättchen abzupfen und in feine Streifen schneiden. Suppe mit einem Kartoffelstampfer grob zerkleinern. Mit Salz und Pfeffer würzen. Mit Petersilie bestreuen. Dazu die Curry-Croûtons servieren."
+    ],
+    "id": "rec_90"
+  },
+  {
+    "title": "Reispfanne mit Gemüse",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "295 kcal",
+      "Kohlenhydrate": "53,9 g",
+      "Fett": "6,6 g",
+      "Eiweiß": "7,9 g"
+    },
+    "ingredients": [
+      "150 g ja! Parboiled Spitzenreis",
+      "Salz",
+      "2 rote Paprika",
+      "1 Zwiebel",
+      "1 Dose(n) ja! Mais (285 g)",
+      "2 EL ja! Rapsöl",
+      "100 g ja! TK Erbsen",
+      "Kräutersalz"
+    ],
+    "instructions": [
+      "Reis nach Packungsanweisung in Salzwasser gar kochen.",
+      "Paprika waschen, das Kerngehäuse entfernen und in Würfel schneiden. Zwiebel schälen und in Streifen schneiden. Mais abtropfen lassen.",
+      "Öl in einer Pfanne erhitzen und die Zwiebeln goldbraun anbraten. Gekochten Reis, Paprika, Mais und Erbsen zugeben und alles kurz mit andünsten, bis die Erbsen gar sind. Mit Kräutersalz abschmecken."
+    ],
+    "id": "rec_91"
+  },
+  {
+    "title": "Klassische Linsensuppe",
+    "tags": [
+      "Vegetarisch",
+      "Laktosefrei",
+      "Kalorienarm",
+      "Fettarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "312 kcal",
+      "Kohlenhydrate": "51,2 g",
+      "Fett": "8,2 g",
+      "Eiweiß": "15,2 g"
+    },
+    "ingredients": [
+      "200 g Berglinsen",
+      "1 l Gemüsebrühe (oder Rinderbrühe)",
+      "300 g Kartoffeln",
+      "1 Bd . Suppengrün",
+      "1 EL Butterschmalz",
+      "0,5 Bd . Petersilie",
+      "3 EL Weißweinessig",
+      "Pfeffer",
+      "Salz",
+      "Schnittlauch"
+    ],
+    "instructions": [
+      "Linsen waschen, abtropfen lassen und 15 Minuten in der Brühe kochen.",
+      "Währenddessen Kartoffeln und Suppengrün waschen, schälen und in sehr feine Würfel schneiden.",
+      "Butterschmalz in einem zweiten Topf erhitzen und Kartoffeln und Suppengrün darin andünsten. Brühe mit den Linsen über das Gemüse geben und nochmals 10 Minuten köcheln.",
+      "Petersilie waschen, trocken schütteln, hacken und in die Suppe geben. Suppe mit Essig, Pfeffer und Salz abschmecken und nach Belieben mit Schnittlauch garnieren."
+    ],
+    "id": "rec_92"
+  },
+  {
+    "title": "Mini Cordon Bleu mit Erbsenpüree und Tomaten-Mais-Salat",
+    "tags": [],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "641 kcal",
+      "Kohlenhydrate": "56,3 g",
+      "Fett": "34,6 g",
+      "Eiweiß": "29,4 g"
+    },
+    "ingredients": [
+      "500 g Kartoffeln",
+      "Salz",
+      "300 g ja! Junge Erbsen (TK)",
+      "400 g Cherry Rispentomaten Dulcita",
+      "140 g ja! Sonnen-Mais natursüß",
+      "15 g Schnittlauch",
+      "8 EL ja! Rapsöl",
+      "2 EL Essig",
+      "1 TL Honig",
+      "1 Spritzer Orangensaft",
+      "Pfeffer",
+      "1 EL Butter",
+      "100 g Schlagsahne",
+      "1 Prise(n) Muskatnuss",
+      "400 g ja! Mini Cordon Bleu"
+    ],
+    "instructions": [
+      "Kartoffeln schälen, waschen, klein schneiden und in kochendem Salzwasser ca. 15 Minuten garen. Ca. 5 Minuten vor Ende der Garzeit die Erbsen zu den Kartoffeln geben.",
+      "Tomaten waschen, halbieren. Mais abtropfen lassen. Schnittlauch in Röllchen schneiden. Alles in eine Schüssel geben. 4 EL Öl mit Essig, Honig und Orangensaft zu einem Dressing verrühren. Mit Salz und Pfeffer würzen.",
+      "Zimmerwarme Butter und Sahne zu den Kartoffeln und Erbsen geben und grob zerstampfen. Mit Salz, Pfeffer und Muskatnuss abschmecken. Warm halten.",
+      "Mini Cordon Bleu in einer beschichteten Pfanne mit 4 EL Rapsöl bei mittlerer Hitze 6-8 Minuten braten.",
+      "Dressing über den Salat gießen. Mini Cordon Bleu mit Erbsenpüree und Salat anrichten."
+    ],
+    "id": "rec_93"
+  },
+  {
+    "title": "Zitronen-Linguine mit Rucola",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "463 kcal",
+      "Kohlenhydrate": "82,2 g",
+      "Fett": "9,3 g",
+      "Eiweiß": "14,8 g"
+    },
+    "ingredients": [
+      "400 g Linguine",
+      "Salz",
+      "2 rote Paprika",
+      "200 g Rucola",
+      "1 -Zitrone",
+      "1 Zehe(n) Knoblauch",
+      "3 EL Olivenöl",
+      "Pfeffer"
+    ],
+    "instructions": [
+      "Linguine nach Packungsanweisung in Salzwasser zubereiten.",
+      "Paprika waschen, Kerne entfernen und in kleine Würfel schneiden. Rucola verlesen, waschen und trocken schütteln. Zitrone unter heißem Wasser waschen, gut abtrocknen und anschließend die Schale abreiben. Zitrone dann halbieren und eine Hälfte auspressen. Knoblauch schälen und fein hacken.",
+      "Öl erhitzen und Paprika sowie Knoblauch anschwitzen.",
+      "Nudeln abgießen, 200 ml Nudelwasser auffangen. Nudeln mit dem aufgefangenen Wasser in die Pfanne geben und mit den Paprika vermischen.",
+      "Rucola und abgeriebene Zitronenschale unterrühren und mit Salz, Pfeffer und Zitronensaft abschmecken."
+    ],
+    "id": "rec_94"
+  },
+  {
+    "title": "Winterliche Kohlpfanne",
+    "tags": [
+      "Vegetarisch",
+      "Vegan",
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "526 kcal",
+      "Kohlenhydrate": "60,6 g",
+      "Fett": "25,1 g",
+      "Eiweiß": "18,7 g"
+    },
+    "ingredients": [
+      "1 Spitzkohl",
+      "2 Zwiebeln",
+      "185 g Räuchertofu",
+      "4 EL Rapsöl",
+      "1 TL Kümmel",
+      "200 ml Gemüsebrühe",
+      "Pfeffer",
+      "240 g Naturreis",
+      "3 EL Haselnusskerne"
+    ],
+    "instructions": [
+      "Spitzkohl vierteln, den Strunk entfernen und in feine Streifen schneiden. Zwiebeln schälen und in Streifen schneiden. Tofu fein würfeln.",
+      "Öl in einer Pfanne erhitzen und Zwiebeln und Tofu goldbraun anrösten. Kohl und Kümmel zugeben, mit anrösten und mit Gemüsebrühe aufgießen. 20 Minuten köcheln lassen und mit Pfeffer abschmecken.",
+      "Reis nach Packungsanweisung kochen. Haselnüsse in einer Pfanne ohne Fett rösten und grob hacken. Reis mit der Kohlpfanne servieren und mit Haselnüssen garnieren."
+    ],
+    "id": "rec_95"
+  },
+  {
+    "title": "Griechische Bowl",
+    "tags": [
+      "Glutenfrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "847 kcal",
+      "Kohlenhydrate": "81,4 g",
+      "Fett": "38,9 g",
+      "Eiweiß": "44,4 g"
+    },
+    "ingredients": [
+      "320 g ja! Parboiled Spitzenreis",
+      "Salz",
+      "1 EL ja! Olivenöl",
+      "500 g Gyrosfleisch",
+      "0,5 Gurke",
+      "2 Zehe(n) Knoblauch",
+      "200 g ja! Vollmilch-Joghurt",
+      "Pfeffer",
+      "200 g Cherrytomaten",
+      "150 g ja! Hirtenkäse",
+      "15 g Petersilie",
+      "500 g ja! Krautsalat mit grüner Paprika"
+    ],
+    "instructions": [
+      "Reis nach Packungsanweisung in Salzwasser kochen.",
+      "Öl in einer Pfanne erhitzen, Fleisch ca. 10 Minuten rundherum braten.",
+      "Für das Tzatziki Gurke waschen, reiben, Wasser ausdrücken. Knoblauch schälen, fein hacken. Joghurt mit Gurke und Knoblauch verrühren. Mit Salz und Pfeffer würzen.",
+      "Tomaten waschen und halbieren. Hirtenkäse in Würfel schneiden. Petersilie waschen und hacken.",
+      "Reis auf 4 Schalen verteilen. Krautsalat, Tzatziki, Tomaten, Hirtenkäse und Gyros auf dem Reis anrichten und mit Petersilie bestreut servieren. Mit Salz und Pfeffer würzen."
+    ],
+    "id": "rec_96"
+  },
+  {
+    "title": "Cremiger Low-Carb Brokkoli-Auflauf mit Hähnchen",
+    "tags": [
+      "Low Carb"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "597 kcal",
+      "Kohlenhydrate": "12,5 g",
+      "Fett": "37,5 g",
+      "Eiweiß": "55,2 g"
+    },
+    "ingredients": [
+      "4 Stück Hähnchenbrustfilets",
+      "1 Zwiebel",
+      "1 Zehe(n) Knoblauch",
+      "0,5 Bd . frische Petersilie",
+      "600 g Brokkoli",
+      "2 EL Rapsöl",
+      "200 ml Brühe",
+      "100 ml Sahne",
+      "200 g Sahneschmelzkäse",
+      "Salz",
+      "Pfeffer",
+      "100 g Gratinkäse"
+    ],
+    "instructions": [
+      "Hähnchen in Würfel schneiden. Zwiebel und Knoblauch schälen und fein würfeln. Petersilie waschen und fein hacken. Brokkoli waschen und die Röschen abtrennen. Brokkoliröschen in reichlich Salzwasser für 3-4 Minuten blanchieren und anschließend in Eiswasser kalt abschrecken.",
+      "Öl in einer Pfanne erhitzen. Hähnchen darin scharf anbraten. Dann die Zwiebeln und den Knoblauch dazugeben und 1-2 Minuten mitbraten. Alles mit der Brühe ablöschen und Sahne und Schmelzkäse hinzufügen. Unter Rühren kurz aufkochen und köcheln lassen, bis der Schmelzkäse sich vollständig gelöst hat. Mit Salz und Pfeffer abschmecken. Dann den Brokkoli dazugeben.",
+      "Alles in eine ofenfeste Form geben, mit dem Käse bestreuen und im vorgeheizten Backofen bei 180 °C Ober-/Unterhitze für 20 Minuten backen. Nach dem Backen mit frischer Petersilie bestreuen."
+    ],
+    "id": "rec_97"
+  },
+  {
+    "title": "Gefüllte Paprika Vegetarisch",
+    "tags": [
+      "Vegetarisch",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "431 kcal",
+      "Kohlenhydrate": "59,1 g",
+      "Fett": "14,8 g",
+      "Eiweiß": "18,7 g"
+    },
+    "ingredients": [
+      "250 g Couscous",
+      "4 Paprika",
+      "500 g Blattspinat",
+      "1 Zehe(n) Knoblauch",
+      "1 Zwiebel",
+      "1 EL Öl",
+      "Salz",
+      "Pfeffer",
+      "Chiligewürz",
+      "150 g Feta",
+      "300 ml Gemüsebrühe"
+    ],
+    "instructions": [
+      "Couscous nach Packungsanweisung zubereiten. Backofen auf 200°C Ober-/ Unterhitze vorheizen.",
+      "Paprika waschen, Deckel abschneiden und die Kerne entfernen. Spinat waschen, trocken schleudern und ggf. lange Stiele entfernen. Knoblauch und Zwiebel schälen und fein hacken.",
+      "1 EL Öl erhitzen und Zwiebel, Knoblauch und Spinat anschwitzen, bis der Spinat zusammengefallen ist. Mit Salz, Pfeffer und Chiligewürz abschmecken.",
+      "Feta zerbröseln, mit dem Couscous und dem Spinat vermischen. Die Masse in die Paprikaschoten füllen.",
+      "Paprika nebeneinander in eine Auflaufform füllen, die Gemüsebrühe angießen und im vorgeheizten Backofen ca. 20-30 Minuten garen."
+    ],
+    "id": "rec_98"
+  },
+  {
+    "title": "Bami Goreng",
+    "tags": [
+      "Laktosefrei"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "549 kcal",
+      "Kohlenhydrate": "68,9 g",
+      "Fett": "10,2 g",
+      "Eiweiß": "46,8 g"
+    },
+    "ingredients": [
+      "250 g Mie-Nudeln",
+      "1 Stück Ingwer",
+      "2 Zehe(n) Knoblauch",
+      "50 g Ketjap Manis",
+      "8 EL Sojasauce",
+      "1 TL Sambal Oelek",
+      "1 TL Currypulver",
+      "1 EL Wasser",
+      "1 TL Speisestärke",
+      "1 Pak Choi",
+      "0,5 Bd . Frühlingszwiebeln",
+      "200 g Zuckerschoten",
+      "2 Möhren",
+      "2 Hühnerbrüste",
+      "3 EL Öl",
+      "90 g Garnelen verzehrfertig"
+    ],
+    "instructions": [
+      "Nudeln nach Packungsanweisung al dente kochen und abgießen.",
+      "Ingwer und Knoblauch schälen und fein würfeln. Mit Ketjap Manis, 6 EL Sojasauce, Sambal Oelek und Currypulver zu einer Marinade verrühren. 1 EL kaltes Wasser mit 1 TL Speisestärke verrühren und dazugeben.",
+      "Pak Choi, Frühlingszwiebeln und Zuckerschoten waschen. Möhren schälen. Pak Choi in Streifen und Möhren in Stifte schneiden. Frühlingszwiebeln in feine Ringe schneiden. Die Zuckerschoten von den harten Enden befreien und ggf. störende Fäden abziehen.",
+      "Hähnchenbrust in Würfel schneiden. 2 El Öl in einem Wok erhitzen. Die Hähnchenbrust darin 5-7 Min. von allen Seiten anbraten und beiseite legen. Restliches Öl in die Pfanne geben und das Gemüse, mit Ausnahme der Frühlingszwiebeln, darin scharf anbraten. Kurz bevor das Gemüse gar ist, Hähnchen, Garnelen, Nudeln und die Marinade hinzufügen. Alles vermischen und für weitere 2-3 Minuten in der Pfanne schwenken.",
+      "Nudeln auf 4 Teller verteilen, mit Sojasauce beträufeln und mit Frühlingszwiebeln bestreuen."
+    ],
+    "id": "rec_99"
+  },
+  {
+    "title": "Zucchini-Puffer mit Feta",
+    "tags": [
+      "Vegetarisch",
+      "Low Carb",
+      "Kalorienarm"
+    ],
+    "difficulty": "Einfach",
+    "portions": "für 4 Portionen",
+    "nutritionalInfo": {
+      "Energie": "252 kcal",
+      "Kohlenhydrate": "13,1 g",
+      "Fett": "17,5 g",
+      "Eiweiß": "11,2 g"
+    },
+    "ingredients": [
+      "2 große Zucchini",
+      "Salz",
+      "1 Ei (L)",
+      "4 EL Weizenmehl Type 405",
+      "Pfeffer",
+      "130 g Feta",
+      "3 EL Rapsöl"
+    ],
+    "instructions": [
+      "Zucchini waschen und grob reiben. Leicht salzen und 5 Minuten stehen lassen. Raspel gut ausdrücken und die Flüssigkeit abgießen.",
+      "Ei, Mehl, Salz und Pfeffer hinzufügen und gut vermischen. Feta dazu krümeln und ebenfalls vermischen.",
+      "Öl in einer großen Pfanne erhitzen und nach und nach Puffer nach beliebiger Größe ausbacken. Mehrmals wenden und heiß servieren. Dazu schmeckt ein Joghurt- oder Kräuterdip."
+    ],
+    "id": "rec_100"
+  }
+]

--- a/scale_recipes.js
+++ b/scale_recipes.js
@@ -1,0 +1,231 @@
+const fs = require('fs');
+const path = require('path');
+
+const RECIPES_FILE_PATH = path.join('data', 'recipes.json');
+const RECIPES_2_FILE_PATH = path.join('data', 'recipes_2.json');
+const RECIPES_4_FILE_PATH = path.join('data', 'recipes_4.json');
+
+let originalRecipes = [];
+
+// 1. Parse `recipes.json`
+try {
+    const rawData = fs.readFileSync(RECIPES_FILE_PATH, 'utf-8');
+    originalRecipes = JSON.parse(rawData);
+    console.log(`Successfully loaded ${originalRecipes.length} recipes.`);
+} catch (error) {
+    console.error("Error loading or parsing recipes.json:", error);
+    process.exit(1); // Exit if we can't load the base data
+}
+
+// Placeholder for unscalable ingredients reporting
+const unscalableIngredients = new Set();
+
+// 2. Create Helper Functions (JavaScript)
+
+/**
+ * Parses the portions string (e.g., "für 4 Portionen") to extract the number of portions.
+ * @param {string} portionsString - The string describing the portions.
+ * @returns {number|null} The number of portions, or null if not parsable.
+ */
+function getPortionCount(portionsString) {
+    if (!portionsString || typeof portionsString !== 'string') {
+        return null;
+    }
+    const match = portionsString.match(/für (\d+)\s+(Portionen|Personen)/i);
+    if (match && match[1]) {
+        return parseInt(match[1], 10);
+    }
+    // Fallback for just a number
+    const simpleMatch = portionsString.match(/(\d+)/);
+    if (simpleMatch && simpleMatch[1]) {
+        return parseInt(simpleMatch[1], 10);
+    }
+    return null;
+}
+
+/**
+ * Formats the new portion number back into a string, trying to match original wording.
+ * @param {number} count - The number of portions.
+ * @param {string} originalPortionsString - The original portions string to match wording.
+ * @returns {string} The formatted portions string.
+ */
+function formatPortions(count, originalPortionsString) {
+    if (originalPortionsString && originalPortionsString.toLowerCase().includes("personen")) {
+        return `für ${count} Personen`;
+    }
+    return `für ${count} Portionen`;
+}
+
+// 3. Develop Ingredient Scaling Logic (JavaScript)
+
+/**
+ * Scales an ingredient string based on original and target portion sizes.
+ * @param {string} ingredientString - The ingredient string (e.g., "500 g Flour").
+ * @param {number} originalPortions - The original number of portions for the recipe.
+ * @param {number} targetPortions - The target number of portions.
+ * @param {Set<string>} unscalableIngredientsSet - A Set to store unscalable ingredient strings.
+ * @returns {string} The scaled ingredient string, or original if not scalable.
+ */
+function scaleIngredient(ingredientString, originalPortions, targetPortions, unscalableIngredientsSet) {
+    if (originalPortions === null || originalPortions <= 0 || targetPortions <= 0) {
+        unscalableIngredientsSet.add(ingredientString);
+        return ingredientString; // Cannot scale if original portions are unknown or invalid
+    }
+
+    // Regex to capture quantity (integer or decimal with comma/dot), unit, and rest of the string
+    // Allows for optional space between quantity and unit
+    const ingredientRegex = /^(\d+([.,]\d+)?)\s*([a-zA-ZäöüÄÖÜßéèàêâûôîç°§]+(?:\([a-zA-ZäöüÄÖÜßéèàêâûôîç°§]+\))?)?\s*(.*)/;
+    const match = ingredientString.match(ingredientRegex);
+
+    if (match && match[1]) {
+        let quantity = parseFloat(match[1].replace(',', '.')); // Normalize comma to dot for parseFloat
+        const unit = match[3] || ""; // Unit might be undefined
+        const name = match[4] || ""; // Name of the ingredient
+
+        // Check for units that should not be scaled or have specific handling
+        const nonScalableUnits = ["prise", "msp.", "pck.", "dose(n)", "glas", "becher", "knolle(n)", "stange(n)", "zweig(e)", "topf", "handvoll"];
+        // Pck. and Dose(n) might be scalable in some contexts, but for now, let's be cautious.
+        // User feedback indicated "1 Pck. ja! Buttergemüse (TK, à 300 g)" - the "à 300g" implies the pack size is fixed.
+
+        if (unit && nonScalableUnits.some(nsUnit => unit.toLowerCase().startsWith(nsUnit))) {
+             // For specific units like Pck or Dose where the size is fixed (e.g. "1 Pck. (à 300g)")
+             // we might want to scale the number of packs, but not the "à XXXg" part.
+             // For now, if the unit is in nonScalableUnits, we scale the leading number of these items.
+        }
+
+
+        if (isNaN(quantity)) {
+            unscalableIngredientsSet.add(ingredientString);
+            return ingredientString;
+        }
+
+        let scaledQuantity = (quantity / originalPortions) * targetPortions;
+
+        // Basic rounding: integers remain integers if whole, otherwise 1 decimal place.
+        // More sophisticated rounding might be needed depending on typical kitchen measurements.
+        if (Number.isInteger(scaledQuantity) || scaledQuantity % 1 === 0) {
+            scaledQuantity = Math.round(scaledQuantity);
+        } else if (scaledQuantity < 1 && scaledQuantity > 0) {
+            // For small quantities, round to 2 decimal places, or handle as fractions if desired
+            scaledQuantity = parseFloat(scaledQuantity.toFixed(2));
+        }
+        else {
+            scaledQuantity = parseFloat(scaledQuantity.toFixed(1));
+        }
+
+        // Avoid 0 quantity unless it was originally 0
+        if (scaledQuantity === 0 && quantity !== 0) {
+            // This might happen if originalPortions is much larger than targetPortions.
+            // Decide on a minimum quantity or keep as is. For now, let's keep a small fraction.
+            // Or, if it's like "0,5 EL", it should become "0.25 EL" for half.
+            // Let's stick to toFixed(1) or toFixed(2) which handles this.
+            // If scaled quantity becomes very small, e.g. 0.01, it might be better to list it as "a pinch" or similar.
+            // For now, just use the scaled value.
+        }
+
+
+        // Reconstruct the string, replacing comma with dot for consistency in output if desired, or keep original.
+        // Here, we output with a dot as the decimal separator.
+        let quantityStr = String(scaledQuantity).replace('.', ',');
+
+
+        // Handle cases like "1 Zehe(n) Knoblauch" -> "0,5 Zehe(n) Knoblauch" is weird.
+        // For "Zehe(n)", "Stück", etc., maybe round to nearest whole or half?
+        const wholeItemUnits = ["zehe(n)", "stück", "knoblauchzehen"]; // Add more as identified
+        if (unit && wholeItemUnits.some(wiUnit => unit.toLowerCase().startsWith(wiUnit))) {
+            if (scaledQuantity < 0.5 && scaledQuantity > 0) scaledQuantity = 0.5; // Minimum 0.5 for these
+            else scaledQuantity = Math.round(scaledQuantity * 2) / 2; // Round to nearest 0.5
+            quantityStr = String(scaledQuantity).replace('.', ',');
+        }
+
+
+        return `${quantityStr}${unit ? ' ' + unit : ''} ${name}`.trim();
+    } else {
+        // No numeric quantity found at the beginning, or structure doesn't match
+        // Check for "eine Prise", "ein Bund" etc.
+        const textQuantities = [
+            { pattern: /^(eine|einen|ein)\s+Prise/i, base: 1, unitText: "Prise" },
+            { pattern: /^(eine|einen|ein)\s+Msp./i, base: 1, unitText: "Msp." },
+            { pattern: /^(eine|einen|ein)\s+Bd\./i, base: 1, unitText: "Bd." },
+            // Add more textual quantities if needed
+        ];
+
+        for (const tq of textQuantities) {
+            if (tq.pattern.test(ingredientString)) {
+                // These are typically not scaled or scaled carefully.
+                // For now, keep them as is, and add to unscalable.
+                unscalableIngredientsSet.add(ingredientString);
+                return ingredientString;
+            }
+        }
+
+        unscalableIngredientsSet.add(ingredientString);
+        return ingredientString;
+    }
+}
+
+
+// Main processing function
+function processRecipes() {
+    console.log("Processing recipes...");
+
+    const allRecipesFor2 = [];
+    const allRecipesFor4 = [];
+
+    originalRecipes.forEach(originalRecipe => {
+        const originalPortionCount = getPortionCount(originalRecipe.portions);
+
+        if (originalPortionCount === null) {
+            console.warn(`Could not parse portion count for recipe: "${originalRecipe.title}". Skipping this recipe.`);
+            unscalableIngredients.add(`Recipe: "${originalRecipe.title}" - Invalid portions: ${originalRecipe.portions}`);
+            return; // Skip this recipe
+        }
+
+        // Create recipe for 2 portions
+        const recipeFor2 = JSON.parse(JSON.stringify(originalRecipe)); // Deep copy
+        recipeFor2.portions = formatPortions(2, originalRecipe.portions);
+        recipeFor2.ingredients = originalRecipe.ingredients.map(ing =>
+            scaleIngredient(ing, originalPortionCount, 2, unscalableIngredients)
+        );
+        allRecipesFor2.push(recipeFor2);
+
+        // Create recipe for 4 portions
+        const recipeFor4 = JSON.parse(JSON.stringify(originalRecipe)); // Deep copy
+        recipeFor4.portions = formatPortions(4, originalRecipe.portions);
+        recipeFor4.ingredients = originalRecipe.ingredients.map(ing =>
+            scaleIngredient(ing, originalPortionCount, 4, unscalableIngredients)
+        );
+        allRecipesFor4.push(recipeFor4);
+    });
+
+    // Step 5: Write New JSON Files (JavaScript)
+    try {
+        fs.writeFileSync(RECIPES_2_FILE_PATH, JSON.stringify(allRecipesFor2, null, 2), 'utf-8');
+        console.log(`Successfully wrote ${allRecipesFor2.length} recipes to ${RECIPES_2_FILE_PATH}`);
+        fs.writeFileSync(RECIPES_4_FILE_PATH, JSON.stringify(allRecipesFor4, null, 2), 'utf-8');
+        console.log(`Successfully wrote ${allRecipesFor4.length} recipes to ${RECIPES_4_FILE_PATH}`);
+    } catch (error) {
+        console.error("Error writing recipe files:", error);
+    }
+
+    // Step 6: Report Unscalable Ingredients
+    if (unscalableIngredients.size > 0) {
+        console.log("\n--- Unscalable Ingredients Report ---");
+        unscalableIngredients.forEach(ing => console.log(ing));
+        console.log("--- End of Report ---");
+        // This message will also be sent to the user via message_user tool later
+    }
+}
+
+// Call main function if this script is executed directly
+if (require.main === module) {
+    processRecipes();
+}
+
+module.exports = {
+    originalRecipes,
+    unscalableIngredients,
+    getPortionCount,
+    formatPortions
+    // Will export other functions for testing or modular use later
+};


### PR DESCRIPTION
This commit introduces a Node.js script `scale_recipes.js` that processes an existing `data/recipes.json` file.

The script performs the following actions:
- Parses the original recipes.
- For each recipe, determines its original portion size.
- Scales the ingredient quantities to generate versions for 2 and 4 portions.
- Handles various numeric formats (integers, decimals with comma/dot) and common units.
- Ingredients without clear leading numeric quantities (e.g., "Salz", "Pfeffer") are kept as is, and a list of these is reported.
- Writes two new files: `data/recipes_2.json` and `data/recipes_4.json`, containing all recipes with ingredients scaled for 2 and 4 people respectively.

The goal is to provide pre-calculated recipe versions to avoid information loss from repeated conversions and to make portion-specific data readily available.