### PR TITLE
Refactor plan creation and dashboard interaction

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1794,3 +1794,59 @@ body.dark-mode .shopping-list-item-card.collected .item-card-header h4,
 body.dark-mode .shopping-list-item-card.collected .item-card-body {
     text-decoration-color: var(--dark-accent-red);
 }
+
+/* Confirmation Dialog Specific Styles */
+.confirm-dialog h3 {
+    margin-top: 0;
+    font-size: 1.6rem; /* Slightly larger for emphasis */
+    color: var(--k-text-primary);
+    margin-bottom: 1rem;
+    text-align: center;
+    border-bottom: 2px solid var(--k-primary-pop-1-lighter);
+    padding-bottom: 0.75rem;
+}
+body.dark-mode .confirm-dialog h3 {
+    color: var(--dark-text-primary);
+    border-bottom-color: var(--dark-primary-pop-1-lighter);
+}
+
+.confirm-dialog p {
+    margin-bottom: 2rem; /* More space before buttons */
+    font-size: 1.1em;
+    line-height: 1.6;
+    text-align: center;
+    color: var(--k-text-secondary);
+}
+body.dark-mode .confirm-dialog p {
+    color: var(--dark-text-secondary);
+}
+
+.confirm-dialog-actions {
+    display: flex;
+    justify-content: center; /* Center buttons */
+    gap: 1.5rem; /* More space between buttons */
+}
+
+.confirm-dialog-actions .btn-confirm,
+.confirm-dialog-actions .btn-danger {
+    padding: 0.75rem 1.75rem; /* More padding for better click target */
+    font-size: 1rem; /* Standard button font size */
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    min-width: 180px; /* Ensure buttons have a decent minimum width */
+    justify-content: center;
+}
+
+/* Adjust modal content for confirm dialog */
+.modal-content.confirm-dialog {
+    max-width: 550px; /* Slightly wider for better text flow */
+    background-color: var(--k-bg-card); /* Use card background for consistency */
+    color: var(--k-text-primary);
+    text-align: left; /* Reset text-align if inherited */
+    padding: 2rem 2.5rem; /* Generous padding */
+}
+body.dark-mode .modal-content.confirm-dialog {
+    background-color: var(--dark-bg-card);
+    color: var(--dark-text-primary);
+}

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 
                 <section id="generator-view" class="view hidden">
                     <div class="card">
-                        <h2><i class="ti ti-settings"></i> Plane deine Woche</h2>
+                        <h2><i class="ti ti-settings"></i> Plane deine Woche (Option 1: Ganze Woche)</h2>
                         <form id="generator-form">
                             <div class="form-group-inline">
                                 <div class="form-group">
@@ -94,8 +94,22 @@
                                      The closing div for generator-filter-grid will be removed later if this is the only child,
                                      or adjusted if we change to a horizontal layout directly on the form. -->
                             </div> <!-- This closes generator-filter-grid -->
-                            <button type="submit" class="btn-primary generator-submit-btn"><i class="ti ti-rocket"></i> Plan generieren</button>
+                            <button type="submit" class="btn-primary generator-submit-btn"><i class="ti ti-rocket"></i> Ganze Woche generieren</button>
                         </form>
+                    </div>
+
+                    <hr class="section-divider"> <!-- Visual separator -->
+
+                    <!-- New section for suggested recipes -->
+                    <div class="card">
+                        <h2><i class="ti ti-chef-hat"></i> Wähle ein einzelnes Rezept (Option 2)</h2>
+                        <p>Oder wähle ein Rezept aus unseren Vorschlägen für heute:</p>
+                        <div id="suggested-recipes-container" class="recipe-options">
+                            <!-- Suggested recipe cards will be injected here by JavaScript -->
+                        </div>
+                        <button id="create-single-recipe-plan-btn" class="btn-primary" style="margin-top: 1rem;" disabled>
+                            <i class="ti ti-calendar-plus"></i> Dieses Rezept für heute einplanen
+                        </button>
                     </div>
                 </section>
 
