### PR TITLE
fix: Revert dashboard to row layout and restore recipe selection

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -291,91 +291,36 @@ main.main-content { flex: 1; min-width: 0; }
 .view.hidden { display: none; }
 
 
-/* WEEKLY PLAN CALENDAR VIEW STYLES */
-.weekly-plan-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); /* Responsive: 1 column on small, up to 7 on large */
-    gap: 1.5rem;
-    padding: 1rem 0;
-}
-
-@media (min-width: 768px) { /* Tablets and up */
-    .weekly-plan-grid {
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); /* Adjust minmax for more columns */
-    }
-}
-
-@media (min-width: 1200px) { /* Larger desktops, aim for 7 columns if space allows */
-    .weekly-plan-grid {
-         /* Attempt to fit more, but auto-fit handles if not enough recipes for 7 days or viewport too small */
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    }
-     /* If a fixed 7-day week is always shown, even with fewer plan days: */
-    /* .weekly-plan-grid { grid-template-columns: repeat(7, 1fr); } */
-}
-
-
-.calendar-day-cell {
-    background-color: var(--k-bg-card);
-    border: 1px solid var(--k-border-light);
-    border-radius: 12px;
-    padding: 1.5rem;
-    box-shadow: var(--shadow-soft);
-    display: flex;
-    flex-direction: column;
-}
-
-.calendar-day-title {
-    font-size: 1.5rem; /* Slightly smaller than old day titles */
-    font-weight: 700;
-    color: var(--k-primary-pop-1);
-    margin-bottom: 1rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 2px solid var(--k-primary-pop-1-lighter);
-}
-
-.calendar-recipe-options {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem; /* Space between recipe cards if multiple options are shown */
-    flex-grow: 1; /* Allow this container to grow and push buttons down */
-}
-
-.calendar-recipe-options .recipe-card {
-    /* Recipe cards in calendar might be slightly more compact */
-    padding: 1rem;
-    box-shadow: var(--shadow-soft); /* Softer shadow for nested cards */
-}
-.calendar-recipe-options .recipe-card h4 {
-    font-size: 1.1rem; /* Slightly smaller titles in calendar view */
-}
-.calendar-recipe-options .recipe-card p,
-.calendar-recipe-options .recipe-card .tags,
-.calendar-recipe-options .recipe-card .recipe-nutrition-info {
-    font-size: 0.8rem; /* Smaller text for details */
-}
-.calendar-recipe-options .recipe-card .btn-info {
-    padding: 0.5rem 1rem;
-    font-size: 0.85rem;
-}
-.calendar-recipe-options .single-selected-recipe {
-    /* Styles for when only one selected recipe is shown */
-    /* border-color: var(--k-primary-pop-2); */ /* Example: distinct border */
-}
-.no-options-text {
-    font-style: italic;
-    color: var(--k-text-secondary);
-    text-align: center;
-    padding: 1rem;
-}
-
-
 /* REZEPTKARTEN - VIBRANT STYLING (General, used in generator and potentially calendar) */
-/* .day-container { margin-bottom: 3rem; } */ /* Replaced by calendar grid */
-/* .day-container h3 { ... } */ /* Replaced by .calendar-day-title */
+/* Styles for the original row-based dashboard layout */
+.day-container {
+    margin-bottom: 3rem;
+}
+.day-container h3 { /* For "Montag", "Dienstag" etc. */
+    font-size: 1.8rem; /* Larger day titles */
+    font-weight: 700;
+    padding-bottom: 0.75rem;
+    border-bottom: 3px solid var(--k-primary-pop-1); /* Pop color border */
+    margin-bottom: 2rem; /* More space below day title */
+    color: var(--k-primary-pop-1); /* Pop color for day title text */
+}
 
