### PR TITLE
Refactor Option 1 selection to generator page & fix Option 2 shopping…

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,14 @@
                             </div> <!-- This closes generator-filter-grid -->
                             <button type="submit" class="btn-primary generator-submit-btn"><i class="ti ti-rocket"></i> Plan generieren</button>
                         </form>
+                        <!-- Container for displaying recipe options directly on this page -->
+                        <div id="daily-options-display-container" class="hidden" style="margin-top: 2rem;">
+                            <!-- Recipe options will be rendered here by JavaScript -->
+                        </div>
+                        <!-- Button to confirm selections made on this page -->
+                        <button id="confirm-generated-plan-btn" class="btn-confirm hidden" style="margin-top: 1rem;">
+                            <i class="ti ti-checks"></i> Auswahl bestätigen und Plan anzeigen
+                        </button>
                     </div>
 
                     <hr class="section-divider"> <!-- Visual separator -->


### PR DESCRIPTION
… list

- Option 1: Recipe selection (two options per day) now occurs directly on the 'Plan erstellen' page after initial generation. A new 'Auswahl bestätigen und Plan anzeigen' button takes the user to the dashboard with the finalized plan.
- Modified ui.renderDashboard to only display confirmed/selected recipes.
- Added ui.renderDailyOptionsInGeneratorView for handling recipe selection UI on the generator page.
- Fixed shopping list generation for Option 2 (single recipe plans) by ensuring the correct 'persons' count is used from localStorage.
- Ensured new button texts are in German.