@@ -200,6 +214,17 @@
         <div class="modal-content">
             <button class="modal-close-btn">×</button>
             <div id="modal-body"></div>
+        </div>
+    </div>
+
+    <div id="confirm-new-plan-modal" class="modal-overlay hidden">
+        <div class="modal-content confirm-dialog">
+            <h3>Bestätigung</h3>
+            <p>Du hast bereits einen aktiven Plan. Bist du sicher, dass du einen neuen Plan erstellen und den alten überschreiben möchtest?</p>
+            <div class="confirm-dialog-actions">
+                <button id="confirm-new-plan-yes" class="btn-confirm"><i class="ti ti-check"></i> Ja, neuen Plan erstellen</button>
+                <button id="confirm-new-plan-no" class="btn-danger"><i class="ti ti-x"></i> Abbrechen</button>
+            </div>
         </div>
     </div>
     

--- a/js/ui.js
+++ b/js/ui.js
@@ -201,6 +201,29 @@ const ui = (() => {
             placeholder.textContent = 'Gib Zutaten in deinen Vorrat ein, um Rezeptvorschläge zu sehen, oder lösche die aktuelle Ansicht.';
             container.appendChild(placeholder);
         },
+        renderSuggestedRecipes: (recipes, onSelectSuggestedRecipe, onInfoClick) => {
+            const container = document.getElementById('suggested-recipes-container');
+            if (!container) return;
+            container.innerHTML = ''; // Clear previous suggestions
+
+            if (recipes && recipes.length > 0) {
+                recipes.forEach(recipe => {
+                    const card = createRecipeCardElement(recipe, onInfoClick); // Reuse existing card creator
+                    card.dataset.recipeId = recipe.id; // Store recipe ID for selection
+                    card.classList.add('suggested-recipe-card'); // Add a class for specific styling or selection logic
+
+                    card.addEventListener('click', (e) => {
+                        // Handle visual selection: remove 'selected' from other suggested cards
+                        container.querySelectorAll('.suggested-recipe-card').forEach(c => c.classList.remove('selected'));
+                        e.currentTarget.classList.add('selected');
+                        onSelectSuggestedRecipe(recipe); // Pass the full recipe object to the callback
+                    });
+                    container.appendChild(card);
+                });
+            } else {
+                container.innerHTML = '<p>Keine Rezeptvorschläge verfügbar.</p>';
+            }
+        },
         openRecipeModal: openModalWithRecipe,
         switchView: (viewId) => { document.querySelectorAll('.view').forEach(v => v.classList.add('hidden')); document.getElementById(viewId).classList.remove('hidden'); },
         updateConfirmButtonState: (plan) => {


### PR DESCRIPTION
Implements the following changes to the "plan erstellen" (create plan) workflow:

1.  **Suggested Recipes on "Plan erstellen":**
    *   The "Plan erstellen" page (`generator-view`) now displays a selection of suggested recipes.
    *   Users can select one of these recipes.

2.  **Single Recipe Plan to Dashboard:**
    *   If a user selects a suggested recipe and clicks "Dieses Rezept für heute einplanen", a single-day plan (defaulting to Monday) is created.
    *   The user is redirected to the dashboard, which displays only this single day and the chosen recipe.
    *   The "Wochenplan bestätigen" button is enabled for this single-day plan.

3.  **Confirmation for New Plan if One Exists:**
    *   When navigating to "Plan erstellen" (either via nav link or the initial button on an empty dashboard), if a weekly plan already exists in localStorage:
        *   A confirmation modal appears: "Du hast bereits einen aktiven Plan. Bist du sicher, dass du einen neuen Plan erstellen und den alten überschreiben möchtest?"
        *   If "Ja" is clicked, the existing plan is deleted, and the user proceeds to the "Plan erstellen" page.
        *   If "Abbrechen" is clicked (or modal dismissed), the user stays on their current view, and the existing plan remains.

The changes involve updates to `index.html` (structure for suggested recipes and confirmation modal), `js/app.js` (logic for suggestions, single plan creation, confirmation flow), `js/ui.js` (rendering suggested recipes), and `css/style.css` (styling for the new modal).