### PR TITLE
Remove 'ja!' from ingredient names in JSON files

### DIFF
--- a/data/recipes_2.json
+++ b/data/recipes_2.json
@@ -50,7 +50,7 @@
       "2 Zwiebeln",
       "1 EL Rapsöl",
       "400 g Gnocchi (Kühlregal)",
-      "1 Pck . ja! Buttergemüse (TK, à 300 g)",
+      "1 Pck . Buttergemüse (TK, à 300 g)",
       "200 ml Gemüsebrühe",
       "100 g Crème fraîche",
       "5 g Schnittlauch"
@@ -152,16 +152,16 @@
       "Eiweiß": "27,4 g"
     },
     "ingredients": [
-      "62,5 g ja! Langkorn-Spitzenreis",
-      "ja! Jodsalz",
+      "62,5 g Langkorn-Spitzenreis",
+      "Jodsalz",
       "1 rote Paprikaschoten",
       "0,5 Salatgurke",
       "1 Lauchzwiebeln",
-      "1,5 EL ja! Sonnenblumenöl",
+      "1,5 EL Sonnenblumenöl",
       "0,5 EL Weißweinessig",
       "Pfeffer",
       "0,5 TL Zucker",
-      "250 g ja! gemischtes Hackfleisch"
+      "250 g gemischtes Hackfleisch"
     ],
     "instructions": [
       "Reis in kochendem Salzwasser nach Packungsanweisung zubereiten. Paprika putzen, waschen, entkernen und in Streifen schneiden. Gurke putzen, waschen und fein würfeln. Lauchzwiebeln putzen, waschen und in feine Ringe schneiden. Gurke, Lauchzwiebeln, 1 EL ÖL und Essig mischen. Mit Salz, Pfeffer und Zucker würzen.",
@@ -429,16 +429,16 @@
       "Eiweiß": "24,7 g"
     },
     "ingredients": [
-      "150 g ja! Weizenmehl",
-      "250 ml ja! fettarme H-Milch",
+      "150 g Weizenmehl",
+      "250 ml fettarme H-Milch",
       "1,5 Eier (Größe M)",
-      "ja! Jodsalz",
-      "2 EL ja! Markenbutter",
+      "Jodsalz",
+      "2 EL Markenbutter",
       "1 kleine Zucchini",
-      "100 g ja! Delikatess Kochschinken",
+      "100 g Delikatess Kochschinken",
       "0,5 Dose(n) gehackte Tomaten",
       "Pfeffer",
-      "50 g ja! geriebener Gratin- und Pizzakäse"
+      "50 g geriebener Gratin- und Pizzakäse"
     ],
     "instructions": [
       "Mehl, Milch und Eier zu einem glatten Pfannkuchenteig verrühren. Mit Salz würzen. Butter portionsweise in einer Pfanne erhitzen. Nacheinander ca. 8-10 dünne Pfannkuchen aus dem Teig backen.",
@@ -495,10 +495,10 @@
     },
     "ingredients": [
       "1 Zwiebeln",
-      "0,5 Pck . ja! Rahmspinat (450 g)",
-      "200 g ja! Spaghetti",
-      "400 ml ja! Gemüsebrühe",
-      "100 ml ja! Schlagsahne",
+      "0,5 Pck . Rahmspinat (450 g)",
+      "200 g Spaghetti",
+      "400 ml Gemüsebrühe",
+      "100 ml Schlagsahne",
       "25 g Parmesan"
     ],
     "instructions": [
@@ -520,7 +520,7 @@
       "Eiweiß": "31,7 g"
     },
     "ingredients": [
-      "100 g ja! TK-Erbsen",
+      "100 g TK-Erbsen",
       "250 g Penne",
       "Salz",
       "0,5 Zwiebel",
@@ -592,17 +592,17 @@
       "Eiweiß": "29,5 g"
     },
     "ingredients": [
-      "200 g ja! Penne",
-      "150 g ja! Blumenkohl (TK)",
+      "200 g Penne",
+      "150 g Blumenkohl (TK)",
       "0,5 Zehe(n) Knoblauch",
-      "1 EL ja! Butter",
-      "0,5 EL ja! Weizenmehl (Type 405)",
-      "100 ml ja! Vollmilch",
-      "50 g ja! Schlagsahne",
-      "ja! Salz",
-      "ja! Pfeffer",
-      "0,5 TL ja! Paprikapulver edelsüß",
-      "100 g ja! Cheddar"
+      "1 EL Butter",
+      "0,5 EL Weizenmehl (Type 405)",
+      "100 ml Vollmilch",
+      "50 g Schlagsahne",
+      "Salz",
+      "Pfeffer",
+      "0,5 TL Paprikapulver edelsüß",
+      "100 g Cheddar"
     ],
     "instructions": [
       "Penne laut Packungsanleitung zubereiten und ca. 3 Minuten vor Ende der Garzeit den gefrorenen Blumenkohl dazugeben.",
@@ -628,13 +628,13 @@
       "Eiweiß": "29,3 g"
     },
     "ingredients": [
-      "400 ml ja! Tomatencremesuppe",
+      "400 ml Tomatencremesuppe",
       "250 g Penne Mezzane Rigate",
       "50 g Getrocknete Tomaten in Öl",
       "0,5 TL Knoblauchpulver",
       "Pfeffer",
       "Salz",
-      "1 ja ! Mozzarella"
+      "1 Mozzarella"
     ],
     "instructions": [
       "Tomatencremesuppe, 750 ml Wasser und Penne in einen Topf geben, erhitzen und für 15 Minuten köcheln lassen, bis die Penne al dente sind.",
@@ -659,8 +659,8 @@
       "Eiweiß": "15,1 g"
     },
     "ingredients": [
-      "150 g Ja! TK-Erbsen",
-      "240 g Ja! Langkorn-Reis",
+      "150 g TK-Erbsen",
+      "240 g Langkorn-Reis",
       "0,5 mittlere Zwiebel",
       "0,5 Zehe(n) Knoblauch",
       "0,25 Bd . frische Petersilie",
@@ -1442,14 +1442,14 @@
       "50 g Möhren",
       "1 EL Rapsöl nativ",
       "250 g Hackfleisch gemischt",
-      "1 EL ja! Tomatenmark 3-fach konzentriert",
+      "1 EL Tomatenmark 3-fach konzentriert",
       "1 Dose(n) Tomaten geschält à 400g",
-      "ja! Jodsalz",
-      "ja! Pfeffer schwarz gemahlen",
-      "ja! Raffinade Zucker",
+      "Jodsalz",
+      "Pfeffer schwarz gemahlen",
+      "Raffinade Zucker",
       "1 TL Oregano gerebelt",
-      "200 g ja! Spaghetti",
-      "25 g ja! geriebener Mozzarella"
+      "200 g Spaghetti",
+      "25 g geriebener Mozzarella"
     ],
     "instructions": [
       "Zwiebeln und Knoblauch schälen und fein hacken. Möhren schälen und fein würfeln.",
@@ -1867,17 +1867,17 @@
       "0,5 Salatgurke",
       "1,5 Stiel(e) Dill",
       "1 EL ja! Schmand",
-      "1,5 EL ja! Condimento bianco",
-      "0,5 TL ja! Senf mittelscharf",
-      "ja! Jodsalz",
-      "ja! Pfeffer schwarz gemahlen",
+      "0,5 EL Condimento bianco",
+      "0,5 TL Senf mittelscharf",
+      "Jodsalz",
+      "Pfeffer schwarz gemahlen",
       "400 g Kartoffeln",
       "1 Zwiebeln",
-      "1,5 EL ja! Natives Rapsöl",
+      "1,5 EL Natives Rapsöl",
       "300 g Schweine-Schinkenschnitzel",
       "1 Eier",
-      "2 EL ja! Weizenmehl Type 405",
-      "75 g ja! Paniermehl",
+      "2 EL Weizenmehl Type 405",
+      "75 g Paniermehl",
       "0,5 Zitrone"
     ],
     "instructions": [
@@ -1946,7 +1946,7 @@
       "140 ml getrocknete Tomaten in Öl mit Oregano",
       "0,5 Dose(n) stückige Tomaten",
       "2 Stiel(e) Basilikum",
-      "1 TL ja! Tomatenmark",
+      "1 TL Tomatenmark",
       "Bunter Pfeffer aus der Mühle",
       "Fleur de Sel",
       "Zucker",
@@ -2052,20 +2052,20 @@
       "Eiweiß": "52 g"
     },
     "ingredients": [
-      "150 g ja! Buttergemüse (TK)",
-      "160 g ja! Penne Rigate",
+      "150 g Buttergemüse (TK)",
+      "160 g Penne Rigate",
       "Salz",
       "0,5 große Zwiebel",
       "1 Zehe(n) Knoblauch",
-      "1 EL ja! Rapsöl",
-      "200 g ja! Hackfleisch gemischt",
-      "250 g ja! Tomaten passiert",
+      "1 EL Rapsöl",
+      "200 g Hackfleisch gemischt",
+      "250 g Tomaten passiert",
       "Pfeffer",
       "0,5 Prise(n) Zucker",
       "0,25 TL Oregano getrocknet",
       "0,13 TL Thymian getrocknet",
-      "100 g ja! Schmand",
-      "125 g ja! geriebener Gratin- und Pizzakäse"
+      "100 g Schmand",
+      "125 g geriebener Gratin- und Pizzakäse"
     ],
     "instructions": [
       "Buttergemüse antauen lassen. Nudeln in Salzwasser bissfest kochen. Zwiebel und Knoblauch schälen, würfeln. Backofen auf 180 °C Ober-/Unterhitze vorheizen.",
@@ -2086,7 +2086,7 @@
       "Eiweiß": "32,2 g"
     },
     "ingredients": [
-      "2 ja ! Hähnchen Mini Schnitzel",
+      "2 Hähnchen Mini Schnitzel",
       "2 Tortilla -Wraps",
       "2 EL Frischkäse",
       "25 g Nachos",
@@ -2124,10 +2124,10 @@
     "ingredients": [
       "0,17 Zwiebel",
       "0,17 rote Zwiebel",
-      "0,5 EL ja! Sonnenblumenöl",
-      "20,8 g ja! Schinkenwürfel",
-      "33,3 g ja! Frischkäse Natur Doppelrahmstufe",
-      "16,7 g ja! Schmand",
+      "0,5 EL Sonnenblumenöl",
+      "20,8 g Schinkenwürfel",
+      "33,3 g Frischkäse Natur Doppelrahmstufe",
+      "16,7 g Schmand",
       "0,5 Zweig(e) Basilikum",
       "0,83 Tomaten",
       "Salz",
@@ -2135,12 +2135,12 @@
       "0,33 Pck . Pizzateig (Kühlregal)",
       "1 TL Paniermehl",
       "0,17 Eigelb",
-      "0,33 EL ja! Milch",
-      "33,3 g ja! Geriebener Gouda",
+      "0,33 EL Milch",
+      "33,3 g Geriebener Gouda",
       "33,3 g Cocktailtomaten",
       "0,5 Stück Romana-Salatherzen",
       "0,67 EL Weißwein-Essig",
-      "0,08 TL ja! mittelscharfer Senf",
+      "0,08 TL mittelscharfer Senf",
       "Zucker"
     ],
     "instructions": [
@@ -2236,10 +2236,10 @@
       "100 ml Gemüsebrühe",
       "1,5 EL Obstessig",
       "1,5 EL mittelscharfer Senf",
-      "0,5 EL ja! Zucker",
+      "0,5 EL Zucker",
       "Pfeffer",
       "1,5 EL Pflanzenöl",
-      "50 g ja! Delikatess-Mayonnaise",
+      "50 g Delikatess-Mayonnaise",
       "2 Gewürzgurken",
       "1,5 Eier"
     ],
@@ -2329,13 +2329,13 @@
       "Eiweiß": "16,6 g"
     },
     "ingredients": [
-      "125 g ja! Langkorn-Reis",
-      "300 ml ja! Gemüsebrühe",
-      "150 g ja! TK-Erbsen",
+      "125 g Langkorn-Reis",
+      "300 ml Gemüsebrühe",
+      "150 g TK-Erbsen",
       "125 g Champignons",
       "1 Zwiebeln",
-      "0,5 EL ja! Rapsöl",
-      "50 g ja! Hirtenkäse"
+      "0,5 EL Rapsöl",
+      "50 g Hirtenkäse"
     ],
     "instructions": [
       "Reis mit der Gemüsebrühe aufkochen und bei schwacher Hitze ca. 10 Minuten quellen, bis der Reis gar und die Flüssigkeit aufgesogen ist. Nach 5 Minuten die gefrorenen Erbsen zugeben.",
@@ -2402,14 +2402,14 @@
       "1 TL ja! Senf mittelscharf",
       "0,5 Zwiebel",
       "1 EL ja! Natives Rapsöl",
-      "0,5 EL ja! Tomatenmark 3-fach konzentriert",
+      "0,5 EL Tomatenmark 3-fach konzentriert",
       "100 ml Traubensaft",
-      "100 ml ja! Klare Gemüsebrühe (Pulver)",
+      "100 ml Klare Gemüsebrühe (Pulver)",
       "1 Lorbeerblätter",
       "400 g Kartoffeln",
-      "ja! Jodsalz",
-      "360 g ja! Rotkohl mit Apfelstücken",
-      "ja! Pfeffer schwarz gemahlen",
+      "Jodsalz",
+      "360 g Rotkohl mit Apfelstücken",
+      "Pfeffer schwarz gemahlen",
       "0,5 TL Küchenmeister Speisestärke"
     ],
     "instructions": [
@@ -2444,7 +2444,7 @@
       "1 EL Sonnenblumenöl nativ",
       "200 g Porree",
       "0,5 Dose(n) stückige Tomaten (500 g)",
-      "1 EL ja! Tomatenmark",
+      "1 EL Tomatenmark",
       "75 ml Gemüsebrühe"
     ],
     "instructions": [
@@ -2468,20 +2468,20 @@
     "ingredients": [
       "1 Zwiebeln (à ca. 60 g)",
       "1 Knoblauchzehen",
-      "0,5 Dose(n) ja! Kidney-Bohnen (255 g)",
-      "0,5 Dose(n) ja! Super Sweet Mais (425 ml)",
-      "1 EL ja! Natives Rapsöl",
-      "250 g ja! Hackfleisch gemischt",
-      "0,5 EL ja! Tomatenmark 3-fach konzentriert",
-      "0,5 Dose(n) ja! Fein gehackte Tomaten (400 g)",
-      "100 ml ja! Gemüsebrühe",
+      "0,5 Dose(n) Kidney-Bohnen (255 g)",
+      "0,5 Dose(n) Super Sweet Mais (425 ml)",
+      "1 EL Natives Rapsöl",
+      "250 g Hackfleisch gemischt",
+      "0,5 EL Tomatenmark 3-fach konzentriert",
+      "0,5 Dose(n) Fein gehackte Tomaten (400 g)",
+      "100 ml Gemüsebrühe",
       "1,5 Stiel(e) Petersilie",
       "Salz",
       "Pfeffer",
       "0,25 TL Kreuzkümmel (gemahlen)",
       "Zucker",
       "2 Spritzer Tabasco",
-      "75 g ja! Saure Sahne"
+      "75 g Saure Sahne"
     ],
     "instructions": [
       "Zwiebeln schälen, halbieren und fein würfeln. Knoblauch schälen und fein hacken. Bohnen in ein Sieb gießen, mit kaltem Wasser abspülen und gut abtropfen lassen. Mais zu den Bohnen geben und ebenfalls abtropfen lassen.",
@@ -2572,17 +2572,17 @@
       "Eiweiß": "21,8 g"
     },
     "ingredients": [
-      "25 g ja! Delicatess Bacon",
-      "400 g ja! Kaisergemüse TK",
+      "25 g Delicatess Bacon",
+      "400 g Kaisergemüse TK",
       "0,5 Zwiebel",
-      "0,5 EL ja! Sonnenblumenöl",
-      "100 g ja! Schlagsahne",
-      "ja! Jodsalz",
+      "0,5 EL Sonnenblumenöl",
+      "100 g Schlagsahne",
+      "Jodsalz",
       "Pfeffer",
-      "200 g ja! Fusilli",
+      "200 g Fusilli",
       "0,5 Knoblauchzehe",
-      "1 Scheibe(n) ja! American Sandwich",
-      "1 EL ja! Markenbutter"
+      "1 Scheibe(n) American Sandwich",
+      "1 EL Markenbutter"
     ],
     "instructions": [
       "Gemüse auftauen lassen. Zwiebel schälen und fein würfeln. Öl in einer Pfanne erhitzen, Zwiebel darin andünsten. Gemüse zugeben und mitbraten. Mit Sahne ablöschen, mit Salz und Pfeffer würzen und ca. 5 Minuten köcheln lassen.",
@@ -2923,15 +2923,15 @@
     "ingredients": [
       "0,5 Zwiebel",
       "1 Zehe(n) Knoblauch",
-      "1 EL ja! Olivenöl",
-      "200 g ja! Brokkoli (TK)",
-      "50 ml ja! Gemüsebrühe",
-      "50 g ja! Schlagsahne",
-      "ja! Salz",
-      "ja! Pfeffer",
-      "0,5 TL ja! Paprikapulver edelsüß",
-      "200 g ja! Nudeln (z. B. Fusilli)",
-      "100 g ja! Hirtenkäse"
+      "1 EL Olivenöl",
+      "200 g Brokkoli (TK)",
+      "50 ml Gemüsebrühe",
+      "50 g Schlagsahne",
+      "Salz",
+      "Pfeffer",
+      "0,5 TL Paprikapulver edelsüß",
+      "200 g Nudeln (z. B. Fusilli)",
+      "100 g Hirtenkäse"
     ],
     "instructions": [
       "Zwiebel und Knoblauch schälen und fein würfeln.",
@@ -2990,13 +2990,13 @@
       "Eiweiß": "49,7 g"
     },
     "ingredients": [
-      "200 g ja! Hähnchenbrust-Filetsteaks",
-      "140 g ja! junge Erbsen",
-      "2 TL ja! Pinienkerne",
-      "4 ja ! Getrocknete Tomaten",
-      "3 EL ja! Olivenöl",
+      "200 g Hähnchenbrust-Filetsteaks",
+      "140 g junge Erbsen",
+      "2 TL Pinienkerne",
+      "4 Getrocknete Tomaten",
+      "3 EL Olivenöl",
       "Salz",
-      "400 g ja! Spaghetti",
+      "400 g Spaghetti",
       "Pfeffer"
     ],
     "instructions": [
@@ -3130,13 +3130,13 @@
       "Eiweiß": "7,9 g"
     },
     "ingredients": [
-      "75 g ja! Parboiled Spitzenreis",
+      "75 g Parboiled Spitzenreis",
       "Salz",
       "1 rote Paprika",
       "0,5 Zwiebel",
-      "0,5 Dose(n) ja! Mais (285 g)",
-      "1 EL ja! Rapsöl",
-      "50 g ja! TK Erbsen",
+      "0,5 Dose(n) Mais (285 g)",
+      "1 EL Rapsöl",
+      "50 g TK Erbsen",
       "Kräutersalz"
     ],
     "instructions": [
@@ -3196,11 +3196,11 @@
     "ingredients": [
       "250 g Kartoffeln",
       "Salz",
-      "150 g ja! Junge Erbsen (TK)",
+      "150 g Junge Erbsen (TK)",
       "200 g Cherry Rispentomaten Dulcita",
-      "70 g ja! Sonnen-Mais natursüß",
+      "70 g Sonnen-Mais natursüß",
       "7,5 g Schnittlauch",
-      "4 EL ja! Rapsöl",
+      "4 EL Rapsöl",
       "1 EL Essig",
       "0,5 TL Honig",
       "0,5 Spritzer Orangensaft",
@@ -3208,7 +3208,7 @@
       "0,5 EL Butter",
       "50 g Schlagsahne",
       "0,5 Prise(n) Muskatnuss",
-      "200 g ja! Mini Cordon Bleu"
+      "200 g Mini Cordon Bleu"
     ],
     "instructions": [
       "Kartoffeln schälen, waschen, klein schneiden und in kochendem Salzwasser ca. 15 Minuten garen. Ca. 5 Minuten vor Ende der Garzeit die Erbsen zu den Kartoffeln geben.",
@@ -3300,18 +3300,18 @@
       "Eiweiß": "44,4 g"
     },
     "ingredients": [
-      "160 g ja! Parboiled Spitzenreis",
+      "160 g Parboiled Spitzenreis",
       "Salz",
-      "0,5 EL ja! Olivenöl",
+      "0,5 EL Olivenöl",
       "250 g Gyrosfleisch",
       "0,25 Gurke",
       "1 Zehe(n) Knoblauch",
-      "100 g ja! Vollmilch-Joghurt",
+      "100 g Vollmilch-Joghurt",
       "Pfeffer",
       "100 g Cherrytomaten",
-      "75 g ja! Hirtenkäse",
+      "75 g Hirtenkäse",
       "7,5 g Petersilie",
-      "250 g ja! Krautsalat mit grüner Paprika"
+      "250 g Krautsalat mit grüner Paprika"
     ],
     "instructions": [
       "Reis nach Packungsanweisung in Salzwasser kochen.",

--- a/data/recipes_4.json
+++ b/data/recipes_4.json
@@ -50,7 +50,7 @@
       "4 Zwiebeln",
       "2 EL Rapsöl",
       "800 g Gnocchi (Kühlregal)",
-      "2 Pck . ja! Buttergemüse (TK, à 300 g)",
+      "2 Pck . Buttergemüse (TK, à 300 g)",
       "400 ml Gemüsebrühe",
       "200 g Crème fraîche",
       "10 g Schnittlauch"
@@ -152,16 +152,16 @@
       "Eiweiß": "27,4 g"
     },
     "ingredients": [
-      "125 g ja! Langkorn-Spitzenreis",
-      "ja! Jodsalz",
+      "125 g Langkorn-Spitzenreis",
+      "Jodsalz",
       "2 rote Paprikaschoten",
       "1 Salatgurke",
       "2 Lauchzwiebeln",
-      "3 EL ja! Sonnenblumenöl",
+      "3 EL Sonnenblumenöl",
       "1 EL Weißweinessig",
       "Pfeffer",
       "1 TL Zucker",
-      "500 g ja! gemischtes Hackfleisch"
+      "500 g gemischtes Hackfleisch"
     ],
     "instructions": [
       "Reis in kochendem Salzwasser nach Packungsanweisung zubereiten. Paprika putzen, waschen, entkernen und in Streifen schneiden. Gurke putzen, waschen und fein würfeln. Lauchzwiebeln putzen, waschen und in feine Ringe schneiden. Gurke, Lauchzwiebeln, 1 EL ÖL und Essig mischen. Mit Salz, Pfeffer und Zucker würzen.",
@@ -429,16 +429,16 @@
       "Eiweiß": "24,7 g"
     },
     "ingredients": [
-      "300 g ja! Weizenmehl",
-      "500 ml ja! fettarme H-Milch",
+      "300 g Weizenmehl",
+      "500 ml fettarme H-Milch",
       "3 Eier (Größe M)",
-      "ja! Jodsalz",
-      "4 EL ja! Markenbutter",
+      "Jodsalz",
+      "4 EL Markenbutter",
       "2 kleine Zucchini",
-      "200 g ja! Delikatess Kochschinken",
+      "200 g Delikatess Kochschinken",
       "1 Dose(n) gehackte Tomaten",
       "Pfeffer",
-      "100 g ja! geriebener Gratin- und Pizzakäse"
+      "100 g geriebener Gratin- und Pizzakäse"
     ],
     "instructions": [
       "Mehl, Milch und Eier zu einem glatten Pfannkuchenteig verrühren. Mit Salz würzen. Butter portionsweise in einer Pfanne erhitzen. Nacheinander ca. 8-10 dünne Pfannkuchen aus dem Teig backen.",
@@ -495,10 +495,10 @@
     },
     "ingredients": [
       "2 Zwiebeln",
-      "1 Pck . ja! Rahmspinat (450 g)",
-      "400 g ja! Spaghetti",
-      "800 ml ja! Gemüsebrühe",
-      "200 ml ja! Schlagsahne",
+      "1 Pck . Rahmspinat (450 g)",
+      "400 g Spaghetti",
+      "800 ml Gemüsebrühe",
+      "200 ml Schlagsahne",
       "50 g Parmesan"
     ],
     "instructions": [
@@ -520,7 +520,7 @@
       "Eiweiß": "31,7 g"
     },
     "ingredients": [
-      "200 g ja! TK-Erbsen",
+      "200 g TK-Erbsen",
       "500 g Penne",
       "Salz",
       "1 Zwiebel",
@@ -592,17 +592,17 @@
       "Eiweiß": "29,5 g"
     },
     "ingredients": [
-      "400 g ja! Penne",
-      "300 g ja! Blumenkohl (TK)",
+      "400 g Penne",
+      "300 g Blumenkohl (TK)",
       "1 Zehe(n) Knoblauch",
-      "2 EL ja! Butter",
-      "1 EL ja! Weizenmehl (Type 405)",
-      "200 ml ja! Vollmilch",
-      "100 g ja! Schlagsahne",
-      "ja! Salz",
-      "ja! Pfeffer",
-      "1 TL ja! Paprikapulver edelsüß",
-      "200 g ja! Cheddar"
+      "2 EL Butter",
+      "1 EL Weizenmehl (Type 405)",
+      "200 ml Vollmilch",
+      "100 g Schlagsahne",
+      "Salz",
+      "Pfeffer",
+      "1 TL Paprikapulver edelsüß",
+      "200 g Cheddar"
     ],
     "instructions": [
       "Penne laut Packungsanleitung zubereiten und ca. 3 Minuten vor Ende der Garzeit den gefrorenen Blumenkohl dazugeben.",
@@ -628,13 +628,13 @@
       "Eiweiß": "29,3 g"
     },
     "ingredients": [
-      "800 ml ja! Tomatencremesuppe",
+      "800 ml Tomatencremesuppe",
       "500 g Penne Mezzane Rigate",
       "100 g Getrocknete Tomaten in Öl",
       "1 TL Knoblauchpulver",
       "Pfeffer",
       "Salz",
-      "2 ja ! Mozzarella"
+      "2 Mozzarella"
     ],
     "instructions": [
       "Tomatencremesuppe, 750 ml Wasser und Penne in einen Topf geben, erhitzen und für 15 Minuten köcheln lassen, bis die Penne al dente sind.",
@@ -659,8 +659,8 @@
       "Eiweiß": "15,1 g"
     },
     "ingredients": [
-      "300 g Ja! TK-Erbsen",
-      "480 g Ja! Langkorn-Reis",
+      "300 g TK-Erbsen",
+      "480 g Langkorn-Reis",
       "1 mittlere Zwiebel",
       "0,5 Zehe(n) Knoblauch",
       "0,5 Bd . frische Petersilie",
@@ -1442,14 +1442,14 @@
       "100 g Möhren",
       "2 EL Rapsöl nativ",
       "500 g Hackfleisch gemischt",
-      "2 EL ja! Tomatenmark 3-fach konzentriert",
+      "2 EL Tomatenmark 3-fach konzentriert",
       "2 Dose(n) Tomaten geschält à 400g",
-      "ja! Jodsalz",
-      "ja! Pfeffer schwarz gemahlen",
-      "ja! Raffinade Zucker",
+      "Jodsalz",
+      "Pfeffer schwarz gemahlen",
+      "Raffinade Zucker",
       "2 TL Oregano gerebelt",
-      "400 g ja! Spaghetti",
-      "50 g ja! geriebener Mozzarella"
+      "400 g Spaghetti",
+      "50 g geriebener Mozzarella"
     ],
     "instructions": [
       "Zwiebeln und Knoblauch schälen und fein hacken. Möhren schälen und fein würfeln.",
@@ -1867,17 +1867,17 @@
       "1 Salatgurke",
       "3 Stiel(e) Dill",
       "2 EL ja! Schmand",
-      "3 EL ja! Condimento bianco",
-      "1 TL ja! Senf mittelscharf",
-      "ja! Jodsalz",
-      "ja! Pfeffer schwarz gemahlen",
+      "3 EL Condimento bianco",
+      "1 TL Senf mittelscharf",
+      "Jodsalz",
+      "Pfeffer schwarz gemahlen",
       "800 g Kartoffeln",
       "2 Zwiebeln",
-      "3 EL ja! Natives Rapsöl",
+      "3 EL Natives Rapsöl",
       "600 g Schweine-Schinkenschnitzel",
       "2 Eier",
-      "4 EL ja! Weizenmehl Type 405",
-      "150 g ja! Paniermehl",
+      "4 EL Weizenmehl Type 405",
+      "150 g Paniermehl",
       "1 Zitrone"
     ],
     "instructions": [
@@ -1946,7 +1946,7 @@
       "280 ml getrocknete Tomaten in Öl mit Oregano",
       "1 Dose(n) stückige Tomaten",
       "4 Stiel(e) Basilikum",
-      "2 TL ja! Tomatenmark",
+      "2 TL Tomatenmark",
       "Bunter Pfeffer aus der Mühle",
       "Fleur de Sel",
       "Zucker",
@@ -2052,20 +2052,20 @@
       "Eiweiß": "52 g"
     },
     "ingredients": [
-      "300 g ja! Buttergemüse (TK)",
-      "320 g ja! Penne Rigate",
+      "300 g Buttergemüse (TK)",
+      "320 g Penne Rigate",
       "Salz",
       "1 große Zwiebel",
       "2 Zehe(n) Knoblauch",
-      "2 EL ja! Rapsöl",
-      "400 g ja! Hackfleisch gemischt",
-      "500 g ja! Tomaten passiert",
+      "2 EL Rapsöl",
+      "400 g Hackfleisch gemischt",
+      "500 g Tomaten passiert",
       "Pfeffer",
       "1 Prise(n) Zucker",
       "0,5 TL Oregano getrocknet",
       "0,25 TL Thymian getrocknet",
-      "200 g ja! Schmand",
-      "250 g ja! geriebener Gratin- und Pizzakäse"
+      "200 g Schmand",
+      "250 g geriebener Gratin- und Pizzakäse"
     ],
     "instructions": [
       "Buttergemüse antauen lassen. Nudeln in Salzwasser bissfest kochen. Zwiebel und Knoblauch schälen, würfeln. Backofen auf 180 °C Ober-/Unterhitze vorheizen.",
@@ -2086,7 +2086,7 @@
       "Eiweiß": "32,2 g"
     },
     "ingredients": [
-      "4 ja ! Hähnchen Mini Schnitzel",
+      "4 Hähnchen Mini Schnitzel",
       "4 Tortilla -Wraps",
       "4 EL Frischkäse",
       "50 g Nachos",
@@ -2124,10 +2124,10 @@
     "ingredients": [
       "0,33 Zwiebel",
       "0,33 rote Zwiebel",
-      "1 EL ja! Sonnenblumenöl",
-      "41,7 g ja! Schinkenwürfel",
-      "66,7 g ja! Frischkäse Natur Doppelrahmstufe",
-      "33,3 g ja! Schmand",
+      "1 EL Sonnenblumenöl",
+      "41,7 g Schinkenwürfel",
+      "66,7 g Frischkäse Natur Doppelrahmstufe",
+      "33,3 g Schmand",
       "1 Zweig(e) Basilikum",
       "1,7 Tomaten",
       "Salz",
@@ -2135,12 +2135,12 @@
       "0,67 Pck . Pizzateig (Kühlregal)",
       "2 TL Paniermehl",
       "0,33 Eigelb",
-      "0,67 EL ja! Milch",
-      "66,7 g ja! Geriebener Gouda",
+      "0,67 EL Milch",
+      "66,7 g Geriebener Gouda",
       "66,7 g Cocktailtomaten",
       "0,5 Stück Romana-Salatherzen",
       "1,3 EL Weißwein-Essig",
-      "0,17 TL ja! mittelscharfer Senf",
+      "0,17 TL mittelscharfer Senf",
       "Zucker"
     ],
     "instructions": [
@@ -2236,10 +2236,10 @@
       "200 ml Gemüsebrühe",
       "3 EL Obstessig",
       "3 EL mittelscharfer Senf",
-      "1 EL ja! Zucker",
+      "1 EL Zucker",
       "Pfeffer",
       "3 EL Pflanzenöl",
-      "100 g ja! Delikatess-Mayonnaise",
+      "100 g Delikatess-Mayonnaise",
       "4 Gewürzgurken",
       "3 Eier"
     ],
@@ -2329,13 +2329,13 @@
       "Eiweiß": "16,6 g"
     },
     "ingredients": [
-      "250 g ja! Langkorn-Reis",
-      "600 ml ja! Gemüsebrühe",
-      "300 g ja! TK-Erbsen",
+      "250 g Langkorn-Reis",
+      "600 ml Gemüsebrühe",
+      "300 g TK-Erbsen",
       "250 g Champignons",
       "2 Zwiebeln",
-      "1 EL ja! Rapsöl",
-      "100 g ja! Hirtenkäse"
+      "1 EL Rapsöl",
+      "100 g Hirtenkäse"
     ],
     "instructions": [
       "Reis mit der Gemüsebrühe aufkochen und bei schwacher Hitze ca. 10 Minuten quellen, bis der Reis gar und die Flüssigkeit aufgesogen ist. Nach 5 Minuten die gefrorenen Erbsen zugeben.",
@@ -2397,19 +2397,19 @@
       "Eiweiß": "23,3 g"
     },
     "ingredients": [
-      "4 ja ! Cornichons",
-      "320 g ja! Rinder Minutensteaks",
-      "2 TL ja! Senf mittelscharf",
+      "4 Cornichons",
+      "320 g Rinder Minutensteaks",
+      "2 TL Senf mittelscharf",
       "1 Zwiebel",
-      "2 EL ja! Natives Rapsöl",
-      "1 EL ja! Tomatenmark 3-fach konzentriert",
+      "2 EL Natives Rapsöl",
+      "1 EL Tomatenmark 3-fach konzentriert",
       "200 ml Traubensaft",
-      "200 ml ja! Klare Gemüsebrühe (Pulver)",
+      "200 ml Klare Gemüsebrühe (Pulver)",
       "2 Lorbeerblätter",
       "800 g Kartoffeln",
-      "ja! Jodsalz",
-      "720 g ja! Rotkohl mit Apfelstücken",
-      "ja! Pfeffer schwarz gemahlen",
+      "Jodsalz",
+      "720 g Rotkohl mit Apfelstücken",
+      "Pfeffer schwarz gemahlen",
       "1 TL Küchenmeister Speisestärke"
     ],
     "instructions": [
@@ -2444,7 +2444,7 @@
       "2 EL Sonnenblumenöl nativ",
       "400 g Porree",
       "1 Dose(n) stückige Tomaten (500 g)",
-      "2 EL ja! Tomatenmark",
+      "2 EL Tomatenmark",
       "150 ml Gemüsebrühe"
     ],
     "instructions": [
@@ -2468,20 +2468,20 @@
     "ingredients": [
       "2 Zwiebeln (à ca. 60 g)",
       "2 Knoblauchzehen",
-      "1 Dose(n) ja! Kidney-Bohnen (255 g)",
-      "1 Dose(n) ja! Super Sweet Mais (425 ml)",
-      "2 EL ja! Natives Rapsöl",
-      "500 g ja! Hackfleisch gemischt",
-      "1 EL ja! Tomatenmark 3-fach konzentriert",
-      "1 Dose(n) ja! Fein gehackte Tomaten (400 g)",
-      "200 ml ja! Gemüsebrühe",
+      "1 Dose(n) Kidney-Bohnen (255 g)",
+      "1 Dose(n) Super Sweet Mais (425 ml)",
+      "2 EL Natives Rapsöl",
+      "500 g Hackfleisch gemischt",
+      "1 EL Tomatenmark 3-fach konzentriert",
+      "1 Dose(n) Fein gehackte Tomaten (400 g)",
+      "200 ml Gemüsebrühe",
       "3 Stiel(e) Petersilie",
       "Salz",
       "Pfeffer",
       "0,5 TL Kreuzkümmel (gemahlen)",
       "Zucker",
       "4 Spritzer Tabasco",
-      "150 g ja! Saure Sahne"
+      "150 g Saure Sahne"
     ],
     "instructions": [
       "Zwiebeln schälen, halbieren und fein würfeln. Knoblauch schälen und fein hacken. Bohnen in ein Sieb gießen, mit kaltem Wasser abspülen und gut abtropfen lassen. Mais zu den Bohnen geben und ebenfalls abtropfen lassen.",
@@ -2572,17 +2572,17 @@
       "Eiweiß": "21,8 g"
     },
     "ingredients": [
-      "50 g ja! Delicatess Bacon",
-      "800 g ja! Kaisergemüse TK",
+      "50 g Delicatess Bacon",
+      "800 g Kaisergemüse TK",
       "1 Zwiebel",
-      "1 EL ja! Sonnenblumenöl",
-      "200 g ja! Schlagsahne",
-      "ja! Jodsalz",
+      "1 EL Sonnenblumenöl",
+      "200 g Schlagsahne",
+      "Jodsalz",
       "Pfeffer",
-      "400 g ja! Fusilli",
+      "400 g Fusilli",
       "1 Knoblauchzehe",
-      "2 Scheibe(n) ja! American Sandwich",
-      "2 EL ja! Markenbutter"
+      "2 Scheibe(n) American Sandwich",
+      "2 EL Markenbutter"
     ],
     "instructions": [
       "Gemüse auftauen lassen. Zwiebel schälen und fein würfeln. Öl in einer Pfanne erhitzen, Zwiebel darin andünsten. Gemüse zugeben und mitbraten. Mit Sahne ablöschen, mit Salz und Pfeffer würzen und ca. 5 Minuten köcheln lassen.",
@@ -2923,15 +2923,15 @@
     "ingredients": [
       "1 Zwiebel",
       "2 Zehe(n) Knoblauch",
-      "2 EL ja! Olivenöl",
-      "400 g ja! Brokkoli (TK)",
-      "100 ml ja! Gemüsebrühe",
-      "100 g ja! Schlagsahne",
-      "ja! Salz",
-      "ja! Pfeffer",
-      "1 TL ja! Paprikapulver edelsüß",
-      "400 g ja! Nudeln (z. B. Fusilli)",
-      "200 g ja! Hirtenkäse"
+      "2 EL Olivenöl",
+      "400 g Brokkoli (TK)",
+      "100 ml Gemüsebrühe",
+      "100 g Schlagsahne",
+      "Salz",
+      "Pfeffer",
+      "1 TL Paprikapulver edelsüß",
+      "400 g Nudeln (z. B. Fusilli)",
+      "200 g Hirtenkäse"
     ],
     "instructions": [
       "Zwiebel und Knoblauch schälen und fein würfeln.",
@@ -2990,13 +2990,13 @@
       "Eiweiß": "49,7 g"
     },
     "ingredients": [
-      "400 g ja! Hähnchenbrust-Filetsteaks",
-      "280 g ja! junge Erbsen",
-      "4 TL ja! Pinienkerne",
-      "8 ja ! Getrocknete Tomaten",
-      "6 EL ja! Olivenöl",
+      "400 g Hähnchenbrust-Filetsteaks",
+      "280 g junge Erbsen",
+      "4 TL Pinienkerne",
+      "8 Getrocknete Tomaten",
+      "6 EL Olivenöl",
       "Salz",
-      "800 g ja! Spaghetti",
+      "800 g Spaghetti",
       "Pfeffer"
     ],
     "instructions": [
@@ -3130,13 +3130,13 @@
       "Eiweiß": "7,9 g"
     },
     "ingredients": [
-      "150 g ja! Parboiled Spitzenreis",
+      "150 g Parboiled Spitzenreis",
       "Salz",
       "2 rote Paprika",
       "1 Zwiebel",
-      "1 Dose(n) ja! Mais (285 g)",
-      "2 EL ja! Rapsöl",
-      "100 g ja! TK Erbsen",
+      "1 Dose(n) Mais (285 g)",
+      "2 EL Rapsöl",
+      "100 g TK Erbsen",
       "Kräutersalz"
     ],
     "instructions": [
@@ -3196,11 +3196,11 @@
     "ingredients": [
       "500 g Kartoffeln",
       "Salz",
-      "300 g ja! Junge Erbsen (TK)",
+      "300 g Junge Erbsen (TK)",
       "400 g Cherry Rispentomaten Dulcita",
-      "140 g ja! Sonnen-Mais natursüß",
+      "140 g Sonnen-Mais natursüß",
       "15 g Schnittlauch",
-      "8 EL ja! Rapsöl",
+      "8 EL Rapsöl",
       "2 EL Essig",
       "1 TL Honig",
       "1 Spritzer Orangensaft",
@@ -3208,7 +3208,7 @@
       "1 EL Butter",
       "100 g Schlagsahne",
       "1 Prise(n) Muskatnuss",
-      "400 g ja! Mini Cordon Bleu"
+      "400 g Mini Cordon Bleu"
     ],
     "instructions": [
       "Kartoffeln schälen, waschen, klein schneiden und in kochendem Salzwasser ca. 15 Minuten garen. Ca. 5 Minuten vor Ende der Garzeit die Erbsen zu den Kartoffeln geben.",
@@ -3300,18 +3300,18 @@
       "Eiweiß": "44,4 g"
     },
     "ingredients": [
-      "320 g ja! Parboiled Spitzenreis",
+      "320 g Parboiled Spitzenreis",
       "Salz",
-      "1 EL ja! Olivenöl",
+      "1 EL Olivenöl",
       "500 g Gyrosfleisch",
       "0,5 Gurke",
       "2 Zehe(n) Knoblauch",
-      "200 g ja! Vollmilch-Joghurt",
+      "200 g Vollmilch-Joghurt",
       "Pfeffer",
       "200 g Cherrytomaten",
-      "150 g ja! Hirtenkäse",
+      "150 g Hirtenkäse",
       "15 g Petersilie",
-      "500 g ja! Krautsalat mit grüner Paprika"
+      "500 g Krautsalat mit grüner Paprika"
     ],
     "instructions": [
       "Reis nach Packungsanweisung in Salzwasser kochen.",


### PR DESCRIPTION
This commit removes the 'ja! ' prefix from ingredient names in data/recipes_2.json and data/recipes_4.json.