### PR TITLE
Fix: Prevent recipe options from disappearing on selection in generat…

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -426,15 +426,53 @@ body.dark-mode #dashboard-view .card { background-color: transparent; border: no
 .recipe-options-for-day {
     display: grid;
     grid-template-columns: repeat(2, 1fr); /* Two columns */
-    gap: 1.5rem; /* Gap between cards */
-    margin-bottom: 1.5rem; /* Space below each day's options container */
+    gap: 1rem; /* Slightly reduced gap for a tighter look */
+    margin-bottom: 1rem; /* Space below each day's options container */
 }
 
 /* Wrapper for each recipe card (which includes the hidden radio) */
 .recipe-option-wrapper {
-    display: flex;
-    flex-direction: column; /* Ensure card takes up the space */
+    display: flex; /* Allows recipe card to fill the wrapper */
+    flex-direction: column;
+    position: relative; /* For potential future absolute positioning within wrapper if needed */
 }
+
+/* Ensure recipe card within the option wrapper behaves well in a flex/grid item */
+.recipe-option-wrapper .recipe-card {
+    flex-grow: 1; /* Make card expand to fill wrapper height if wrappers are equalized by grid */
+    /* The existing .recipe-card styles for border, padding, etc., will apply. */
+    /* The .selected-by-radio class will override border and add transform. */
+}
+
+/* Styling for the new informational text about the selected recipe */
+.selected-option-info {
+    font-size: 0.85em;
+    text-align: center;
+    color: var(--k-text-secondary);
+    margin-top: 0.75rem; /* Space above this text */
+    padding: 0.5rem;
+    background-color: var(--k-primary-pop-2-lighter); /* Subtle background */
+    border-radius: 4px;
+    border: 1px solid var(--k-primary-pop-2);
+}
+
+body.dark-mode .selected-option-info {
+    color: var(--dark-text-secondary);
+    background-color: var(--dark-primary-pop-2-lighter);
+    border-color: var(--dark-primary-pop-2);
+}
+
+
+/* Responsive adjustments for recipe options in generator */
+@media (max-width: 768px) { /* Smaller tablets / large phones */
+    .recipe-options-for-day {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); /* Allow more flexible wrapping */
+        gap: 0.75rem;
+    }
+}
+
+/* The media query for 576px already handles .recipe-options-for-day stacking to 1fr */
+
 
 .recipe-card { /* Individual recipe card - general styling */
     background: var(--k-bg-card);
@@ -959,7 +997,7 @@ body.dark-mode fieldset {
 /* Adjusting the generator-filter-grid for potentially single fieldset */
 .generator-filter-grid {
     display: block;
-
+    /* Removed grid-template-columns if it's not a grid of fieldsets anymore */
     margin-bottom: 1rem; /* Reduced margin */
 }
 
@@ -1443,7 +1481,10 @@ footer i.fa-heart {
     }
 
     /* On mobile phones, stack recipe options for a day */
-    .recipe-options-for-day { grid-template-columns: 1fr; gap: 1rem; }
+    .recipe-options-for-day {
+        grid-template-columns: 1fr; /* Single column */
+        gap: 1rem;
+    }
 
     .recipe-card { padding: 1.25rem; } /* More padding in recipe cards */
     .recipe-card-image { height: 170px; }

--- a/js/ui.js
+++ b/js/ui.js
@@ -382,87 +382,69 @@ export const renderDailyOptionsInGeneratorView = (plan, onInfoClick, onSelectRec
             dayTitle.textContent = dayObject.day;
             dayCard.appendChild(dayTitle);
 
-            if (dayObject.selected) {
-                const recipeCard = createRecipeCardElement(dayObject.selected, onInfoClick);
-                recipeCard.classList.add('confirmed-selection');
-                // Add a little note or change styling to allow unselecting or changing
-                const changeText = document.createElement('p');
-                changeText.innerHTML = 'Ausgewählt. Wähle eine andere Option, um zu wechseln.';
-                changeText.style.fontSize = '0.8em';
-                changeText.style.textAlign = 'center';
-                dayCard.appendChild(recipeCard);
-                dayCard.appendChild(changeText);
-
-                // Still show options to allow changing selection
+            if (dayObject.options && dayObject.options.length > 0) {
                 const optionsContainer = document.createElement('div');
-                optionsContainer.className = 'recipe-options-for-day';
+                optionsContainer.className = 'recipe-options-for-day'; // This class should define a stable grid or flex layout
+
                 dayObject.options.forEach((recipeOption, optionIndex) => {
                     const optionWrapper = document.createElement('div');
-                    optionWrapper.className = 'recipe-option-wrapper';
+                    optionWrapper.className = 'recipe-option-wrapper'; // Wrapper for radio and card
+
                     const recipeCardInstance = createRecipeCardElement(recipeOption, onInfoClick);
-                    const radioButton = document.createElement('input');
-                    radioButton.type = 'radio';
-                    radioButton.name = `gen-day-${dayIndex}-selection`;
-                    radioButton.value = recipeOption.id;
-                    radioButton.dataset.recipeIndex = optionIndex;
-                    radioButton.className = 'recipe-select-radio-generator'; // Different class for specific handler
-                    if (dayObject.selected && dayObject.selected.id === recipeOption.id) {
-                        radioButton.checked = true;
-                    }
-                    optionWrapper.appendChild(radioButton);
-                    optionWrapper.appendChild(recipeCardInstance);
-                    optionsContainer.appendChild(optionWrapper);
-                });
-                dayCard.appendChild(optionsContainer);
-
-            } else if (dayObject.options && dayObject.options.length > 0) {
-                const optionsContainer = document.createElement('div');
-                optionsContainer.className = 'recipe-options-for-day';
-                dayObject.options.forEach((recipeOption, optionIndex) => {
-                    const optionWrapper = document.createElement('div');
-                    optionWrapper.className = 'recipe-option-wrapper';
-                    const recipeCardInstance = createRecipeCardElement(recipeOption, onInfoClick); // Corrected variable name
                     const radioButton = document.createElement('input');
                     radioButton.type = 'radio';
                     radioButton.name = `gen-day-${dayIndex}-selection`; // Unique name for radio group per day
                     radioButton.value = recipeOption.id;
-                    radioButton.dataset.recipeIndex = optionIndex;
-                    radioButton.className = 'recipe-select-radio-generator visually-hidden-radio'; // Added class to hide radio
-                    // Check if this option is the selected one
+                    radioButton.dataset.recipeIndex = optionIndex; // Store option index for logic if needed
+                    radioButton.className = 'recipe-select-radio-generator visually-hidden-radio'; // Hide actual radio
+
+                    // Check if this option is the currently selected one for the day
                     if (dayObject.selected && dayObject.selected.id === recipeOption.id) {
                         radioButton.checked = true;
-                        recipeCardInstance.classList.add('selected-by-radio'); // Add class if selected
+                        recipeCardInstance.classList.add('selected-by-radio'); // Visual cue for selected card
                     }
 
+                    // Event listener on the card itself to act as the radio button label
                     recipeCardInstance.addEventListener('click', (e) => {
-                        // If the click is on the info button, let its own handler work
+                        // If the click is on the info button, let its own handler work and don't select
                         if (e.target.closest('.btn-info')) {
                             return;
                         }
                         e.stopPropagation(); // Prevent other click listeners if any
 
-                        // Unselect other cards visually for this day
-                        const allRadioSelectedCards = optionsContainer.querySelectorAll('.recipe-card.selected-by-radio');
-                        if(allRadioSelectedCards) {
-                            allRadioSelectedCards.forEach(card => {
-                                card.classList.remove('selected-by-radio');
-                            });
-                        }
-                        // Select current card visually
+                        // Visually unselect all other cards in this day's options
+                        const allCardsInGroup = optionsContainer.querySelectorAll('.recipe-card');
+                        allCardsInGroup.forEach(card => card.classList.remove('selected-by-radio'));
+
+                        // Visually select the clicked card
                         recipeCardInstance.classList.add('selected-by-radio');
 
-                        // Check the hidden radio button
+                        // Programmatically check the hidden radio button
                         radioButton.checked = true;
-                        // Manually trigger change event on radio button
-                        const event = new Event('change', { bubbles: true });
-                        radioButton.dispatchEvent(event);
+
+                        // Manually trigger a 'change' event on the radio button
+                        // This is crucial for the event listener in generatorView.js to pick up the change
+                        const changeEvent = new Event('change', { bubbles: true });
+                        radioButton.dispatchEvent(changeEvent);
                     });
 
-                    optionWrapper.appendChild(radioButton); // Keep radio for logic, but hide with CSS
-                    optionWrapper.appendChild(recipeCardInstance);
+                    optionWrapper.appendChild(radioButton); // Radio first (though hidden)
+                    optionWrapper.appendChild(recipeCardInstance); // Then the card
                     optionsContainer.appendChild(optionWrapper);
                 });
                 dayCard.appendChild(optionsContainer);
+
+                // Add a message if a recipe is selected
+                if (dayObject.selected) {
+                    const selectedInfoText = document.createElement('p');
+                    selectedInfoText.className = 'selected-option-info'; // For styling
+                    selectedInfoText.innerHTML = `Ausgewählt: <strong>${dayObject.selected.title}</strong>. Wähle eine andere Option, um zu wechseln.`;
+                    selectedInfoText.style.fontSize = '0.9em';
+                    selectedInfoText.style.textAlign = 'center';
+                    selectedInfoText.style.marginTop = '0.5rem'; // Add some space
+                    dayCard.appendChild(selectedInfoText);
+                }
+
             } else {
                 const noOptionsMsg = document.createElement('p');
                 noOptionsMsg.textContent = "Keine Rezeptoptionen für diesen Tag verfügbar.";


### PR DESCRIPTION
…or view

Modified the rendering logic in `renderDailyOptionsInGeneratorView` to ensure all recipe options for a day remain visible when a selection is made. Selection now toggles a visual style and updates an informational text without causing options to be re-rendered in a way that makes them disappear or shift.

Updated CSS to support the new layout and informational text, ensuring a stable and clear user experience during recipe selection in the plan generator.