### PR TITLE
feat: Implement portion size selection for recipes

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,8 +66,17 @@
                         <form id="generator-form">
                             <div class="form-group-inline">
                                 <div class="form-group">
-                                    <label for="persons"><i class="fa-solid fa-users"></i> Personen</label>
-                                    <input type="number" id="persons" value="1" min="1" required>
+                                    <label><i class="fa-solid fa-users"></i> Portionen</label>
+                                    <div class="radio-group-container" id="portions-radio-group">
+                                        <div class="radio-group">
+                                            <input type="radio" id="portions-2" name="portions" value="2" checked>
+                                            <label for="portions-2">2 Personen</label>
+                                        </div>
+                                        <div class="radio-group">
+                                            <input type="radio" id="portions-4" name="portions" value="4">
+                                            <label for="portions-4">4 Personen</label>
+                                        </div>
+                                    </div>
                                 </div>
                                 <div class="form-group">
                                     <label for="budget"><i class="fa-solid fa-piggy-bank"></i> Budget/Portion (€)</label>


### PR DESCRIPTION
This commit introduces functionality for users to select between 2-person and 4-person meal plans.

Key changes:

- Replaced the numerical input for 'persons' in the meal plan generator with radio buttons for '2 portions' or '4 portions'.
- Updated `js/app.js` to:
    - Read the selected portion size from the new radio buttons.
    - Store this preference in `localStorage`.
    - Initialize the radio button state from `localStorage` on page load.
    - Dynamically load either `recipes_2.json` or `recipes_4.json` based on the stored portion preference at application startup.
- Ensured that `js/logic.js` (specifically `generateShoppingList`) correctly interprets the 'portions' field from the loaded recipe data to accurately scale ingredients for the shopping list.

If a user selects recipes based on one portion size (e.g., 2-person recipes loaded by default) and then changes the plan settings to a different portion size (e.g., 4 persons) before confirming the plan, the shopping list will correctly scale the ingredients of the initially selected recipes. A page reload after changing portion settings will load the corresponding recipe dataset for future plan generation.