### PR TITLE
docs: Remove outdated recipe script info from README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,18 @@ Dies ist ein funktionsfähiger Prototyp einer Web-Anwendung, die rein mit Vanill
 
 Diese Version ist für die **Veröffentlichung (Deployment)** optimiert, indem Rezeptdaten vorab generiert und statisch ausgeliefert werden.
 
+## Was macht diese Anwendung?
+
+Foodie ist ein digitaler Essensplaner, der Ihnen dabei hilft, Ihre Mahlzeiten für die Woche einfach und effizient zu organisieren. Mit Foodie können Sie:
+
+*   **Wochenpläne erstellen:** Generieren Sie automatisch Essenspläne basierend auf der gewünschten Portionsgröße und speziellen Ernährungsmerkmalen (z.B. vegetarisch, vegan). Wählen Sie aus vorgeschlagenen Rezepten Ihre Favoriten für jeden Tag aus.
+*   **Vorräte verwalten:** Erfassen Sie Lebensmittel, die Sie bereits zu Hause haben, in Ihrem digitalen Vorrat. Suchen und fügen Sie Artikel hinzu, inklusive Menge, Einheit und optionalem Haltbarkeitsdatum.
+*   **Rezepte entdecken:** Finden Sie passende Rezeptideen basierend auf den Lebensmitteln in Ihrem Vorrat.
+*   **Einkaufslisten generieren:** Erstellen Sie automatisch eine Einkaufsliste basierend auf Ihrem bestätigten Wochenplan. Die Liste berücksichtigt bereits vorhandene Artikel aus Ihrem Vorrat, um unnötige Käufe zu vermeiden.
+*   **Rezeptdetails einsehen:** Informieren Sie sich über Zutaten, Zubereitungsschritte und Nährwertangaben für jedes Rezept.
+
+Das Ziel von Foodie ist es, die Essensplanung zu vereinfachen, Lebensmittelverschwendung zu reduzieren und Ihnen dabei zu helfen, sich abwechslungsreich und budgetfreundlich zu ernähren. Alle Ihre Daten, wie der aktuelle Wochenplan und Ihr Vorratsinventar, werden lokal in Ihrem Browser gespeichert.
+
 ## Features
 
 - **Performance-Optimierung**:
@@ -19,11 +31,3 @@ Diese Version ist für die **Veröffentlichung (Deployment)** optimiert, indem R
 Es ist kein Webserver oder Build-Schritt für die reine Ausführung notwendig.
 1. Lade alle Dateien in einen Ordner.
 2. Öffne `index.html` direkt in einem modernen Webbrowser.
-
-### (Optional) Rezepte neu generieren
-Wenn du die Rezeptdaten ändern oder erweitern möchtest, kannst du das `generate-recipes.js`-Skript verwenden.
-1. Stelle sicher, dass du [Node.js](https://nodejs.org/) installiert hast.
-2. Öffne ein Terminal im Projektverzeichnis.
-3. Führe den folgenden Befehl aus:
-   ```bash
-   node generate-recipes.js


### PR DESCRIPTION
- Removed section describing `scale_recipes.js` as it's no longer used.
- Corrected duplicated 'Lokale Ausführung' section.
- README now accurately reflects that portion-specific recipe files (recipes_2.json, recipes_4.json) are manually curated and not generated by a script within this repository.