-/* .recipe-options { ... } */ /* Replaced by .calendar-recipe-options for dashboard context */
-/* Styles for .recipe-options in generator view might need to be distinct if they exist or are added */
+.recipe-options { /* This is the container for the two recipe cards per day */
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); /* Should result in 2 columns on most screens */
+    gap: 2rem;
+}
+/* End of original row-based dashboard layout styles */
+
+
+/* Removed WEEKLY PLAN CALENDAR VIEW STYLES */
+/* .weekly-plan-grid { ... } */
+/* .calendar-day-cell { ... } */
+/* .calendar-day-title { ... } */
+/* .calendar-recipe-options { ... } */
+/* .calendar-recipe-options .recipe-card { ... } */
+/* .no-options-text { ... } */
+
 
 .recipe-card { /* Individual recipe card - general styling */
     background: var(--k-bg-card);

--- a/js/ui.js
+++ b/js/ui.js
@@ -111,76 +111,42 @@ const ui = (() => {
             const noPlanDisplay = document.getElementById('no-plan-display');
             const weeklyPlanContainer = document.getElementById('weekly-plan-container');
             if (plan && plan.length > 0) {
-                weeklyPlanContainer.innerHTML = ''; // Clear previous plan
-                weeklyPlanContainer.className = 'weekly-plan-grid'; // Add class for grid styling
-
-                // Create headers for days of the week - optional, if we want a true calendar header row
-                // const daysOfWeek = ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"];
-                // daysOfWeek.forEach(dayName => {
-                //     const dayHeader = document.createElement('div');
-                //     dayHeader.className = 'calendar-day-header';
-                //     dayHeader.textContent = dayName;
-                //     weeklyPlanContainer.appendChild(dayHeader);
-                // });
+                weeklyPlanContainer.innerHTML = ''; // Clear previous plan cards
+                weeklyPlanContainer.className = ''; // Reset class from weekly-plan-grid if it was set
 
                 plan.forEach((dayObject, dayIndex) => {
-                    const dayCell = document.createElement('div');
-                    dayCell.className = 'calendar-day-cell';
+                    const dayContainer = document.createElement('div');
+                    dayContainer.className = 'day-container'; // Use the old class for rows
 
-                    const dayTitle = document.createElement('h4');
-                    dayTitle.className = 'calendar-day-title';
+                    const dayTitle = document.createElement('h3'); // Use h3 as it was before
                     dayTitle.textContent = dayObject.day;
-                    dayCell.appendChild(dayTitle);
+                    dayContainer.appendChild(dayTitle);
 
-                    const recipesContainer = document.createElement('div');
-                    recipesContainer.className = 'calendar-recipe-options';
+                    const optionsContainer = document.createElement('div');
+                    optionsContainer.className = 'recipe-options'; // Use the old class for 2-column recipe layout
 
-                    if (dayObject.selected) {
-                        // If a recipe is selected, show only that one, perhaps larger or more prominently
-                        const card = createRecipeCardElement(dayObject.selected, onInfoClick);
-                        card.classList.add('selected', 'single-selected-recipe');
-                        // No click event to change selection here, this is display only for the "calendar"
-                        // To change, user would go back to a "plan editing" mode or regenerate.
-                        // For simplicity, we'll keep the card interactive as before.
-                        card.dataset.dayIndex = dayIndex;
-                        card.dataset.recipeId = dayObject.selected.id;
-                        card.addEventListener('click', (e) => {
-                             // Allow re-selection / de-selection or opening modal
-                            // To truly make it "calendar like" this interaction might change
-                            // For now, retain selection ability.
-                            const currentSelected = dayCell.querySelector('.recipe-card.selected');
-                            if (currentSelected && currentSelected !== e.currentTarget) {
-                                currentSelected.classList.remove('selected');
-                            }
-                            e.currentTarget.classList.toggle('selected');
-                            if (e.currentTarget.classList.contains('selected')) {
-                                onSelectRecipe(e.currentTarget.dataset.dayIndex, e.currentTarget.dataset.recipeId);
-                            } else {
-                                // Logic for deselecting:
-                                // onSelectRecipe(e.currentTarget.dataset.dayIndex, null); // Assuming onSelectRecipe handles null
-                            }
-                        });
-                        recipesContainer.appendChild(card);
-                    } else if (dayObject.options && dayObject.options.length > 0) {
-                        // If no recipe is selected, show options (could be one or two, or more)
+                    if (dayObject.options && dayObject.options.length > 0) {
                         dayObject.options.forEach(recipe => {
                             const card = createRecipeCardElement(recipe, onInfoClick);
                             card.dataset.dayIndex = dayIndex;
                             card.dataset.recipeId = recipe.id;
-                            // Card is not pre-selected here
+                            if (dayObject.selected && dayObject.selected.id === recipe.id) {
+                                card.classList.add('selected');
+                            }
                             card.addEventListener('click', (e) => {
-                                // Clear selection from other cards in the same day cell
-                                recipesContainer.querySelectorAll('.recipe-card.selected').forEach(c => c.classList.remove('selected'));
-                                e.currentTarget.classList.add('selected'); // Select current card
+                                // Remove 'selected' from sibling cards in the same day's optionsContainer
+                                optionsContainer.querySelectorAll('.recipe-card').forEach(c => c.classList.remove('selected'));
+                                // Add 'selected' to the clicked card
+                                e.currentTarget.classList.add('selected');
                                 onSelectRecipe(e.currentTarget.dataset.dayIndex, e.currentTarget.dataset.recipeId);
                             });
-                            recipesContainer.appendChild(card);
+                            optionsContainer.appendChild(card);
                         });
                     } else {
-                        recipesContainer.innerHTML = '<p class="no-options-text">Keine Optionen für diesen Tag.</p>';
+                        optionsContainer.innerHTML = '<p class="no-options-text">Keine Optionen für diesen Tag.</p>';
                     }
-                    dayCell.appendChild(recipesContainer);
-                    weeklyPlanContainer.appendChild(dayCell);
+                    dayContainer.appendChild(optionsContainer);
+                    weeklyPlanContainer.appendChild(dayContainer);
                 });
 
                 if (planDisplay) {
@@ -202,7 +168,7 @@ const ui = (() => {
                 }
                 if (weeklyPlanContainer) {
                     weeklyPlanContainer.innerHTML = '';
-                    weeklyPlanContainer.className = ''; // Reset class if no plan
+                    weeklyPlanContainer.className = ''; // Reset class
                 }
             }
         },


### PR DESCRIPTION
This commit reverts the weekly plan display on the dashboard to its previous row-based layout and ensures recipe selection functionality is working correctly.

Changes include:
- Modified `js/ui.js` (renderDashboard) to generate HTML using `.day-container` and `.recipe-options` for each day, restoring the previous structure.
- Removed CSS specific to the calendar grid view and reinstated styles for the row-based layout in `css/style.css`. This ensures each day displays its recipe options in two columns.
- Verified that recipe card click event listeners are correctly configured to handle selection state and update the application's plan data.