### PR TITLE
Restore daily recipe selection workflow and remove warnings

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -12,6 +12,11 @@ function generateWeeklyPlan(allRecipes, prefs) {
     // Budget filter (was non-functional anyway)
     // isQuick filter
     // Dynamic tags filter (prefs.selectedTags)
+    if (prefs.selectedTags && prefs.selectedTags.length > 0) {
+        availableRecipes = availableRecipes.filter(r =>
+            prefs.selectedTags.every(tag => Array.isArray(r.tags) && r.tags.includes(tag))
+        );
+    }
     // cuisine filter
 
     // Shuffle the available recipes


### PR DESCRIPTION
- Modified generateWeeklyPlan to ensure 'selected' is null and tags filter is active.
- Removed recipe quantity warnings in plan generation flow.
- Updated renderDashboard to display two recipe options per day with radio buttons if no recipe is selected for that day, or the selected recipe if one exists.
- Implemented handleRecipeSelect in app.js to manage user's daily recipe choices on the dashboard, updating localStorage and re-rendering.
- Ensured confirmPlanBtn logic uses the user-selected recipes for the shopping list.